### PR TITLE
Column naming

### DIFF
--- a/conduit/lib/src/db/managed/attributes.dart
+++ b/conduit/lib/src/db/managed/attributes.dart
@@ -23,7 +23,11 @@ class Table {
   /// the name of the underlying table matches the name of the table definition class.
   ///
   /// See also [Table.unique] for the behavior of [uniquePropertySet].
-  const Table({this.name, this.uniquePropertySet});
+  const Table(
+      {this.legacyNaming = true,
+      this.name,
+      this.uniquePropertySet,
+      this.columnLegacyNaming = true});
 
   /// Configures each instance of a table definition to be unique for the combination of [properties].
   ///
@@ -39,10 +43,18 @@ class Table {
   /// null if not set.
   final List<Symbol>? uniquePropertySet;
 
+  /// Useful to avoid/allow using new snake_case naming convention if [name] is not set
+  /// This property defaults to true to avoid breaking change ensuring backward compatibility
+  final bool legacyNaming;
+
   /// The name of the underlying database table.
   ///
-  /// If this value is not set, the name defaults to the name of the table definition class.
+  /// If this value is not set, the name defaults to the name of the table definition class using snake_case naming convention without the prefix '_' underscore.
   final String? name;
+
+  /// Useful to avoid/allow using new snake_case naming convention for columns if [Column.name] is not set
+  /// This property defaults to true to avoid breaking change ensuring backward compatibility
+  final bool columnLegacyNaming;
 }
 
 /// Possible values for a delete rule in a [Relate].
@@ -128,7 +140,9 @@ class Column {
       bool indexed = false,
       bool omitByDefault = false,
       bool autoincrement = false,
-      List<Validate> validators = const []})
+      List<Validate> validators = const [],
+      this.legacyNaming,
+      this.name})
       : isPrimaryKey = primaryKey,
         databaseType = databaseType,
         isNullable = nullable,
@@ -197,6 +211,27 @@ class Column {
   /// When the data model is compiled, this list is combined with any `Validate` annotations on the annotated property.
   ///
   final List<Validate> validators;
+
+  /// Useful to avoid/allow using new snake_case naming convention if [name] is not set
+  ///
+  /// This property defaults to null to delegate to [Table.columnLegacyNaming]
+  /// If true or false is set then [Table.columnLegacyNaming] will be ignored
+  final bool? legacyNaming;
+
+  /// The name of the underlying column in table.
+  ///
+  /// If this value is not set, the name defaults to the name of the model attribute using snake_case naming convention.
+  final String? name;
+}
+
+/// An annotation used to specify how a field is serialized in API responses.
+class ResponseKey {
+  const ResponseKey({this.name});
+
+  /// The name to be used when serializing this field.
+  ///
+  /// If this value is not set, the name defaults to [Column.name].
+  final String? name;
 }
 
 /// Annotation for [ManagedObject] properties that allows them to participate in [ManagedObject.asMap] and/or [ManagedObject.readFromMap].

--- a/conduit/lib/src/db/managed/attributes.dart
+++ b/conduit/lib/src/db/managed/attributes.dart
@@ -54,8 +54,11 @@ class Table {
   /// If this value is not set, the name defaults to the name of the table definition class using snake_case naming convention without the prefix '_' underscore.
   final String? name;
 
-  /// Useful to avoid/allow using new snake_case naming convention for columns if [Column.name] is not set
+  /// Useful to avoid/allow using new snake_case naming convention for columns.
   /// This property defaults to true to avoid breaking change ensuring backward compatibility
+  ///
+  /// If a column is annotated with `@Column()` with a non-`null` value for
+  /// `name` or `legacyNaming`, that value takes precedent.
   final bool columnLegacyNaming;
 }
 
@@ -217,7 +220,9 @@ class Column {
   /// Useful to avoid/allow using new snake_case naming convention if [name] is not set
   ///
   /// This property defaults to null to delegate to [Table.columnLegacyNaming]
-  /// If true or false is set then [Table.columnLegacyNaming] will be ignored
+  /// The default value, `null`, indicates that the behavior should be
+  /// acquired from the [Table.columnLegacyNaming] annotation on the
+  /// enclosing class.
   final bool? legacyNaming;
 
   /// The name of the underlying column in table.
@@ -226,15 +231,42 @@ class Column {
   final String? name;
 }
 
+/// An annotation used to specify how a Model is serialized in API responses.
+@Target({TargetKind.classType})
+class ResponseModel {
+  const ResponseModel({this.fieldIncludeIfNull = true});
+
+  /// Whether the serializer should include fields with `null` values in the
+  /// serialized Model output.
+  ///
+  /// If `true` (the default), all fields in the Model are written to JSON, even if they are
+  /// `null`.
+  ///
+  /// If a field is annotated with `@ResponseKey()` with a non-`null` value for
+  /// `includeIfNull`, that value takes precedent.
+  final bool fieldIncludeIfNull;
+}
+
 /// An annotation used to specify how a field is serialized in API responses.
 @Target({TargetKind.field, TargetKind.getter, TargetKind.setter})
 class ResponseKey {
-  const ResponseKey({this.name});
+  const ResponseKey({this.name, this.includeIfNull});
 
   /// The name to be used when serializing this field.
   ///
   /// If this value is not set, the name defaults to [Column.name].
   final String? name;
+
+  /// Whether the serializer should include the field with `null` value in the
+  /// serialized output.
+  ///
+  /// If `true`, the serializer should include the field in the serialized
+  /// output, even if the value is `null`.
+  ///
+  /// The default value, `null`, indicates that the behavior should be
+  /// acquired from the [ResponseModel.fieldIncludeIfNull] annotation on the
+  /// enclosing class.
+  final bool? includeIfNull;
 }
 
 /// Annotation for [ManagedObject] properties that allows them to participate in [ManagedObject.asMap] and/or [ManagedObject.readFromMap].

--- a/conduit/lib/src/db/managed/attributes.dart
+++ b/conduit/lib/src/db/managed/attributes.dart
@@ -26,10 +26,10 @@ class Table {
   ///
   /// See also [Table.unique] for the behavior of [uniquePropertySet].
   const Table(
-      {this.legacyNaming = true,
+      {this.useSnakeCaseName = false,
       this.name,
       this.uniquePropertySet,
-      this.columnLegacyNaming = true});
+      this.useSnakeCaseColumnName = false});
 
   /// Configures each instance of a table definition to be unique for the combination of [properties].
   ///
@@ -45,21 +45,21 @@ class Table {
   /// null if not set.
   final List<Symbol>? uniquePropertySet;
 
-  /// Useful to avoid/allow using new snake_case naming convention if [name] is not set
-  /// This property defaults to true to avoid breaking change ensuring backward compatibility
-  final bool legacyNaming;
+  /// Useful to indicate using new snake_case naming convention if [name] is not set
+  /// This property defaults to false to avoid breaking change ensuring backward compatibility
+  final bool useSnakeCaseName;
 
   /// The name of the underlying database table.
   ///
   /// If this value is not set, the name defaults to the name of the table definition class using snake_case naming convention without the prefix '_' underscore.
   final String? name;
 
-  /// Useful to avoid/allow using new snake_case naming convention for columns.
-  /// This property defaults to true to avoid breaking change ensuring backward compatibility
+  /// Useful to indicate using new snake_case naming convention for columns.
+  /// This property defaults to false to avoid breaking change ensuring backward compatibility
   ///
   /// If a column is annotated with `@Column()` with a non-`null` value for
-  /// `name` or `legacyNaming`, that value takes precedent.
-  final bool columnLegacyNaming;
+  /// `name` or `useSnakeCaseName`, that value takes precedent.
+  final bool useSnakeCaseColumnName;
 }
 
 /// Possible values for a delete rule in a [Relate].
@@ -146,7 +146,7 @@ class Column {
       bool omitByDefault = false,
       bool autoincrement = false,
       List<Validate> validators = const [],
-      this.legacyNaming,
+      this.useSnakeCaseName,
       this.name})
       : isPrimaryKey = primaryKey,
         databaseType = databaseType,
@@ -217,13 +217,13 @@ class Column {
   ///
   final List<Validate> validators;
 
-  /// Useful to avoid/allow using new snake_case naming convention if [name] is not set
+  /// Useful to indicate using new snake_case naming convention if [name] is not set
   ///
-  /// This property defaults to null to delegate to [Table.columnLegacyNaming]
+  /// This property defaults to null to delegate to [Table.useSnakeCaseColumnName]
   /// The default value, `null`, indicates that the behavior should be
-  /// acquired from the [Table.columnLegacyNaming] annotation on the
+  /// acquired from the [Table.useSnakeCaseColumnName] annotation on the
   /// enclosing class.
-  final bool? legacyNaming;
+  final bool? useSnakeCaseName;
 
   /// The name of the underlying column in table.
   ///
@@ -234,7 +234,7 @@ class Column {
 /// An annotation used to specify how a Model is serialized in API responses.
 @Target({TargetKind.classType})
 class ResponseModel {
-  const ResponseModel({this.fieldIncludeIfNull = true});
+  const ResponseModel({this.includeIfNullField = true});
 
   /// Whether the serializer should include fields with `null` values in the
   /// serialized Model output.
@@ -244,7 +244,7 @@ class ResponseModel {
   ///
   /// If a field is annotated with `@ResponseKey()` with a non-`null` value for
   /// `includeIfNull`, that value takes precedent.
-  final bool fieldIncludeIfNull;
+  final bool includeIfNullField;
 }
 
 /// An annotation used to specify how a field is serialized in API responses.
@@ -264,7 +264,7 @@ class ResponseKey {
   /// output, even if the value is `null`.
   ///
   /// The default value, `null`, indicates that the behavior should be
-  /// acquired from the [ResponseModel.fieldIncludeIfNull] annotation on the
+  /// acquired from the [ResponseModel.includeIfNullField] annotation on the
   /// enclosing class.
   final bool? includeIfNull;
 }

--- a/conduit/lib/src/db/managed/attributes.dart
+++ b/conduit/lib/src/db/managed/attributes.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta_meta.dart';
+
 import '../query/query.dart';
 import 'managed.dart';
 
@@ -225,6 +227,7 @@ class Column {
 }
 
 /// An annotation used to specify how a field is serialized in API responses.
+@Target({TargetKind.field, TargetKind.getter, TargetKind.setter})
 class ResponseKey {
   const ResponseKey({this.name});
 

--- a/conduit/lib/src/db/managed/object.dart
+++ b/conduit/lib/src/db/managed/object.dart
@@ -252,7 +252,7 @@ abstract class ManagedObject<T> extends Serializable {
             throw ValidationException(["invalid input type for key '$key'"]);
           }
 
-          entity.runtime!.setTransientValueForKey(this, key, decodedValue);
+          entity.runtime!.setTransientValueForKey(this, property.name, decodedValue);
         }
       } else {
         backing.setValueForProperty(
@@ -285,7 +285,7 @@ abstract class ManagedObject<T> extends Serializable {
         .forEach((attr) {
       var value = entity.runtime!.getTransientValueForKey(this, attr!.name);
       if (value != null) {
-        outputMap[mapKeyName(attr.name)] = value;
+        outputMap[mapKeyName(attr.responseKey?.name ?? attr.name)] = value;
       }
     });
 

--- a/conduit/lib/src/db/managed/object.dart
+++ b/conduit/lib/src/db/managed/object.dart
@@ -77,7 +77,7 @@ abstract class ManagedObject<T> extends Serializable {
   };
 
   late final bool modelFieldIncludeIfNull = properties.isEmpty ||
-      (properties.values.first?.responseModel?.fieldIncludeIfNull ?? true);
+      (properties.values.first?.responseModel?.includeIfNullField ?? true);
 
   String mapKeyName(String propertyName) {
     final property = properties[propertyName];

--- a/conduit/lib/src/db/managed/property_description.dart
+++ b/conduit/lib/src/db/managed/property_description.dart
@@ -4,10 +4,8 @@ import 'package:conduit_runtime/runtime.dart';
 
 import '../persistent_store/persistent_store.dart';
 import '../query/query.dart';
-import 'exception.dart';
 import 'managed.dart';
 import 'relationship_type.dart';
-import 'type.dart';
 
 /// Contains database column information and metadata for a property of a [ManagedObject] object.
 ///
@@ -22,7 +20,8 @@ abstract class ManagedPropertyDescription {
       bool nullable = false,
       bool includedInDefaultResultSet = true,
       bool autoincrement = false,
-      List<ManagedValidator?> validators = const []})
+      List<ManagedValidator?> validators = const [],
+      this.responseKey,})
       : isUnique = unique,
         isIndexed = indexed,
         isNullable = nullable,
@@ -84,6 +83,8 @@ abstract class ManagedPropertyDescription {
   List<ManagedValidator?> get validators => _validators;
 
   final List<ManagedValidator?> _validators;
+
+  final ResponseKey? responseKey;
 
   /// Whether or not a the argument can be assigned to this property.
   bool isAssignableWith(dynamic dartValue) => type!.isAssignableWith(dartValue);
@@ -159,7 +160,8 @@ class ManagedAttributeDescription extends ManagedPropertyDescription {
       bool nullable = false,
       bool includedInDefaultResultSet = true,
       bool autoincrement = false,
-      List<ManagedValidator?> validators = const []})
+      List<ManagedValidator?> validators = const [],
+      ResponseKey? responseKey})
       : isPrimaryKey = primaryKey,
         defaultValue = defaultValue,
         transientStatus = transientStatus,
@@ -169,10 +171,13 @@ class ManagedAttributeDescription extends ManagedPropertyDescription {
             nullable: nullable,
             includedInDefaultResultSet: includedInDefaultResultSet,
             autoincrement: autoincrement,
-            validators: validators);
+            validators: validators,
+            responseKey: responseKey,
+      );
 
   ManagedAttributeDescription.transient(ManagedEntity entity, String name,
-      ManagedType type, Type declaredType, this.transientStatus)
+      ManagedType type, Type declaredType, this.transientStatus,
+      {ResponseKey? responseKey})
       : isPrimaryKey = false,
         defaultValue = null,
         super(entity, name, type, declaredType,
@@ -181,7 +186,9 @@ class ManagedAttributeDescription extends ManagedPropertyDescription {
             nullable: false,
             includedInDefaultResultSet: false,
             autoincrement: false,
-            validators: []);
+            validators: [],
+            responseKey: responseKey
+      );
 
   // ignore: prefer_constructors_over_static_methods
   static ManagedAttributeDescription make<T>(
@@ -388,13 +395,16 @@ class ManagedRelationshipDescription extends ManagedPropertyDescription {
       bool indexed = false,
       bool nullable = false,
       bool includedInDefaultResultSet = true,
-      List<ManagedValidator> validators = const []})
+      List<ManagedValidator> validators = const [],
+      ResponseKey? responseKey})
       : super(entity, name, type, declaredType,
             unique: unique,
             indexed: indexed,
             nullable: nullable,
             includedInDefaultResultSet: includedInDefaultResultSet,
-            validators: validators);
+            validators: validators,
+            responseKey: responseKey,
+  );
 
   // ignore: prefer_constructors_over_static_methods
   static ManagedRelationshipDescription make<T>(

--- a/conduit/lib/src/db/managed/property_description.dart
+++ b/conduit/lib/src/db/managed/property_description.dart
@@ -21,6 +21,7 @@ abstract class ManagedPropertyDescription {
       bool includedInDefaultResultSet = true,
       bool autoincrement = false,
       List<ManagedValidator?> validators = const [],
+      this.responseModel,
       this.responseKey,})
       : isUnique = unique,
         isIndexed = indexed,
@@ -84,6 +85,7 @@ abstract class ManagedPropertyDescription {
 
   final List<ManagedValidator?> _validators;
 
+  final ResponseModel? responseModel;
   final ResponseKey? responseKey;
 
   /// Whether or not a the argument can be assigned to this property.
@@ -161,7 +163,8 @@ class ManagedAttributeDescription extends ManagedPropertyDescription {
       bool includedInDefaultResultSet = true,
       bool autoincrement = false,
       List<ManagedValidator?> validators = const [],
-      ResponseKey? responseKey})
+      ResponseModel? responseModel,
+      ResponseKey? responseKey,})
       : isPrimaryKey = primaryKey,
         defaultValue = defaultValue,
         transientStatus = transientStatus,
@@ -172,6 +175,7 @@ class ManagedAttributeDescription extends ManagedPropertyDescription {
             includedInDefaultResultSet: includedInDefaultResultSet,
             autoincrement: autoincrement,
             validators: validators,
+            responseModel: responseModel,
             responseKey: responseKey,
       );
 
@@ -396,13 +400,15 @@ class ManagedRelationshipDescription extends ManagedPropertyDescription {
       bool nullable = false,
       bool includedInDefaultResultSet = true,
       List<ManagedValidator> validators = const [],
-      ResponseKey? responseKey})
+      ResponseModel? responseModel,
+      ResponseKey? responseKey,})
       : super(entity, name, type, declaredType,
             unique: unique,
             indexed: indexed,
             nullable: nullable,
             includedInDefaultResultSet: includedInDefaultResultSet,
             validators: validators,
+            responseModel: responseModel,
             responseKey: responseKey,
   );
 

--- a/conduit/lib/src/runtime/orm/entity_builder.dart
+++ b/conduit/lib/src/runtime/orm/entity_builder.dart
@@ -17,7 +17,6 @@ class EntityBuilder {
         tableDefinitionType = getTableDefinitionForType(type),
         metadata = firstMetadataOfType(getTableDefinitionForType(type),),
         responseModel = firstMetadataOfType(getTableDefinitionForType(type),) {
-    name = _getName();
 
     entity = ManagedEntity(
         name, type, MirrorSystem.getName(tableDefinitionType.simpleName))

--- a/conduit/lib/src/runtime/orm/entity_builder.dart
+++ b/conduit/lib/src/runtime/orm/entity_builder.dart
@@ -9,7 +9,7 @@ import 'package:conduit/src/runtime/orm/property_builder.dart';
 import 'package:conduit/src/runtime/orm_impl.dart';
 import 'package:conduit/src/utilities/mirror_helpers.dart';
 import 'package:logging/logging.dart';
-import 'package:recase/recase.dart';
+import 'package:conduit/src/utilities/text_case.dart';
 
 class EntityBuilder {
   EntityBuilder(Type type)

--- a/conduit/lib/src/runtime/orm/entity_builder.dart
+++ b/conduit/lib/src/runtime/orm/entity_builder.dart
@@ -198,7 +198,7 @@ class EntityBuilder {
 
     final name = mirrorName();
 
-    return (metadata ?? const Table()).legacyNaming ? name : name.snakeCase;
+    return (metadata ?? const Table()).useSnakeCaseName ? name.snakeCase : name;
   }
 
   List<PropertyBuilder> _getProperties() {

--- a/conduit/lib/src/runtime/orm/entity_builder.dart
+++ b/conduit/lib/src/runtime/orm/entity_builder.dart
@@ -125,6 +125,9 @@ class EntityBuilder {
       entity.symbolMap[Symbol(p.name)] = p.name;
       entity.symbolMap[Symbol("${p.name}=")] = p.name;
 
+      entity.symbolMap[Symbol(p.propertyName)] = p.name;
+      entity.symbolMap[Symbol("${p.propertyName}=")] = p.name;
+
       if (p.isRelationship) {
         relationships[p.name] = p.relationship;
       } else {

--- a/conduit/lib/src/runtime/orm/entity_builder.dart
+++ b/conduit/lib/src/runtime/orm/entity_builder.dart
@@ -15,7 +15,8 @@ class EntityBuilder {
   EntityBuilder(Type type)
       : instanceType = reflectClass(type),
         tableDefinitionType = getTableDefinitionForType(type),
-        metadata = firstMetadataOfType(getTableDefinitionForType(type)) {
+        metadata = firstMetadataOfType(getTableDefinitionForType(type),),
+        responseModel = firstMetadataOfType(getTableDefinitionForType(type),) {
     name = _getName();
 
     entity = ManagedEntity(
@@ -37,6 +38,7 @@ class EntityBuilder {
   final ClassMirror instanceType;
   final ClassMirror tableDefinitionType;
   final Table? metadata;
+  final ResponseModel? responseModel;
 
   ManagedEntityRuntime? runtime;
 

--- a/conduit/lib/src/runtime/orm/entity_builder.dart
+++ b/conduit/lib/src/runtime/orm/entity_builder.dart
@@ -41,7 +41,7 @@ class EntityBuilder {
 
   ManagedEntityRuntime? runtime;
 
-  late String name;
+  late final String name = _getName();
   late ManagedEntity entity;
   List<String>? uniquePropertySet;
   late PropertyBuilder primaryKeyProperty;

--- a/conduit/lib/src/runtime/orm/property_builder.dart
+++ b/conduit/lib/src/runtime/orm/property_builder.dart
@@ -252,6 +252,10 @@ class PropertyBuilder {
               "as this method shouldn't be invoked on non-property or non-accessors.");
     }
 
+    if(serialize != null) {
+      return name;
+    }
+
     return (column?.useSnakeCaseName ??
             (parent.metadata ?? const Table()).useSnakeCaseColumnName)
         ? name.snakeCase

--- a/conduit/lib/src/runtime/orm/property_builder.dart
+++ b/conduit/lib/src/runtime/orm/property_builder.dart
@@ -7,7 +7,7 @@ import 'package:conduit/src/runtime/orm/entity_builder.dart';
 import 'package:conduit/src/runtime/orm/entity_mirrors.dart';
 import 'package:conduit/src/runtime/orm/validator_builder.dart';
 import 'package:conduit/src/utilities/mirror_helpers.dart';
-import 'package:recase/recase.dart';
+import 'package:conduit/src/utilities/text_case.dart';
 
 class PropertyBuilder {
   PropertyBuilder(this.parent, this.declaration)

--- a/conduit/lib/src/runtime/orm/property_builder.dart
+++ b/conduit/lib/src/runtime/orm/property_builder.dart
@@ -158,6 +158,7 @@ class PropertyBuilder {
               .where((v) => v != null)
               .cast<ManagedValidator>()
               .toList(),
+          responseModel: parent.responseModel,
           responseKey: responseKey,);
     } else {
       final dartType = getDeclarationType().reflectedType;
@@ -172,6 +173,7 @@ class PropertyBuilder {
           includedInDefaultResultSet: includeInDefaultResultSet,
           autoincrement: autoincrement,
           validators: validators!.map((v) => v.managedValidator).toList(),
+          responseModel: parent.responseModel,
           responseKey: responseKey,);
     }
   }

--- a/conduit/lib/src/runtime/orm/property_builder.dart
+++ b/conduit/lib/src/runtime/orm/property_builder.dart
@@ -252,14 +252,10 @@ class PropertyBuilder {
               "as this method shouldn't be invoked on non-property or non-accessors.");
     }
 
-    final bool useLegacyNaming;
-    if(column?.legacyNaming != null) {
-      useLegacyNaming = column!.legacyNaming!;
-    } else {
-      useLegacyNaming = (parent.metadata ?? const Table()).columnLegacyNaming;
-    }
-
-    return useLegacyNaming ? name : name.snakeCase;
+    return (column?.useSnakeCaseName ??
+            (parent.metadata ?? const Table()).useSnakeCaseColumnName)
+        ? name.snakeCase
+        : name;
   }
 
   EntityBuilder _getRelatedEntityBuilderFrom(List<EntityBuilder>? builders) {

--- a/conduit/lib/src/utilities/text_case.dart
+++ b/conduit/lib/src/utilities/text_case.dart
@@ -1,0 +1,55 @@
+/// An instance of text to be re-cased.
+class TextCase {
+
+  TextCase(String text) : originalText = text {
+    _words = _groupIntoWords(text);
+  }
+
+  final RegExp _upperAlphaRegex = RegExp(r'[A-Z]');
+
+  final symbolSet = {' ', '.', '/', '_', '\\', '-'};
+
+  final String originalText;
+  late final List<String> _words;
+
+  List<String> _groupIntoWords(String text) {
+    StringBuffer sb = StringBuffer();
+    List<String> words = [];
+    bool isAllCaps = text.toUpperCase() == text;
+
+    for (int i = 0; i < text.length; i++) {
+      String char = text[i];
+      String? nextChar = i + 1 == text.length ? null : text[i + 1];
+
+      if (symbolSet.contains(char)) {
+        continue;
+      }
+
+      sb.write(char);
+
+      bool isEndOfWord = nextChar == null ||
+          (_upperAlphaRegex.hasMatch(nextChar) && !isAllCaps) ||
+          symbolSet.contains(nextChar);
+
+      if (isEndOfWord) {
+        words.add(sb.toString());
+        sb.clear();
+      }
+    }
+
+    return words;
+  }
+
+  /// snake_case
+  String get snakeCase => _getSnakeCase();
+
+  String _getSnakeCase({String separator = '_'}) {
+    List<String> words = _words.map((word) => word.toLowerCase()).toList();
+
+    return words.join(separator);
+  }
+}
+
+extension TextCaseExtension on String {
+  String get snakeCase => TextCase(this).snakeCase;
+}

--- a/conduit/pubspec.yaml
+++ b/conduit/pubspec.yaml
@@ -22,8 +22,7 @@ dependencies:
   pub_cache: ^0.3.0
   pub_semver: ^2.0.0
   yaml: ^3.1.0
-  recase: ^4.0.0
-dev_dependencies: 
+dev_dependencies:
   http: ^0.13.0
   matcher: '>=0.12.3 <0.14.0'
   mockito: ^5.0.0

--- a/conduit/pubspec.yaml
+++ b/conduit/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   pub_cache: ^0.3.0
   pub_semver: ^2.0.0
   yaml: ^3.1.0
+  recase: ^4.0.0
 dev_dependencies: 
   http: ^0.13.0
   matcher: '>=0.12.3 <0.14.0'

--- a/conduit/test/db/data_model_test.dart
+++ b/conduit/test/db/data_model_test.dart
@@ -602,7 +602,7 @@ void main() {
     late final Map<String, dynamic> outputMap;
 
     setUpAll(() {
-      dm = ManagedDataModel([AccessPoint, StadiumVenue, Ticket]);
+      dm = ManagedDataModel([AccessPoint]);
       schema = Schema.fromDataModel(dm);
       context = ManagedContext(dm, DefaultPersistentStore());
       e = dm.entityForType(AccessPoint);
@@ -640,101 +640,7 @@ void main() {
     test("ResponseModel includeIfNullField with ResponseKey includeIfNull override", () {
       expect(outputMap['venue_location'], isNotNull);
       expect(outputMap.containsKey('info'), true);
-      expect(outputMap, partial({
-        'CrEaTiOn_DaTe': isNotPresent,
-        'SHORT_DESCRIPTION': isNotPresent,
-        'extraDescription': isNotPresent
-      }));
-    });
-  });
-
-
-
-
-
-
-
-  group("Naming conventions and ResponseKey", () {
-    late ManagedDataModel dm;
-    late ManagedEntity e;
-    late ManagedContext context;
-    late Schema schema;
-    late SchemaTable tableSchema;
-
-    setUpAll(() {
-      dm = ManagedDataModel([AccessPoint, StadiumVenue, Ticket]);
-      schema = Schema.fromDataModel(dm);
-      context = ManagedContext(dm, DefaultPersistentStore());
-      e = dm.entityForType(AccessPoint);
-      tableSchema = schema.tables.first;
-    });
-
-    tearDownAll(() async {
-      await context.close();
-    });
-
-    test("Table snake_case naming", () {
-      expect(e.tableName, 'access_point');
-      expect(e.tableDefinition, '_AccessPoint');
-      expect(tableSchema.name, 'access_point');
-    });
-
-    test("Column snake_case naming", () {
-      expect(e.properties['venue_location'], isNotNull);
-      expect(tableSchema.columnForName('venue_location'), isNotNull);
-    });
-
-    test("Column custom naming", () {
-      expect(e.properties['SHORT_DESCRIPTION'], isNotNull);
-      expect(tableSchema.columnForName('SHORT_DESCRIPTION'), isNotNull);
-    });
-
-    test("Column legacy naming override", () {
-      expect(e.properties['extraDescription'], isNotNull);
-      expect(tableSchema.columnForName('extradescription'), isNotNull);
-    });
-
-    test("API response JSON field custom naming", () {
-      final inputMap = {
-        'id': 1,
-        'CrEaTiOn_DaTe': "2021-11-10T00:02:37.472299Z",
-      };
-
-      final ap = AccessPoint();
-      ap.readFromMap(inputMap);
-      final outputMap = ap.asMap();
-      expect(outputMap['CrEaTiOn_DaTe'], isNotNull);
-    });
-  });
-
-  group("ResponseModel and ResponseKey includeIfNull", () {
-    late ManagedDataModel dm;
-    late ManagedContext context;
-
-    setUpAll(() {
-      dm = ManagedDataModel([AccessPoint, StadiumVenue, Ticket]);
-      context = ManagedContext(dm, DefaultPersistentStore());
-    });
-
-    tearDownAll(() async {
-      await context.close();
-    });
-
-    test("ResponseModel fieldIncludeIfNull with ResponseKey includeIfNull override", () {
-      final inputMap = {
-        'id': 1,
-        'venue_location': "Theater",
-        'info': null,
-        'CrEaTiOn_DaTe': null,
-        'SHORT_DESCRIPTION': null,
-        'extraDescription': null,
-      };
-
-      final ap = AccessPoint();
-      ap.readFromMap(inputMap);
-      final outputMap = ap.asMap();
-      expect(outputMap['venue_location'], isNotNull);
-      expect(outputMap.containsKey('info'), true);
+      expect(outputMap.containsKey('extra_info'), true);
       expect(outputMap, partial({
         'CrEaTiOn_DaTe': isNotPresent,
         'SHORT_DESCRIPTION': isNotPresent,
@@ -810,7 +716,7 @@ class _Event {
 class AccessPoint extends ManagedObject<_AccessPoint> implements _AccessPoint {
   @Serialize()
   @ResponseKey(name: 'extra_info')
-  String? get extraInfo => info == null ? null : '$info Some extra info';
+  String? get extraInfo => '$info Some extra info';
 
   @Serialize()
   @ResponseKey(name: 'extra_info')

--- a/conduit/test/db/data_model_test.dart
+++ b/conduit/test/db/data_model_test.dart
@@ -499,6 +499,161 @@ void main() {
     });
   });
 
+  group("@Table(...) and @Column(...) basic naming", () {
+    late SchemaTable tableSchema;
+
+    setUpAll(() {
+      tableSchema = Schema.fromDataModel(ManagedDataModel([Ticket])).tables.first;
+    });
+
+    test("Table default 'legacy' naming", () {
+      expect(tableSchema.name, '_Ticket');
+    });
+
+    test("Column default 'legacy' naming", () {
+      expect(tableSchema.columnForName('venuelocation'), isNotNull);
+    });
+
+    test("Column custom naming", () {
+      expect(tableSchema.columnForName('SHORT_DESCRIPTION'), isNotNull);
+    });
+
+    test("Column snake_case naming", () {
+      expect(tableSchema.columnForName('extra_description'), isNotNull);
+    });
+  });
+
+  group("@Table(...) and @Column(...) interaction naming", () {
+    late SchemaTable tableSchema;
+
+    setUpAll(() {
+      tableSchema = Schema.fromDataModel(ManagedDataModel([StadiumVenue])).tables.first;
+    });
+
+    test("Table snake_case naming", () {
+      expect(tableSchema.name, 'stadium_venue');
+    });
+
+    test("Column snake_case naming from @Table() annotation", () {
+      expect(tableSchema.columnForName('venue_location'), isNotNull);
+    });
+
+    test("Column custom naming, overrides @Table() column naming annotation" , () {
+      expect(tableSchema.columnForName('SHORT_DESCRIPTION'), isNotNull);
+    });
+
+    test("Column legacy naming overriding snake case naming from @Table() annotation", () {
+      expect(tableSchema.columnForName('extradescription'), isNotNull);
+    });
+  });
+
+  group("ResponseKey tests", () {
+    late ManagedDataModel dm;
+    late ManagedContext context;
+    final inputMap = {
+      'id': 1,
+      'CrEaTiOn_DaTe': "2021-11-10T00:02:37.472299Z",
+    };
+    late final Map<String, dynamic> outputMap;
+
+    setUpAll(() {
+      dm = ManagedDataModel([Event]);
+      context = ManagedContext(dm, DefaultPersistentStore());
+      final ap = Event();
+      ap.readFromMap(inputMap);
+      outputMap = ap.asMap();
+    });
+
+    tearDownAll(() async {
+      await context.close();
+    });
+
+    test("ResponseKey don't include if null", () {
+      expect(outputMap.containsKey('info'), false);
+    });
+
+    test("ResponseKey include if null (default)", () {
+      expect(outputMap.containsKey('description'), false);
+    });
+
+    test("ResponseKey custom naming", () {
+      expect(outputMap['CrEaTiOn_DaTe'], isNotNull);
+    });
+
+    test("ResponseKey transient field custom naming", () {
+      expect(outputMap['extra_info'], isNotNull);
+    });
+  });
+
+  group("ResponseModel, ResponseKey, Table and Column all mixed", () {
+    late ManagedDataModel dm;
+    late ManagedEntity e;
+    late ManagedContext context;
+    late Schema schema;
+    late SchemaTable tableSchema;
+    final inputMap = {
+      'id': 1,
+      'venue_location': "Theater",
+      'info': null,
+      'CrEaTiOn_DaTe': null,
+      'SHORT_DESCRIPTION': null,
+      'extraDescription': null,
+    };
+    late final Map<String, dynamic> outputMap;
+
+    setUpAll(() {
+      dm = ManagedDataModel([AccessPoint, StadiumVenue, Ticket]);
+      schema = Schema.fromDataModel(dm);
+      context = ManagedContext(dm, DefaultPersistentStore());
+      e = dm.entityForType(AccessPoint);
+      tableSchema = schema.tables.first;
+      final ap = AccessPoint();
+      ap.readFromMap(inputMap);
+      outputMap = ap.asMap();
+    });
+
+    tearDownAll(() async {
+      await context.close();
+    });
+
+    test("Table snake_case naming", () {
+      expect(e.tableName, 'access_point');
+      expect(e.tableDefinition, '_AccessPoint');
+      expect(tableSchema.name, 'access_point');
+    });
+
+    test("Column snake_case naming from @Table() annotation", () {
+      expect(e.properties['venue_location'], isNotNull);
+      expect(tableSchema.columnForName('venue_location'), isNotNull);
+    });
+
+    test("Column custom naming from @Column() annotation", () {
+      expect(e.properties['SHORT_DESCRIPTION'], isNotNull);
+      expect(tableSchema.columnForName('SHORT_DESCRIPTION'), isNotNull);
+    });
+
+    test("Column legacy naming by @Column() annotation overriding useSnakeCaseName", () {
+      expect(e.properties['extraDescription'], isNotNull);
+      expect(tableSchema.columnForName('extradescription'), isNotNull);
+    });
+
+    test("ResponseModel includeIfNullField with ResponseKey includeIfNull override", () {
+      expect(outputMap['venue_location'], isNotNull);
+      expect(outputMap.containsKey('info'), true);
+      expect(outputMap, partial({
+        'CrEaTiOn_DaTe': isNotPresent,
+        'SHORT_DESCRIPTION': isNotPresent,
+        'extraDescription': isNotPresent
+      }));
+    });
+  });
+
+
+
+
+
+
+
   group("Naming conventions and ResponseKey", () {
     late ManagedDataModel dm;
     late ManagedEntity e;
@@ -506,15 +661,15 @@ void main() {
     late Schema schema;
     late SchemaTable tableSchema;
 
-    setUp(() {
-      dm = ManagedDataModel([AccessPoint]);
+    setUpAll(() {
+      dm = ManagedDataModel([AccessPoint, StadiumVenue, Ticket]);
       schema = Schema.fromDataModel(dm);
       context = ManagedContext(dm, DefaultPersistentStore());
       e = dm.entityForType(AccessPoint);
       tableSchema = schema.tables.first;
     });
 
-    tearDown(() async {
+    tearDownAll(() async {
       await context.close();
     });
 
@@ -556,12 +711,12 @@ void main() {
     late ManagedDataModel dm;
     late ManagedContext context;
 
-    setUp(() {
-      dm = ManagedDataModel([AccessPoint]);
+    setUpAll(() {
+      dm = ManagedDataModel([AccessPoint, StadiumVenue, Ticket]);
       context = ManagedContext(dm, DefaultPersistentStore());
     });
 
-    tearDown(() async {
+    tearDownAll(() async {
       await context.close();
     });
 
@@ -589,6 +744,69 @@ void main() {
   });
 }
 
+class Ticket extends ManagedObject<_Ticket> implements _Ticket {}
+
+@Table()
+class _Ticket {
+  @primaryKey
+  int? id;
+
+  @Column(nullable: true, )
+  String? venueLocation;
+
+  @Column(nullable: true, name: 'SHORT_DESCRIPTION')
+  String? shortDescription;
+
+  @Column(nullable: true, useSnakeCaseName: true)
+  String? extraDescription;
+}
+
+class StadiumVenue extends ManagedObject<_StadiumVenue> implements _StadiumVenue {}
+
+@Table(useSnakeCaseName: true, useSnakeCaseColumnName: true)
+class _StadiumVenue {
+  @primaryKey
+  int? id;
+
+  DateTime? creationDate;
+
+  @Column(nullable: true, )
+  String? venueLocation;
+
+  @Column(nullable: true, name: 'SHORT_DESCRIPTION')
+  String? shortDescription;
+
+  @Column(nullable: true, useSnakeCaseName: false)
+  String? extraDescription;
+}
+
+class Event extends ManagedObject<_Event> implements _Event {
+  @Serialize()
+  @ResponseKey(name: 'extra_info')
+  String? get extraInfo => '$info Some extra info';
+
+  @Serialize()
+  @ResponseKey(name: 'extra_info')
+  set extraInfo(String? extra) => info = '$info $extra';
+}
+
+@Table()
+class _Event {
+  @primaryKey
+  int? id;
+
+  @ResponseKey(includeIfNull: false)
+  @Column(nullable: true)
+  String? info;
+
+  @ResponseKey(includeIfNull: true)
+  @Column(nullable: true)
+  String? description;
+
+  @ResponseKey(name: 'CrEaTiOn_DaTe', includeIfNull: false)
+  DateTime? creationDate;
+}
+
 class AccessPoint extends ManagedObject<_AccessPoint> implements _AccessPoint {
   @Serialize()
   @ResponseKey(name: 'extra_info')
@@ -599,8 +817,8 @@ class AccessPoint extends ManagedObject<_AccessPoint> implements _AccessPoint {
   set extraInfo(String? extra) => info = '$info $extra';
 }
 
-@ResponseModel(fieldIncludeIfNull: false)
-@Table(legacyNaming: false, columnLegacyNaming: false)
+@ResponseModel(includeIfNullField: false)
+@Table(useSnakeCaseName: true, useSnakeCaseColumnName: true)
 class _AccessPoint {
   @primaryKey
   int? id;
@@ -618,7 +836,7 @@ class _AccessPoint {
   @Column(nullable: true, name: 'SHORT_DESCRIPTION')
   String? shortDescription;
 
-  @Column(nullable: true, legacyNaming: true)
+  @Column(nullable: true, useSnakeCaseName: false)
   String? extraDescription;
 }
 

--- a/conduit/test/db/data_model_test.dart
+++ b/conduit/test/db/data_model_test.dart
@@ -1,6 +1,7 @@
 import 'package:conduit/conduit.dart';
 import 'package:conduit/src/db/managed/relationship_type.dart';
 import 'package:conduit/src/dev/helpers.dart';
+import 'package:conduit_test/conduit_test.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -550,6 +551,42 @@ void main() {
       expect(outputMap['CrEaTiOn_DaTe'], isNotNull);
     });
   });
+
+  group("ResponseModel and ResponseKey includeIfNull", () {
+    late ManagedDataModel dm;
+    late ManagedContext context;
+
+    setUp(() {
+      dm = ManagedDataModel([AccessPoint]);
+      context = ManagedContext(dm, DefaultPersistentStore());
+    });
+
+    tearDown(() async {
+      await context.close();
+    });
+
+    test("ResponseModel fieldIncludeIfNull with ResponseKey includeIfNull override", () {
+      final inputMap = {
+        'id': 1,
+        'venue_location': "Theater",
+        'info': null,
+        'CrEaTiOn_DaTe': null,
+        'SHORT_DESCRIPTION': null,
+        'extraDescription': null,
+      };
+
+      final ap = AccessPoint();
+      ap.readFromMap(inputMap);
+      final outputMap = ap.asMap();
+      expect(outputMap['venue_location'], isNotNull);
+      expect(outputMap.containsKey('info'), true);
+      expect(outputMap, partial({
+        'CrEaTiOn_DaTe': isNotPresent,
+        'SHORT_DESCRIPTION': isNotPresent,
+        'extraDescription': isNotPresent
+      }));
+    });
+  });
 }
 
 class AccessPoint extends ManagedObject<_AccessPoint> implements _AccessPoint {
@@ -562,11 +599,13 @@ class AccessPoint extends ManagedObject<_AccessPoint> implements _AccessPoint {
   set extraInfo(String? extra) => info = '$info $extra';
 }
 
+@ResponseModel(fieldIncludeIfNull: false)
 @Table(legacyNaming: false, columnLegacyNaming: false)
 class _AccessPoint {
   @primaryKey
   int? id;
 
+  @ResponseKey(includeIfNull: true)
   @Column(nullable: true)
   String? info;
 


### PR DESCRIPTION
I made this PR based on [issue 67](https://github.com/conduit-dart/conduit/issues/67).

### Current situation
- Column doesn't allow to specify a custom name.
- Column names are not using proper naming conventions. 
    - e.g: Model field: `creationDate` => resulting column name: `creationdate`
    - e.g: Model field: `streetAddressLocation` => resulting column name: `streetaddresslocation`
- Table names are not using proper naming conventions. 
    - e.g: Model: `_User` => resulting table name: `_user`
    - e.g: Model: `_AccessPoint` => resulting table name: `_accesspoint`
- API response's JSON field names uses the Model field names; devs should be able to specify custom field name for JSON input/output to ensure proper naming convention. Model field names and JSON field names not necessarily should use the same naming convention. Although this can be done by overriding `readFromMap(...)` and `asMap()` from `ManagedObject` it will be a nightmare for devs to achieve this.
- API response's JSON always includes all fields no matter if it's null. Sometimes is necessary to avoid including null values in responses to reduce payload.

### What this PR brings
**NOTE:** All Column and Table naming conventions changes I mention here are considered **breaking changes**, anyway I managed to keep code legacy compatible with backguard compatibility, **using conduit would be the same**, nothing changes by default.

- `@Column()` updated to support custom naming and proper naming conventions with legacy support by default. By default `@Column()` remains the same, but now you can use `@Column(name: 'some_column_name')` to specify a custom name for this model field in the table. On the other hand you can use `@Column(useSnakeCaseName: true|false)`, to indicate to use **snake_case** naming, when this is false legacy naming will be used for naming the column. By default property `useSnakeCaseName` is `null` which delegates naming to `@Table()` *explained below*.
    - e.g: 
    ```dart
    @Column(nullable: true, name: 'creation_date')
    DateTime? creationDate;
    ```
    *Resulting column name: `creation_date`*
    - e.g: 
    ```dart
    @Column(nullable: true, useSnakeCaseName: true)
    String? streetAddressLocation;
    ```
    *Resulting column name: `street_address_location`*
    - e.g: 
    ```dart
    @Column(nullable: true)
    DateTime? creationDate;
    ```
    *Resulting column name: `creationdate`. This is the current situation and default*

- `@Table()` updated to support proper naming conventions with legacy support by default. By default `@Table()` remains the same, but now you can use `@Table(useSnakeCaseName: true|false)` to indicate to use **snake_case** naming, when this is false legacy naming will be used for naming the table; `useSnakeCaseName` is `false` by default. Also you can use `@Table(useSnakeCaseColumnName: true|false)` to indicate to use **snake_case** naming, when this is false legacy naming will be used for naming all the columns in the specified table; `useSnakeCaseColumnName` is `false` by default and can be overriden by `@Column(useSnakeCaseName: true|false)`.    
    - e.g: 
    ```dart
    @Table(useSnakeCaseName: true, useSnakeCaseColumnName: true)
    class _AccessPoint {
        @Column(nullable: true)
        String? mainStreet;
    }
    ```
    *Resulting table name: `access_point` and column name: `main_street`*
    - e.g: 
    ```dart
    @Table(useSnakeCaseName: true, useSnakeCaseColumnName: true)
    class _AccessPoint {
        @Column(nullable: true, useSnakeCaseName: false)
        String? mainStreet;
    }
    ```
    *Resulting table name: `access_point` and column name: `mainstreet`. Here `@Column(...)` overrides column legacy naming*
    - e.g: 
    ```dart
    @Table()
    class _AccessPoint {
        @Column(nullable: true)
        String? mainStreet;
    }
    ```
    *Resulting table name: `_accesspoint` and column name: `mainstreet`. This is the current situation and default*

- Created new annotation `@ResponseKey(...)` to allow devs to use custom API response's JSON field names and to decide wether or not a null field should be included in response. `@ResponseKey(...)` can be used with `@Column()` and `@Serialize()` for transient properties.
    - e.g: 
    ```dart
    @ResponseKey(name: 'CrEaTiOn_DaTe', includeIfNull: false)
    @Column(nullable: true)
    DateTime? creationDate;
    ```
    *Column name `creationdate`, resulting JSON field name: `"CrEaTiOn_DaTe": "2021-11-10T00:02:37.472299Z"`, if there is no data available for this field then will not be included in response*
    - e.g: 
    ```dart    
    @ResponseKey(includeIfNull: true)
    @Column(nullable: true, name: 'creation_date')
    DateTime? creationDate;
    ```
    *Column name `creation_date`, resulting JSON field name: `"creation_date": "2021-11-10T00:02:37.472299Z"`, if there is no data available for this field `null` value will be included in response. Here notes how JSON field name will match Column name*
    - e.g: 
    ```dart    
    @Column(nullable: true)
    DateTime? creationDate;
    ```
    *Column name `creationdate`, resulting JSON field name: `"creationDate": "2021-11-10T00:02:37.472299Z"`. Here notes how JSON field name will not match Column name, instead uses Model field name. this is the current situation and default*
    - e.g: 
    ```dart
    @Serialize()
    @ResponseKey(name: 'extra_info')
    String? get extraInfo => '$info and Some extra info';

    @Serialize()
    @ResponseKey(name: 'extra_info')
    set extraInfo(String? extra) => info = '$info $extra';
    ```
    *Resulting JSON field name: `"extra_info": "info from db and Some extra info"`*

- Created new annotation `@ResponseModel()` to allow devs to decide wether or not all null fields from a Model should be included in response. By default `@ResponseModel()` includes null fields in responses, to avoid including null fields in responses just `@ResponseModel(includeIfNullField: false)`. If a Model field uses anotation `@ResponseKey(includeIfNull: true|false)` then `@ResponseModel(...)` is overriden. 