### PR TITLE
convertToPrimitiveValue should return Map<String,dynamic>

### DIFF
--- a/conduit/lib/src/db/managed/property_description.dart
+++ b/conduit/lib/src/db/managed/property_description.dart
@@ -458,8 +458,8 @@ class ManagedRelationshipDescription extends ManagedPropertyDescription {
       if (relationshipType == ManagedRelationshipType.belongsTo &&
           value.backing.contents!.length == 1 &&
           value.backing.contents!.containsKey(destinationEntity.primaryKey)) {
-        return {
-          destinationEntity.primaryKey: value[destinationEntity.primaryKey]
+        return <String, dynamic>{
+          destinationEntity.primaryKey!: value[destinationEntity.primaryKey]
         };
       }
 


### PR DESCRIPTION
ManagedRelationshipDescription.convertToPrimitiveValue should return
Map<String, dynamic>{} instead of Map<dynamic,dynamic>. The reverse
function convertFromPrimitiveValue explicitly checks for the exact map type