### PR TITLE
Update references to `conduit.io` to `theconduit.dev`

### DIFF
--- a/packages/cli/lib/conduit.dart
+++ b/packages/cli/lib/conduit.dart
@@ -13,7 +13,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 /// The core libraries of the Conduit framework.
 ///
-/// See documentation guides at https://conduit.io/docs/.
+/// See documentation guides at https://docs.theconduit.dev/.
 library conduit;
 
 export 'package:conduit_config/conduit_config.dart';

--- a/packages/cli/templates/db/README.md
+++ b/packages/cli/templates/db/README.md
@@ -34,4 +34,4 @@ The default configuration file used when testing is `config.src.yaml`. This file
 
 ## Deploying an Application
 
-See the documentation for [Deployment](https://conduit.io/docs/deploy/).
+See the documentation for [Deployment](https://docs.theconduit.dev/deploy/).

--- a/packages/cli/templates/db/lib/channel.dart
+++ b/packages/cli/templates/db/lib/channel.dart
@@ -4,7 +4,7 @@ import 'package:wildfire/wildfire.dart';
 /// This type initializes an application.
 ///
 /// Override methods in this class to set up routes and initialize services like
-/// database connections. See http://conduit.io/docs/http/channel/.
+/// database connections. See https://docs.theconduit.dev/http/channel/.
 class WildfireChannel extends ApplicationChannel {
   late ManagedContext context;
 
@@ -62,7 +62,7 @@ class WildfireChannel extends ApplicationChannel {
 /// file specific to this application.
 ///
 /// Configuration files must have key-value for the properties in this class.
-/// For more documentation on configuration files, see https://conduit.io/docs/configure/ and
+/// For more documentation on configuration files, see https://docs.theconduit.dev/configure/ and
 /// https://pub.dartlang.org/packages/safe_config.
 class WildfireConfiguration extends Configuration {
   WildfireConfiguration(String fileName) : super.fromFile(File(fileName));

--- a/packages/cli/templates/db_and_auth/README.md
+++ b/packages/cli/templates/db_and_auth/README.md
@@ -2,7 +2,7 @@
 
 ## Database
 
-You will need a local database for testing, and another database for running the application locally. The behavior and configuration of these databases are documented here: http://conduit.io/docs/testing/mixins/.
+You will need a local database for testing, and another database for running the application locally. The behavior and configuration of these databases are documented here: https://docs.theconduit.dev/testing/mixins/.
 
 To run tests, you must have a configuration file named `config.src.yaml`. By default, it is configured to connect your application to a database named `conduit_test_db` (documented in the link above) and should not need to be edited. Tables are automatically created and deleted during test execution.
 
@@ -24,7 +24,7 @@ conduit auth add-client --id com.local.test \
     --connect postgres://user:password@localhost:5432/wildfire
 ```
 
-To run your tests with OAuth 2.0 client identifiers, see this documentation: http://conduit.io/docs/testing/mixins/#testing-applications-that-use-oauth-20.
+To run your tests with OAuth 2.0 client identifiers, see this documentation: https://docs.theconduit.dev/testing/mixins/#testing-applications-that-use-oauth-20.
 
 ## Running the server locally
 
@@ -154,4 +154,4 @@ The default configuration file used when testing is `config.src.yaml`. This file
 
 ## Deploying an Application
 
-See the documentation for [Deployment](https://conduit.io/docs/deploy/).
+See the documentation for [Deployment](https://docs.theconduit.dev/deploy/).

--- a/packages/cli/templates/db_and_auth/lib/channel.dart
+++ b/packages/cli/templates/db_and_auth/lib/channel.dart
@@ -8,7 +8,7 @@ import 'package:wildfire/wildfire.dart';
 /// This type initializes an application.
 ///
 /// Override methods in this class to set up routes and initialize services like
-/// database connections. See http://conduit.io/docs/http/channel/.
+/// database connections. See https://docs.theconduit.dev/http/channel/.
 class WildfireChannel extends ApplicationChannel
     implements AuthRedirectControllerDelegate {
   final HTMLRenderer htmlRenderer = HTMLRenderer();

--- a/packages/cli/templates/default/README.md
+++ b/packages/cli/templates/default/README.md
@@ -18,4 +18,4 @@ The default configuration file used when testing is `config.src.yaml`. This file
 
 ## Deploying an Application
 
-See the documentation for [Deployment](https://conduit.io/docs/deploy/).
+See the documentation for [Deployment](https://docs.theconduit.dev/deploy/).

--- a/packages/cli/templates/default/lib/channel.dart
+++ b/packages/cli/templates/default/lib/channel.dart
@@ -3,7 +3,7 @@ import 'package:wildfire/wildfire.dart';
 /// This type initializes an application.
 ///
 /// Override methods in this class to set up routes and initialize services like
-/// database connections. See http://conduit.io/docs/http/channel/.
+/// database connections. See https://docs.theconduit.dev/http/channel/.
 class WildfireChannel extends ApplicationChannel {
   /// Initialize services in this method.
   ///
@@ -28,7 +28,7 @@ class WildfireChannel extends ApplicationChannel {
     final router = Router();
 
     // Prefer to use `link` instead of `linkFunction`.
-    // See: https://conduit.io/docs/http/request_controller/
+    // See: https://docs.theconduit.dev/http/request_controller/
     router.route("/example").linkFunction((request) async {
       return Response.ok({"key": "value"});
     });

--- a/packages/core/lib/conduit_core.dart
+++ b/packages/core/lib/conduit_core.dart
@@ -13,7 +13,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 /// The core libraries of the Conduit framework.
 ///
-/// See documentation guides at https://conduit.io/docs/.
+/// See documentation guides at https://docs.theconduit.dev/.
 library conduit;
 
 export 'package:conduit_config/conduit_config.dart';

--- a/packages/core/lib/src/db/managed/object.dart
+++ b/packages/core/lib/src/db/managed/object.dart
@@ -63,7 +63,7 @@ abstract class ManagedBacking {
 /// A subclass of this type must implement its table definition and use it as the type argument of [ManagedObject]. Properties and methods
 /// declared in the subclass (also called the 'instance type') are not stored in the database.
 ///
-/// See more documentation on defining a data model at http://conduit.io/docs/db/modeling_data/
+/// See more documentation on defining a data model at https://docs.theconduit.dev/db/modeling_data/
 abstract class ManagedObject<T> extends Serializable {
   /// IMPROVEMENT: Cache of entity.properties to reduce property loading time
   late Map<String?, ManagedPropertyDescription?> properties = entity.properties;

--- a/packages/core/lib/src/http/resource_controller.dart
+++ b/packages/core/lib/src/http/resource_controller.dart
@@ -62,7 +62,7 @@ import 'package:meta/meta.dart';
 ///           }
 ///         }
 ///
-/// Bindings will automatically parse values into other types and validate that requests have the desired values. See [Bind] for all possible bindings and https://conduit.io/docs/http/resource_controller/ for more details.
+/// Bindings will automatically parse values into other types and validate that requests have the desired values. See [Bind] for all possible bindings and https://docs.theconduit.dev/http/resource_controller/ for more details.
 ///
 /// To access the request directly, use [request]. Note that the [Request.body] of [request] will be decoded prior to invoking an operation method.
 abstract class ResourceController extends Controller

--- a/packages/core/lib/src/http/router.dart
+++ b/packages/core/lib/src/http/router.dart
@@ -45,7 +45,7 @@ class Router extends Controller {
   /// Routers allow for multiple linked controllers. A request that matches [pattern]
   /// will be sent to the controller linked to this method's return value.
   ///
-  /// The [pattern] must follow the rules of route patterns (see also http://conduit.io/docs/http/routing/).
+  /// The [pattern] must follow the rules of route patterns (see also https://docs.theconduit.dev/http/routing/).
   ///
   /// A pattern consists of one or more path segments, e.g. "/path" or "/path/to".
   ///

--- a/packages/test_harness/README.md
+++ b/packages/test_harness/README.md
@@ -1,5 +1,3 @@
-Test framework for [conduit](https://conduit.io) applications. This package is included as a `dev_dependency` of `conduit` applications.
+Test framework for [conduit](https://theconduit.dev) applications. This package is included as a `dev_dependency` of `conduit` applications.
 
-The documentation for this package is available at [https://conduit.io/docs/testing/](https://conduit.io/docs/testing/).
-
-
+The documentation for this package is available at [https://docs.theconduit.dev/testing/](https://docs.theconduit.dev/testing/).


### PR DESCRIPTION
When trying out the library locally I was browsing the source code and links were incorrectly pointing at the `conduit.io` domain. I hopefully updated all links to match the new deployment.