### PR TITLE
refactor(cli): Change build source to bin/main.dart

### DIFF
--- a/packages/cli/lib/src/commands/build.dart
+++ b/packages/cli/lib/src/commands/build.dart
@@ -2,13 +2,10 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:mirrors';
 
-import 'package:args/args.dart' as arg_package;
 import 'package:conduit/src/command.dart';
 import 'package:conduit/src/metadata.dart';
 import 'package:conduit/src/mixins/project.dart';
-import 'package:conduit_core/conduit_core.dart';
 import 'package:conduit_runtime/runtime.dart';
 import 'package:io/io.dart';
 
@@ -83,88 +80,9 @@ class CLIBuild extends CLICommand with CLIProject {
   }
 
   String getScriptSource(String channelName) {
-    final method = (reflect(_runnerFunc) as ClosureMirror).function;
-
-    return """
-import 'dart:async';
-import 'dart:io';
-
-import 'package:conduit_core/conduit_core.dart';
-import 'package:args/args.dart' as arg_package;
-import 'package:$packageName/$libraryName.dart';
-
-${method.source!.replaceFirst("Application<ApplicationChannel>", "Application<$channelName>").replaceFirst("_runnerFunc", "main")}
-""";
-  }
-}
-
-Future _runnerFunc(List<String> args, dynamic sendPort) async {
-  final argParser = arg_package.ArgParser()
-    ..addOption(
-      "address",
-      abbr: "a",
-      help: "The address to listen on. See HttpServer.bind for more details."
-          " Using the default will listen on any address.",
-    )
-    ..addOption(
-      "config-path",
-      abbr: "c",
-      help:
-          "The path to a configuration file. This File is available in the ApplicationOptions "
-          "for a ApplicationChannel to use to read application-specific configuration values. Relative paths are relative to [directory].",
-      defaultsTo: "config.yaml",
-    )
-    ..addOption(
-      "isolates",
-      abbr: "n",
-      help: "Number of isolates handling requests.",
-    )
-    ..addOption(
-      "port",
-      abbr: "p",
-      help: "The port number to listen for HTTP requests on.",
-      defaultsTo: "8888",
-    )
-    ..addFlag(
-      "ipv6-only",
-      help: "Limits listening to IPv6 connections only.",
-      negatable: false,
-    )
-    ..addOption(
-      "ssl-certificate-path",
-      help:
-          "The path to an SSL certicate file. If provided along with --ssl-certificate-path, the application will be HTTPS-enabled.",
-    )
-    ..addOption(
-      "ssl-key-path",
-      help:
-          "The path to an SSL private key file. If provided along with --ssl-certificate-path, the application will be HTTPS-enabled.",
-    )
-    ..addOption(
-      "timeout",
-      help: "Number of seconds to wait to ensure startup succeeded.",
-      defaultsTo: "45",
-    )
-    ..addFlag("help");
-
-  final values = argParser.parse(args);
-  if (values["help"] == true) {
-    print(argParser.usage);
-    return 0;
-  }
-
-  final app = Application<ApplicationChannel>();
-  app.options = ApplicationOptions()
-    ..port = int.parse(values['port'] as String)
-    ..address = values['address']
-    ..isIpv6Only = values['ipv6-only'] == true
-    ..configurationFilePath = values['config-path'] as String?
-    ..certificateFilePath = values['ssl-certificate-path'] as String?
-    ..privateKeyFilePath = values['ssl-key-path'] as String?;
-  final isolateCountString = values['isolates'];
-  if (isolateCountString == null) {
-    await app.startOnCurrentIsolate();
-  } else {
-    await app.start(numberOfInstances: int.parse(isolateCountString as String));
+    return File(projectDirectory!.uri
+            .resolve('bin/main.dart')
+            .toFilePath(windows: Platform.isWindows))
+        .readAsStringSync();
   }
 }

--- a/packages/cli/templates/db/bin/main.dart
+++ b/packages/cli/templates/db/bin/main.dart
@@ -1,6 +1,6 @@
 import 'package:wildfire/wildfire.dart';
 
-Future main() async {
+Future main(List<String> args) async {
   final values = ApplicationOptions.parser.parse(args);
   if (values["help"] == true) {
     print(ApplicationOptions.parser.usage);

--- a/packages/cli/templates/db/bin/main.dart
+++ b/packages/cli/templates/db/bin/main.dart
@@ -1,12 +1,24 @@
 import 'package:wildfire/wildfire.dart';
 
 Future main() async {
-  final app = Application<WildfireChannel>()
-    ..options.configurationFilePath = "config.yaml"
-    ..options.port = 8888;
+  final values = ApplicationOptions.parser.parse(args);
+  if (values["help"] == true) {
+    print(ApplicationOptions.parser.usage);
+    return 0;
+  }
 
-  await app.startOnCurrentIsolate();
-
-  print("Application started on port: ${app.options.port}.");
-  print("Use Ctrl-C (SIGINT) to stop running the application.");
+  final app = Application<WildfireChannel>();
+  app.options = ApplicationOptions()
+    ..port = int.parse(values['port'] as String)
+    ..address = values['address']
+    ..isIpv6Only = values['ipv6-only'] == true
+    ..configurationFilePath = values['config-path'] as String?
+    ..certificateFilePath = values['ssl-certificate-path'] as String?
+    ..privateKeyFilePath = values['ssl-key-path'] as String?;
+  final isolateCountString = values['isolates'];
+  if (isolateCountString == null) {
+    await app.startOnCurrentIsolate();
+  } else {
+    await app.start(numberOfInstances: int.parse(isolateCountString as String));
+  }
 }

--- a/packages/cli/templates/db_and_auth/bin/main.dart
+++ b/packages/cli/templates/db_and_auth/bin/main.dart
@@ -1,6 +1,6 @@
 import 'package:wildfire/wildfire.dart';
 
-Future main() async {
+Future main(List<String> args) async {
   final values = ApplicationOptions.parser.parse(args);
   if (values["help"] == true) {
     print(ApplicationOptions.parser.usage);

--- a/packages/cli/templates/db_and_auth/bin/main.dart
+++ b/packages/cli/templates/db_and_auth/bin/main.dart
@@ -1,12 +1,24 @@
 import 'package:wildfire/wildfire.dart';
 
 Future main() async {
-  final app = Application<WildfireChannel>()
-    ..options.configurationFilePath = "config.yaml"
-    ..options.port = 8888;
+  final values = ApplicationOptions.parser.parse(args);
+  if (values["help"] == true) {
+    print(ApplicationOptions.parser.usage);
+    return 0;
+  }
 
-  await app.startOnCurrentIsolate();
-
-  print("Application started on port: ${app.options.port}.");
-  print("Use Ctrl-C (SIGINT) to stop running the application.");
+  final app = Application<WildfireChannel>();
+  app.options = ApplicationOptions()
+    ..port = int.parse(values['port'] as String)
+    ..address = values['address']
+    ..isIpv6Only = values['ipv6-only'] == true
+    ..configurationFilePath = values['config-path'] as String?
+    ..certificateFilePath = values['ssl-certificate-path'] as String?
+    ..privateKeyFilePath = values['ssl-key-path'] as String?;
+  final isolateCountString = values['isolates'];
+  if (isolateCountString == null) {
+    await app.startOnCurrentIsolate();
+  } else {
+    await app.start(numberOfInstances: int.parse(isolateCountString as String));
+  }
 }

--- a/packages/cli/templates/default/bin/main.dart
+++ b/packages/cli/templates/default/bin/main.dart
@@ -1,6 +1,6 @@
 import 'package:wildfire/wildfire.dart';
 
-Future main() async {
+Future main(List<String> args) async {
   final values = ApplicationOptions.parser.parse(args);
   if (values["help"] == true) {
     print(ApplicationOptions.parser.usage);

--- a/packages/cli/templates/default/bin/main.dart
+++ b/packages/cli/templates/default/bin/main.dart
@@ -1,12 +1,24 @@
 import 'package:wildfire/wildfire.dart';
 
 Future main() async {
-  final app = Application<WildfireChannel>()
-    ..options.configurationFilePath = "config.yaml"
-    ..options.port = 8888;
+  final values = ApplicationOptions.parser.parse(args);
+  if (values["help"] == true) {
+    print(ApplicationOptions.parser.usage);
+    return 0;
+  }
 
-  await app.startOnCurrentIsolate();
-
-  print("Application started on port: ${app.options.port}.");
-  print("Use Ctrl-C (SIGINT) to stop running the application.");
+  final app = Application<WildfireChannel>();
+  app.options = ApplicationOptions()
+    ..port = int.parse(values['port'] as String)
+    ..address = values['address']
+    ..isIpv6Only = values['ipv6-only'] == true
+    ..configurationFilePath = values['config-path'] as String?
+    ..certificateFilePath = values['ssl-certificate-path'] as String?
+    ..privateKeyFilePath = values['ssl-key-path'] as String?;
+  final isolateCountString = values['isolates'];
+  if (isolateCountString == null) {
+    await app.startOnCurrentIsolate();
+  } else {
+    await app.start(numberOfInstances: int.parse(isolateCountString as String));
+  }
 }

--- a/packages/core/lib/src/application/options.dart
+++ b/packages/core/lib/src/application/options.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:conduit_core/src/application/application.dart';
 import 'package:conduit_core/src/application/channel.dart';
 
@@ -55,4 +56,52 @@ class ApplicationOptions {
   /// This is a user-specific set of configuration options provided by [ApplicationChannel.initializeApplication].
   /// Each instance of [ApplicationChannel] has access to these values if set.
   final Map<String, dynamic> context = {};
+
+  static final parser = ArgParser()
+    ..addOption(
+      "address",
+      abbr: "a",
+      help: "The address to listen on. See HttpServer.bind for more details."
+          " Using the default will listen on any address.",
+    )
+    ..addOption(
+      "config-path",
+      abbr: "c",
+      help:
+          "The path to a configuration file. This File is available in the ApplicationOptions "
+          "for a ApplicationChannel to use to read application-specific configuration values. Relative paths are relative to [directory].",
+      defaultsTo: "config.yaml",
+    )
+    ..addOption(
+      "isolates",
+      abbr: "n",
+      help: "Number of isolates handling requests.",
+    )
+    ..addOption(
+      "port",
+      abbr: "p",
+      help: "The port number to listen for HTTP requests on.",
+      defaultsTo: "8888",
+    )
+    ..addFlag(
+      "ipv6-only",
+      help: "Limits listening to IPv6 connections only.",
+      negatable: false,
+    )
+    ..addOption(
+      "ssl-certificate-path",
+      help:
+          "The path to an SSL certicate file. If provided along with --ssl-certificate-path, the application will be HTTPS-enabled.",
+    )
+    ..addOption(
+      "ssl-key-path",
+      help:
+          "The path to an SSL private key file. If provided along with --ssl-certificate-path, the application will be HTTPS-enabled.",
+    )
+    ..addOption(
+      "timeout",
+      help: "Number of seconds to wait to ensure startup succeeded.",
+      defaultsTo: "45",
+    )
+    ..addFlag("help");
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_workspace
-version: 5.1.2
+version: 5.1.3
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues


### PR DESCRIPTION
This change moves the arg parser into the template files and uses the bin/main.dart file for building, which streamlines development and deployment.