### PR TITLE
Feature/sort predicate

### DIFF
--- a/packages/core/lib/src/db/query/mixin.dart
+++ b/packages/core/lib/src/db/query/mixin.dart
@@ -5,8 +5,7 @@ import 'package:conduit_core/src/db/query/page.dart';
 import 'package:conduit_core/src/db/query/query.dart';
 import 'package:conduit_core/src/db/query/sort_descriptor.dart';
 
-mixin QueryMixin<InstanceType extends ManagedObject>
-    implements Query<InstanceType> {
+mixin QueryMixin<InstanceType extends ManagedObject> implements Query<InstanceType> {
   @override
   int offset = 0;
 
@@ -25,6 +24,9 @@ mixin QueryMixin<InstanceType extends ManagedObject>
   @override
   QueryPredicate? predicate;
 
+  @override
+  QuerySortPredicate? sortPredicate;
+
   QueryPage? pageDescriptor;
   List<QuerySortDescriptor>? sortDescriptors;
   Map<ManagedRelationshipDescription, Query>? subQueries;
@@ -36,10 +38,7 @@ mixin QueryMixin<InstanceType extends ManagedObject>
   List<KeyPath>? _propertiesToFetch;
 
   List<KeyPath> get propertiesToFetch =>
-      _propertiesToFetch ??
-      entity.defaultProperties!
-          .map((k) => KeyPath(entity.properties[k]))
-          .toList();
+      _propertiesToFetch ?? entity.defaultProperties!.map((k) => KeyPath(entity.properties[k])).toList();
 
   @override
   InstanceType get values {
@@ -99,8 +98,7 @@ mixin QueryMixin<InstanceType extends ManagedObject>
     T? boundingValue,
   }) {
     final attribute = entity.identifyAttribute(propertyIdentifier);
-    pageDescriptor =
-        QueryPage(order, attribute.name, boundingValue: boundingValue);
+    pageDescriptor = QueryPage(order, attribute.name, boundingValue: boundingValue);
   }
 
   @override
@@ -122,9 +120,7 @@ mixin QueryMixin<InstanceType extends ManagedObject>
 
     if (properties.any(
       (kp) => kp.path.any(
-        (p) =>
-            p is ManagedRelationshipDescription &&
-            p.relationshipType != ManagedRelationshipType.belongsTo,
+        (p) => p is ManagedRelationshipDescription && p.relationshipType != ManagedRelationshipType.belongsTo,
       ),
     )) {
       throw ArgumentError(
@@ -168,8 +164,7 @@ mixin QueryMixin<InstanceType extends ManagedObject>
             .map((r) => "'${r!.name}'")
             .join(", ");
 
-        throw StateError(
-            "Invalid query construction. This query joins '${fromRelationship.entity.tableName}' "
+        throw StateError("Invalid query construction. This query joins '${fromRelationship.entity.tableName}' "
             "with '${fromRelationship.inverse!.entity.tableName}' on property '${fromRelationship.name}'. "
             "However, '${fromRelationship.inverse!.entity.tableName}' "
             "has also joined '${fromRelationship.entity.tableName}' on this property's inverse "

--- a/packages/core/lib/src/db/query/query.dart
+++ b/packages/core/lib/src/db/query/query.dart
@@ -5,12 +5,14 @@ import 'package:conduit_core/src/db/query/error.dart';
 import 'package:conduit_core/src/db/query/matcher_expression.dart';
 import 'package:conduit_core/src/db/query/predicate.dart';
 import 'package:conduit_core/src/db/query/reduce.dart';
+import 'package:conduit_core/src/db/query/sort_predicate.dart';
 
 export 'error.dart';
 export 'matcher_expression.dart';
+export 'mixin.dart';
 export 'predicate.dart';
 export 'reduce.dart';
-export 'mixin.dart';
+export 'sort_predicate.dart';
 
 /// An object for configuring and executing a database query.
 ///
@@ -239,6 +241,12 @@ abstract class Query<InstanceType extends ManagedObject> {
   /// A predicate will identify the rows being accessed, see [QueryPredicate] for more details. Prefer to use
   /// [where] instead of this property directly.
   QueryPredicate? predicate;
+
+  /// A predicate for sorting the result.
+  ///
+  /// A predicate will identify the rows being accessed, see [QuerySortPredicate] for more details. Prefer to use
+  /// [sortBy] instead of this property directly.
+  QuerySortPredicate? sortPredicate;
 
   /// Values to be used when inserting or updating an object.
   ///

--- a/packages/core/lib/src/db/query/sort_predicate.dart
+++ b/packages/core/lib/src/db/query/sort_predicate.dart
@@ -1,0 +1,17 @@
+import 'package:conduit_core/src/db/query/query.dart';
+
+/// The order in which a collection of objects should be sorted when returned from a database.
+class QuerySortPredicate {
+  QuerySortPredicate(
+    this.predicate,
+    this.order,
+  );
+
+  /// The name of a property to sort by.
+  String predicate;
+
+  /// The order in which values should be sorted.
+  ///
+  /// See [QuerySortOrder] for possible values.
+  QuerySortOrder order;
+}

--- a/packages/postgresql/lib/src/builders/sort.dart
+++ b/packages/postgresql/lib/src/builders/sort.dart
@@ -1,6 +1,7 @@
+import 'package:conduit_core/conduit_core.dart';
+
 import 'column.dart';
 import 'table.dart';
-import 'package:conduit_core/conduit_core.dart';
 
 class ColumnSortBuilder extends ColumnBuilder {
   ColumnSortBuilder(TableBuilder table, String? key, QuerySortOrder order)
@@ -10,4 +11,16 @@ class ColumnSortBuilder extends ColumnBuilder {
   final String order;
 
   String get sqlOrderBy => "${sqlColumnName(withTableNamespace: true)} $order";
+}
+
+class ColumnSortPredicateBuilder extends ColumnSortBuilder {
+  ColumnSortPredicateBuilder(
+      TableBuilder table, String key, QuerySortOrder order)
+      : _key = key,
+        super(table, key, order);
+
+  final String _key;
+
+  @override
+  String get sqlOrderBy => "$_key $order";
 }

--- a/packages/postgresql/lib/src/builders/table.dart
+++ b/packages/postgresql/lib/src/builders/table.dart
@@ -1,10 +1,10 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:conduit_core/conduit_core.dart';
 
+import '../postgresql_query.dart';
 import 'column.dart';
 import 'expression.dart';
 import 'sort.dart';
-import '../postgresql_query.dart';
 
 class TableBuilder implements Returnable {
   TableBuilder(PostgresQuery query, {this.parent, this.joinedBy})
@@ -19,6 +19,15 @@ class TableBuilder implements Returnable {
             ?.map((s) => ColumnSortBuilder(this, s.key, s.order))
             .toList() ??
         [];
+    if (query.sortPredicate != null) {
+      columnSortBuilders.add(
+        ColumnSortPredicateBuilder(
+          this,
+          query.sortPredicate!.predicate,
+          query.sortPredicate!.order,
+        ),
+      );
+    }
 
     if (query.pageDescriptor != null) {
       columnSortBuilders.add(

--- a/packages/postgresql/test/fetch_test.dart
+++ b/packages/postgresql/test/fetch_test.dart
@@ -1,7 +1,8 @@
-import 'not_tests/helpers.dart';
-import 'not_tests/postgres_test_config.dart';
 import 'package:conduit_core/conduit_core.dart';
 import 'package:test/test.dart';
+
+import 'not_tests/helpers.dart';
+import 'not_tests/postgres_test_config.dart';
 
 void main() {
   ManagedContext? context;
@@ -17,19 +18,16 @@ void main() {
     var req = Query<TestModel>(context!)..values = m;
     var item = await req.insert();
 
-    req = Query<TestModel>(context!)
-      ..predicate = QueryPredicate("id = @id", {"id": item.id});
+    req = Query<TestModel>(context!)..predicate = QueryPredicate("id = @id", {"id": item.id});
     item = (await req.fetchOne())!;
 
     expect(item.name, "Joe");
     expect(item.email, "a@a.com");
   });
 
-  test("Query with dynamic entity and mis-matched context throws exception",
-      () async {
+  test("Query with dynamic entity and mis-matched context throws exception", () async {
     context = await PostgresTestConfig().contextWithModels([TestModel]);
-    final someOtherContext =
-        ManagedContext(ManagedDataModel([]), DefaultPersistentStore());
+    final someOtherContext = ManagedContext(ManagedDataModel([]), DefaultPersistentStore());
     try {
       Query.forEntity(
         context!.dataModel!.entityForType(TestModel),
@@ -73,8 +71,7 @@ void main() {
     await req.insert();
 
     try {
-      req = Query<TestModel>(context!)
-        ..returningProperties((t) => [t.id, t["foobar"]]);
+      req = Query<TestModel>(context!)..returningProperties((t) => [t.id, t["foobar"]]);
       fail("unreachable");
     } on ArgumentError catch (e) {
       expect(
@@ -106,8 +103,7 @@ void main() {
       expect(result[i].email, "asc$i@a.com");
     }
 
-    req = Query<TestModel>(context!)
-      ..sortBy((t) => t.id, QuerySortOrder.ascending);
+    req = Query<TestModel>(context!)..sortBy((t) => t.id, QuerySortOrder.ascending);
     result = await req.fetch();
 
     int? idIndex = 0;
@@ -140,11 +136,30 @@ void main() {
     }
   });
 
+  test("Predicate sort descriptors work", () async {
+    context = await PostgresTestConfig().contextWithModels([TestModel]);
+
+    for (int i = 0; i < 10; i++) {
+      final m = TestModel(name: "Joe$i", email: "desc$i@a.com");
+
+      final req = Query<TestModel>(context!)..values = m;
+
+      await req.insert();
+    }
+
+    final req = Query<TestModel>(context!);
+    req.sortPredicate = QuerySortPredicate('random()', QuerySortOrder.ascending);
+    req.predicate = QueryPredicate("email like @key", {"key": "desc%"});
+    final result1 = await req.fetch();
+    final result2 = await req.fetch();
+
+    expect(result1, isNot(orderedEquals(result2)));
+  });
+
   test("Cannot sort by property that doesn't exist", () async {
     context = await PostgresTestConfig().contextWithModels([TestModel]);
     try {
-      Query<TestModel>(context!)
-          .sortBy((u) => u["nonexisting"], QuerySortOrder.ascending);
+      Query<TestModel>(context!).sortBy((u) => u["nonexisting"], QuerySortOrder.ascending);
       expect(true, false);
     } on ArgumentError catch (e) {
       expect(
@@ -233,8 +248,7 @@ void main() {
     await req.insert();
 
     try {
-      req = Query<TestModel>(context!)
-        ..returningProperties((t) => [t.id, t["badkey"]]);
+      req = Query<TestModel>(context!)..returningProperties((t) => [t.id, t["badkey"]]);
 
       fail("unreachable");
     } on ArgumentError catch (e) {
@@ -263,16 +277,11 @@ void main() {
       await (Query<GenPost>(context!)..values = p2).insert();
     }
 
-    final req = Query<GenPost>(context!)
-      ..predicate = QueryPredicate("owner_id = @id", {"id": u1.id});
+    final req = Query<GenPost>(context!)..predicate = QueryPredicate("owner_id = @id", {"id": u1.id});
     var res = await req.fetch();
     expect(res.length, 5);
     expect(
-      res
-          .map((p) => p.text)
-          .where((text) => num.parse(text!) % 2 == 0)
-          .toList()
-          .length,
+      res.map((p) => p.text).where((text) => num.parse(text!) % 2 == 0).toList().length,
       5,
     );
 
@@ -284,19 +293,14 @@ void main() {
     expect(user, isNotNull);
     expect(res.length, 5);
     expect(
-      res
-          .map((p) => p.text)
-          .where((text) => num.parse(text!) % 2 == 0)
-          .toList()
-          .length,
+      res.map((p) => p.text).where((text) => num.parse(text!) % 2 == 0).toList().length,
       5,
     );
   });
 
   test("Fetch object with null reference", () async {
     context = await PostgresTestConfig().contextWithModels([GenUser, GenPost]);
-    var p1 = await (Query<GenPost>(context!)..values = (GenPost()..text = "1"))
-        .insert();
+    var p1 = await (Query<GenPost>(context!)..values = (GenPost()..text = "1")).insert();
 
     final req = Query<GenPost>(context!);
     p1 = (await req.fetchOne())!;
@@ -313,17 +317,14 @@ void main() {
     expect(result.id, greaterThan(0));
     expect(result.backing.contents!["text"], isNull);
 
-    final fq = Query<Omit>(context!)
-      ..predicate = QueryPredicate("id=@id", {"id": result.id});
+    final fq = Query<Omit>(context!)..predicate = QueryPredicate("id=@id", {"id": result.id});
 
     final fResult = (await fq.fetchOne())!;
     expect(fResult.id, result.id);
     expect(fResult.backing.contents!["text"], isNull);
   });
 
-  test(
-      "Throw exception when fetchOne returns more than one because the fetchLimit can't be applied to joins",
-      () async {
+  test("Throw exception when fetchOne returns more than one because the fetchLimit can't be applied to joins", () async {
     context = await PostgresTestConfig().contextWithModels([GenUser, GenPost]);
 
     final objects = [GenUser()..name = "Joe", GenUser()..name = "Bob"];
@@ -347,9 +348,7 @@ void main() {
     }
   });
 
-  test(
-      "Including RelationshipInverse property can only be done by using name of property",
-      () async {
+  test("Including RelationshipInverse property can only be done by using name of property", () async {
     context = await PostgresTestConfig().contextWithModels([GenUser, GenPost]);
 
     final u1 = await (Query<GenUser>(context!)..values.name = "Joe").insert();
@@ -359,16 +358,14 @@ void main() {
           ..values.owner = u1)
         .insert();
 
-    var q = Query<GenPost>(context!)
-      ..returningProperties((p) => [p.id, p.owner]);
+    var q = Query<GenPost>(context!)..returningProperties((p) => [p.id, p.owner]);
 
     final result = (await q.fetchOne())!;
     expect(result.owner!.id, 1);
     expect(result.owner!.backing.contents!.length, 1);
 
     try {
-      q = Query<GenPost>(context!)
-        ..returningProperties((p) => [p.id, p["owner_id"]]);
+      q = Query<GenPost>(context!)..returningProperties((p) => [p.id, p["owner_id"]]);
       expect(true, false);
     } on ArgumentError catch (e) {
       expect(
@@ -387,9 +384,7 @@ void main() {
     expect(result.public, "x");
   });
 
-  test(
-      "When fetching valid enum value from db, is available as enum value and in where",
-      () async {
+  test("When fetching valid enum value from db, is available as enum value and in where", () async {
     context = await PostgresTestConfig().contextWithModels([EnumObject]);
 
     var q = Query<EnumObject>(context!)..values.enumValues = EnumValues.abcd;
@@ -401,13 +396,11 @@ void main() {
     expect(result!.enumValues, EnumValues.abcd);
     expect(result.asMap()["enumValues"], "abcd");
 
-    q = Query<EnumObject>(context!)
-      ..where((o) => o.enumValues).equalTo(EnumValues.abcd);
+    q = Query<EnumObject>(context!)..where((o) => o.enumValues).equalTo(EnumValues.abcd);
     result = await q.fetchOne();
     expect(result, isNotNull);
 
-    q = Query<EnumObject>(context!)
-      ..where((o) => o.enumValues).equalTo(EnumValues.efgh);
+    q = Query<EnumObject>(context!)..where((o) => o.enumValues).equalTo(EnumValues.efgh);
     result = await q.fetchOne();
     expect(result, isNull);
   });
@@ -427,8 +420,7 @@ void main() {
   test("When fetching invalid enum value from db, throws error", () async {
     context = await PostgresTestConfig().contextWithModels([EnumObject]);
 
-    await context!.persistentStore
-        .execute("INSERT INTO _enumobject (enumValues) VALUES ('foobar')");
+    await context!.persistentStore.execute("INSERT INTO _enumobject (enumValues) VALUES ('foobar')");
 
     try {
       final q = Query<EnumObject>(context!);
@@ -469,8 +461,7 @@ void main() {
       expect(o!.name, "bob");
     });
 
-    test("If object does not exist and type is specified, return null",
-        () async {
+    test("If object does not exist and type is specified, return null", () async {
       final o = await context!.fetchObjectWithID<TestModel>(id! + 1);
       expect(o, isNull);
     });
@@ -493,9 +484,7 @@ void main() {
       }
     });
 
-    test(
-        "If identifier type is not the same type as return type, throw exception with 404",
-        () async {
+    test("If identifier type is not the same type as return type, throw exception with 404", () async {
       final o = await context!.fetchObjectWithID<TestModel>("not-an-int");
       expect(o, isNull);
     });
@@ -569,8 +558,7 @@ class _Omit {
   String? text;
 }
 
-class PrivateField extends ManagedObject<_PrivateField>
-    implements _PrivateField {
+class PrivateField extends ManagedObject<_PrivateField> implements _PrivateField {
   PrivateField() : super() {
     _private = "x";
   }


### PR DESCRIPTION
Added sortPredicate to Query to run non propertyIdentifier sorting

Example: query.sortPredicate = QuerySortPredicate('random()', QuerySortOrder.ascending);