### PR TITLE
fix pub not found when flutter installed from snap

### DIFF
--- a/conduit/lib/src/cli/commands/create.dart
+++ b/conduit/lib/src/cli/commands/create.dart
@@ -261,13 +261,13 @@ class CLITemplateCreator extends CLICommand with CLIConduitGlobal {
 
   Future<int> fetchProjectDependencies(Directory workingDirectory,
       {bool offline = false}) async {
-    var args = ["get"];
+    var args = ["pub", "get"];
     if (offline) {
       args.add("--offline");
     }
 
     try {
-      final cmd = Platform.isWindows ? "pub.bat" : "pub";
+      const cmd = "dart";
       var process = await Process.start(cmd, args,
               workingDirectory: workingDirectory.absolute.path,
               runInShell: true)


### PR DESCRIPTION
when running conduit create I am getting the following error
[
![Screenshot from 2021-08-21 18-43-29](https://user-images.githubusercontent.com/51961781/130329050-30ad68b1-99c0-459f-9b51-55fa9ba5a5bc.png)
](url)
and when I read the code Found this line 
``` dart
final cmd = Platform.isWindows ? "pub.bat" : "pub";
```
which can be better if pub called through dart command