### PR TITLE
feat: Allow passing `sslMode` to `PostgreSQLPersistentStore`

### DIFF
--- a/packages/postgresql/lib/src/postgresql_persistent_store.dart
+++ b/packages/postgresql/lib/src/postgresql_persistent_store.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:conduit_core/conduit_core.dart';
 import 'postgresql_query.dart';
 import 'postgresql_schema_generator.dart';
@@ -19,8 +20,11 @@ class PostgreSQLPersistentStore extends PersistentStore
     this.port,
     this.databaseName, {
     this.timeZone = "UTC",
+    String? sslMode,
+    @Deprecated('Use sslMode instead')
     bool useSSL = false,
-  }) : isSSLConnection = useSSL;
+  }) : isSSLConnection = useSSL,
+       sslMode = SslMode.values.singleWhereOrNull((e) => e.name == sslMode);
 
   /// Same constructor as default constructor.
   ///
@@ -32,8 +36,11 @@ class PostgreSQLPersistentStore extends PersistentStore
     this.port,
     this.databaseName, {
     this.timeZone = "UTC",
+    String? sslMode,
+    @Deprecated('Use sslMode instead')
     bool useSSL = false,
-  }) : isSSLConnection = useSSL;
+  }) : isSSLConnection = useSSL,
+       sslMode = SslMode.values.singleWhereOrNull((e) => e.name == sslMode);
 
   PostgreSQLPersistentStore._from(PostgreSQLPersistentStore from)
       : isSSLConnection = from.isSSLConnection,
@@ -42,7 +49,8 @@ class PostgreSQLPersistentStore extends PersistentStore
         host = from.host,
         port = from.port,
         databaseName = from.databaseName,
-        timeZone = from.timeZone;
+        timeZone = from.timeZone,
+        sslMode = from.sslMode;
 
   factory PostgreSQLPersistentStore._transactionProxy(
     PostgreSQLPersistentStore parent,
@@ -73,7 +81,11 @@ class PostgreSQLPersistentStore extends PersistentStore
   final String? timeZone;
 
   /// Whether this connection is established over SSL.
+  @Deprecated('Use sslMode instead')
   final bool isSSLConnection;
+
+  /// The SSL mode of the connection to the database.
+  final SslMode? sslMode;
 
   /// Whether or not the underlying database connection is open.
   ///
@@ -421,7 +433,7 @@ class PostgreSQLPersistentStore extends PersistentStore
       ),
       settings: ConnectionSettings(
         timeZone: timeZone!,
-        sslMode: isSSLConnection ? SslMode.verifyFull : SslMode.disable,
+        sslMode: sslMode ?? (isSSLConnection ? SslMode.verifyFull : SslMode.disable),
         ignoreSuperfluousParameters: true,
       ),
     );


### PR DESCRIPTION
This change keeps backward compatibility for `bool useSSL`, but `useSSL` forces `SslMode.verifyFull` which is not always suitable.

I've spent few hours to find out why my config value `database.sslMode = require` is not used as expected and connection fails with invalid server certificate. I found that's because all SSL modes are reduced to `boo useSSL = true` and this is later used to pass `SslMode.verifyFull` in PostgreSQL Connection.
