### PR TITLE
resource_controller handler should be allowed to return null

### DIFF
--- a/conduit/lib/src/http/resource_controller.dart
+++ b/conduit/lib/src/http/resource_controller.dart
@@ -136,7 +136,7 @@ abstract class ResourceController extends Controller
   }
 
   @override
-  FutureOr<RequestOrResponse> handle(Request request) async {
+  FutureOr<RequestOrResponse?> handle(Request request) async {
     this.request = request;
 
     var preprocessedResult = await willProcessRequest(request);
@@ -242,7 +242,7 @@ abstract class ResourceController extends Controller
         .toList();
   }
 
-  Future<Response> _process() async {
+  Future<Response?> _process() async {
     if (!request!.body.isEmpty) {
       if (!_requestContentTypeIsSupported(request)) {
         return Response(HttpStatus.unsupportedMediaType, null, null);
@@ -361,9 +361,11 @@ abstract class ResourceController extends Controller
 
     /* bind and invoke */
     _runtime!.applyRequestProperties(this, args);
-    final response = await operation.invoker(this, args)!;
-    if (!response.hasExplicitlySetContentType) {
-      response.contentType = responseContentType;
+    final response = await operation.invoker(this, args);
+    if (response != null) {
+      if (!response.hasExplicitlySetContentType) {
+        response.contentType = responseContentType;
+      }
     }
 
     return response;

--- a/conduit/lib/src/http/resource_controller_interfaces.dart
+++ b/conduit/lib/src/http/resource_controller_interfaces.dart
@@ -56,7 +56,7 @@ class ResourceControllerOperation {
   final List<ResourceControllerParameter> positionalParameters;
   final List<ResourceControllerParameter> namedParameters;
 
-  final Future<Response>? Function(ResourceController resourceController,
+  final Future<Response?> Function(ResourceController resourceController,
       ResourceControllerOperationInvocationArgs args) invoker;
 
   /// Checks if a request's method and path variables will select this binder.

--- a/conduit/lib/src/runtime/resource_controller_impl.dart
+++ b/conduit/lib/src/runtime/resource_controller_impl.dart
@@ -292,7 +292,7 @@ class ResourceControllerRuntimeImpl extends ResourceControllerRuntime {
           return reflect(rc)
               .invoke(symbol, args.positionalArguments,
                   args.namedArguments.map((k, v) => MapEntry(Symbol(k), v)))
-              .reflectee as Future<Response>?;
+              .reflectee as Future<Response?>;
         });
   }
 }


### PR DESCRIPTION
the type of the resource_controller_interface invoker is now Future<Response>?, but it should be Future<Response?>. The response handler should be allowed to return null.

In order to upgrade the request to websocket, the controller handler should return null, as stated by the documentation. With this change, websocket upgrade is working.