### PR TITLE
feat(sql): scaffold conduit_sql + general-ORM design (phase 0)

### DIFF
--- a/docs/GENERAL_ORM.md
+++ b/docs/GENERAL_ORM.md
@@ -1,0 +1,242 @@
+# General ORM — multi-dialect SQL backend
+
+> Design proposal for letting Conduit's ORM target backends other than
+> PostgreSQL. Companion to [REFACTOR_CONTEXT.md](REFACTOR_CONTEXT.md).
+> Scope: SQL dialects (Postgres, MySQL, SQLite). Non-SQL stores are a
+> separate problem and out of scope for this proposal.
+
+## 1. Goal
+
+Conduit's ORM (`Query<T>`, `ManagedObject`, `Schema`) is already
+backend-agnostic at the API surface. The only live backend is
+`packages/postgresql/`. PR #192 (closed) attempted a parallel
+`packages/mysql/` package by cloning the postgresql tree; it stalled
+after 3 years because every Postgres improvement required a manual
+re-clone.
+
+Goal: make adding a backend a small, contained job — one new package
+per dialect, ~few hundred lines, no duplicated SQL builder logic.
+First non-Postgres dialect: MySQL. SQLite, MSSQL, etc. follow the
+same shape.
+
+## 2. Where the Postgres-specific logic actually lives
+
+Surveyed `packages/postgresql/lib/src/` — 11 files, 2144 lines. Split
+by how dialect-specific they actually are:
+
+| File | Lines | Dialect-specific? |
+| --- | --- | --- |
+| `postgresql_persistent_store.dart` | 495 | **Yes** — `package:postgres` driver, `SslMode`, connection pooling, parameter substitution syntax (`@varname`) |
+| `postgresql_schema_generator.dart` | 289 | **Yes** — DDL strings (`SERIAL`, `TIMESTAMP`, `JSONB`, `BIGSERIAL` mappings) |
+| `postgresql_query.dart` | 254 | **Mostly no** — INSERT/UPDATE/DELETE/SELECT SQL assembly. Only PG-isms are `RETURNING` clause and the `@varname` parameter style. |
+| `postgresql_query_reduce.dart` | 105 | **No** — aggregation function names (COUNT, MAX, etc.) are SQL-standard |
+| `query_builder.dart` | 138 | **No** — already generically named, coordinates the builders below |
+| `row_instantiator.dart` | 172 | **No** — maps DB rows to `ManagedObject` instances; backend-agnostic |
+| `builders/column.dart` | 158 | **No** — column reference + alias generation |
+| `builders/expression.dart` | 151 | **No** — WHERE clause matchers (`=`, `LIKE`, `IN`, etc.) |
+| `builders/sort.dart` | 24 | **No** — `ORDER BY ... ASC/DESC` |
+| `builders/table.dart` | 341 | **No** — JOIN tree, table aliases, FROM-clause assembly |
+| `builders/value.dart` | 17 | **No** — value/parameter binding wrapper |
+
+About **1100 of the 2144 lines are already dialect-neutral SQL
+construction.** They live in `packages/postgresql/` for historical
+reasons (Aqueduct only ever shipped a Postgres backend) but have no
+inherent PG dependency.
+
+## 3. Approach
+
+Three new pieces:
+
+1. **`packages/sql/` (`conduit_sql`)** — extracted shared SQL toolkit.
+   Becomes the home of the dialect-neutral builders and a `Dialect`
+   abstract interface that captures everything a backend must answer
+   about its own SQL. Imports `conduit_core` only.
+
+2. **`Dialect` interface** — the small surface area that varies by
+   backend. From the Postgres survey above:
+   - **Identifier quoting** — `"foo"` vs `` `foo` `` vs `[foo]`
+   - **Parameter syntax** — `@name` vs `?` vs `$1`
+   - **Auto-increment column type** — `BIGSERIAL` vs `BIGINT AUTO_INCREMENT` vs `INTEGER PRIMARY KEY AUTOINCREMENT`
+   - **DDL type names** for each `ManagedPropertyType`
+   - **Returning-clause support** — Postgres has `RETURNING`; MySQL
+     8.0+ has it for some statements; older MySQL needs a follow-up
+     `LAST_INSERT_ID()` SELECT
+   - **Conflict / upsert syntax** — `ON CONFLICT` vs `ON DUPLICATE KEY`
+   - **Boolean literal** — `TRUE` / `FALSE` vs `1` / `0`
+   - **Date/time formatting**
+   - **JSON column support** — `JSONB` vs `JSON` vs absent
+
+3. **Per-backend adapter packages** — `packages/postgresql/` and the
+   new `packages/mysql/` each shrink to:
+   - `<X>PersistentStore extends PersistentStore` with
+     connection-pool, driver, transaction handling.
+   - `<X>Dialect extends Dialect` returning the dialect-specific
+     strings and capability flags.
+   - Optionally a tiny `<X>Query` if some statements need bespoke
+     assembly that doesn't fit the shared template.
+
+   The estimate is: postgresql shrinks from 2144 lines to about
+   600-800; mysql lands around the same size, with the rest
+   (≈1100 lines) shared via `conduit_sql`.
+
+## 4. User-facing API
+
+Unchanged. A user app today writes:
+
+```dart
+final ctx = ManagedContext(
+  dataModel,
+  PostgreSQLPersistentStore(
+    user, password, host, port, db,
+  ),
+);
+
+final users = await Query<User>(ctx).fetch();
+```
+
+After this work, swapping to MySQL is one import + one constructor
+swap:
+
+```dart
+final ctx = ManagedContext(
+  dataModel,
+  MySQLPersistentStore(
+    user, password, host, port, db,
+  ),
+);
+
+final users = await Query<User>(ctx).fetch();   // identical
+```
+
+`Query<T>`, `ManagedObject`, `Schema`, `Migration` — all unchanged.
+
+## 5. Migration plan (chunked)
+
+Each phase is independently shippable; postgres keeps working at
+every step.
+
+### Phase 0 — Scaffolding (this PR)
+
+- New package `packages/sql/` (`conduit_sql`) at version 6.0.0,
+  registered in workspace + melos.
+- `Dialect` abstract class with the capability surface from §3,
+  stub implementations + doc comments. No real callers yet.
+- `analysis_options.yaml`, `CHANGELOG.md`, `README.md`, `LICENSE`,
+  empty `test/` with a smoke test.
+
+No behavior change for postgresql users.
+
+### Phase 1 — Extract dialect-neutral builders
+
+Move from `packages/postgresql/lib/src/`:
+- `builders/column.dart`, `expression.dart`, `sort.dart`,
+  `table.dart`, `value.dart`
+- `query_builder.dart`, `row_instantiator.dart`
+
+into `packages/sql/lib/src/`. Update imports. Add `Dialect`
+parameter where the moved code currently hard-codes Postgres
+quoting / parameter syntax.
+
+### Phase 2 — Extract reduce + the query template
+
+Move `postgresql_query_reduce.dart` and the dialect-neutral parts of
+`postgresql_query.dart` (INSERT/UPDATE/DELETE/SELECT assembly) into
+`packages/sql/`. The PG-specific `RETURNING` handling goes through
+the `Dialect.returningClauseFor(...)` hook.
+
+### Phase 3 — Postgres adapter cleanup
+
+What remains in `packages/postgresql/`:
+- `postgresql_persistent_store.dart` (driver + transactions)
+- `postgresql_schema_generator.dart` (DDL strings)
+- A new `postgresql_dialect.dart` implementing `Dialect`
+- A thin `postgresql_query.dart` that just plugs the dialect into
+  the shared template.
+
+Estimated final size: ~700 lines, down from 2144.
+
+### Phase 4 — MySQL adapter
+
+`packages/mysql/` (`conduit_mysql`):
+- `mysql_persistent_store.dart` using `package:mysql_client` ^1.x
+  (latest, breaking-change updated from the 0.0.27 in #192)
+- `mysql_schema_generator.dart` mirroring the postgres DDL with
+  MySQL types (`AUTO_INCREMENT`, `JSON`, `DATETIME`, …)
+- `mysql_dialect.dart` implementing `Dialect`
+- `mysql_query.dart` thin wrapper, plus a fallback path for
+  pre-8.0 servers without `RETURNING`.
+- Test suite cloned from `packages/postgresql/test/`, retargeted
+  at a MySQL container in `ci/docker-compose.yaml`.
+
+### Phase 5 — Optional: SQLite adapter
+
+`packages/sqlite/` (`conduit_sqlite`) using `package:sqlite3`. Same
+shape as MySQL. Useful for embedded and test scenarios where
+spinning up Postgres/MySQL is overkill. Lower priority.
+
+### Phase 6 — Docs + migration guide
+
+- `docs/db/connecting.md` shows all three backends.
+- `docs/db/dialects.md` (new) explains the dialect interface for
+  third-party adapters.
+- v6.x → v7.x migration note if any user-visible API changed (none
+  expected).
+
+## 6. Open questions
+
+1. **Migrations DDL across dialects.** A migration file calls
+   `database.createTable(...)` etc. Today the call goes through
+   `PersistentStore`, which is per-backend, so the SQL emitted is
+   already correct for whichever store is attached. **Implication:**
+   migrations stay portable across dialects as long as the user
+   doesn't drop into raw SQL strings inside a migration. Worth a
+   call-out in the docs.
+
+2. **Connection pooling.** `package:postgres` and
+   `package:mysql_client` have different pooling models.
+   `PersistentStore` could either expose a pool-agnostic interface
+   or stay opinionated per-backend. **Lean: per-backend** — pool
+   tuning is dialect-specific in practice.
+
+3. **Transaction isolation levels.** Postgres and MySQL have
+   different default isolation and different syntax for setting it.
+   `ManagedContext.transaction` takes no isolation argument today;
+   adding one is its own design discussion. **Lean: out of scope
+   for this proposal.**
+
+4. **Capability negotiation at construction time.** A `Dialect`
+   could expose feature flags (`supportsReturning`,
+   `supportsCheckConstraints`, `maxIdentifierLength`) so the shared
+   builder can pick the right path. Use a `DialectCapabilities`
+   struct rather than scattering bool getters on `Dialect`.
+
+5. **NoSQL.** A document store like Mongo or KV store like Redis
+   would not implement `Dialect` — the `PersistentStore` interface
+   itself would need a sibling abstraction. **Out of scope for this
+   proposal**, but the package layout (`conduit_sql` rather than
+   `conduit_db_common`) is named to avoid claiming non-SQL territory.
+
+6. **Where the `RETURNING` shim lives.** For dialects that don't
+   have it natively (older MySQL, SQLite), the shared INSERT
+   template needs to emit a `LAST_INSERT_ID()` follow-up. This is a
+   real piece of logic — not just a string difference. Likely lives
+   on `Dialect` as `Future<dynamic> insertReturning(executor, sql, params)`.
+
+## 7. What "starting work" looks like in practice (this PR)
+
+This PR lands phase 0 only:
+
+- New `packages/sql/` package skeleton
+- Stub `Dialect` interface with the capability surface from §3
+- Workspace + melos registration
+- Smoke test that the package builds and the stub interface compiles
+- This design doc
+
+No production code change. Phases 1–4 land in subsequent PRs, in
+order. Phase 5 can land any time after phase 3.
+
+---
+
+*Proposal, not a commitment. Sizes in §3 are line counts as of
+2026-04-25. Phase ordering may shift if extracting the builders
+turns out trickier than the line counts suggest.*

--- a/packages/sql/CHANGELOG.md
+++ b/packages/sql/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 6.0.0
+
+- Initial scaffold (phase 0 of the general-ORM migration documented in
+  `docs/GENERAL_ORM.md`).
+- Defines the `Dialect` abstract interface and `DialectCapabilities`.
+- No production code consumes this yet — phase 1 extracts the shared
+  SQL builders out of `packages/postgresql/`.

--- a/packages/sql/LICENSE
+++ b/packages/sql/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2018, stable/kernel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -1,0 +1,29 @@
+# conduit_sql
+
+Dialect-pluggable SQL backend toolkit for the Conduit ORM. Lets backends like
+Postgres, MySQL, and SQLite share the SQL builder, JOIN planner, and row
+instantiator while only implementing the bits that genuinely differ between
+dialects.
+
+This is **phase 0** of the work documented in
+[`docs/GENERAL_ORM.md`](../../docs/GENERAL_ORM.md): the package, the
+`Dialect` abstract surface, and a smoke test. The shared builders that
+consume this interface are extracted from `packages/postgresql/` in phase 1.
+
+## What's here today
+
+- `Dialect` — abstract interface every adapter implements
+  (identifier quoting, parameter syntax, DDL type names, capability flags).
+- `DialectCapabilities` — feature flags the shared builders branch on
+  (`supportsReturning`, `supportsUpsert`, `supportsJsonColumn`,
+  `supportsCheckConstraints`, `maxIdentifierLength`).
+
+## Not here yet
+
+- The shared SQL builders themselves — phase 1 moves them out of
+  `packages/postgresql/lib/src/{builders,query_builder,row_instantiator}.dart`.
+- A concrete `PostgresDialect` / `MySQLDialect` — phases 3 and 4.
+
+A user app does not import this package directly. They import a backend
+adapter (`conduit_postgresql`, `conduit_mysql`) which depends on this
+package transitively.

--- a/packages/sql/analysis_options.yaml
+++ b/packages/sql/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/sql/lib/conduit_sql.dart
+++ b/packages/sql/lib/conduit_sql.dart
@@ -1,0 +1,8 @@
+/// Dialect-pluggable SQL backend toolkit for the Conduit ORM.
+///
+/// See `docs/GENERAL_ORM.md` for the design and migration plan.
+/// This is the phase-0 scaffold; the dialect-neutral SQL builders
+/// land in subsequent phases.
+library;
+
+export 'src/dialect.dart';

--- a/packages/sql/lib/src/dialect.dart
+++ b/packages/sql/lib/src/dialect.dart
@@ -1,0 +1,90 @@
+import 'package:meta/meta.dart';
+
+/// What an ORM backend must answer about its own SQL.
+///
+/// One concrete subclass per supported database (Postgres, MySQL,
+/// SQLite, …). The shared SQL builders in `conduit_sql` consult an
+/// instance of this class for every dialect-specific decision: how
+/// identifiers are quoted, how parameters are referenced, what DDL
+/// type names mean, and which optional features (RETURNING, JSON,
+/// upsert) are available.
+///
+/// **Phase 0 scaffold.** This interface defines the surface; the
+/// shared builders that consume it are extracted from
+/// `packages/postgresql/` in phase 1. See `docs/GENERAL_ORM.md`.
+@experimental
+abstract class Dialect {
+  const Dialect();
+
+  /// Human-readable name for diagnostics (`'postgres'`, `'mysql'`).
+  String get name;
+
+  /// Wrap an identifier (table name, column name) for the dialect's
+  /// quoting rules. Postgres `"foo"`, MySQL `` `foo` ``,
+  /// MSSQL `[foo]`.
+  String quoteIdentifier(String identifier);
+
+  /// Reference parameter [index] (1-based) inside a SQL string.
+  /// Postgres `@name` / `$N`, MySQL `?`, SQLite `?N`.
+  String parameterReference(int index, {String? name});
+
+  /// DDL type for an auto-incrementing primary key column.
+  /// Postgres `BIGSERIAL`, MySQL `BIGINT AUTO_INCREMENT`,
+  /// SQLite `INTEGER PRIMARY KEY AUTOINCREMENT`.
+  String autoIncrementColumnType();
+
+  /// DDL type name for the given Conduit managed property type.
+  ///
+  /// `propertyType` is a stringified `ManagedPropertyType` value
+  /// (e.g. `'integer'`, `'string'`, `'datetime'`, `'document'`).
+  /// Returning `null` signals the property type is unsupported by
+  /// this dialect, in which case the caller raises a clearer error
+  /// than the database driver would.
+  String? columnTypeFor(String propertyType);
+
+  /// Boolean literal text for [value]. Postgres `TRUE`/`FALSE`;
+  /// MySQL `1`/`0`.
+  String booleanLiteral(bool value);
+
+  /// Capability flags. The shared SQL builders branch on these to
+  /// pick the right code path per backend.
+  DialectCapabilities get capabilities;
+}
+
+/// Optional features a dialect may or may not implement.
+///
+/// Grows additively as the shared builders learn to use more dialect
+/// features. Defaults are conservative — a brand-new adapter that
+/// constructs `DialectCapabilities()` with no overrides gets the
+/// most-portable behavior.
+@immutable
+class DialectCapabilities {
+  const DialectCapabilities({
+    this.supportsReturning = false,
+    this.supportsUpsert = false,
+    this.supportsJsonColumn = false,
+    this.supportsCheckConstraints = false,
+    this.maxIdentifierLength = 63,
+  });
+
+  /// True if INSERT/UPDATE/DELETE can return rows in a single
+  /// round-trip (`RETURNING` clause). Postgres: yes. MySQL 8.0+:
+  /// partial. SQLite: no — needs a follow-up `last_insert_rowid()`.
+  final bool supportsReturning;
+
+  /// True if the dialect has native upsert (`ON CONFLICT … DO …`,
+  /// `ON DUPLICATE KEY UPDATE`).
+  final bool supportsUpsert;
+
+  /// True if a structured-JSON column type exists (`JSONB`, `JSON`).
+  /// False forces the ORM to store JSON as text.
+  final bool supportsJsonColumn;
+
+  /// True if `CHECK` constraints are enforced. MySQL parses but
+  /// historically did not enforce them.
+  final bool supportsCheckConstraints;
+
+  /// Maximum identifier length. Postgres 63. MySQL 64. SQLite 1MB
+  /// in theory; treat as effectively unlimited.
+  final int maxIdentifierLength;
+}

--- a/packages/sql/pubspec.yaml
+++ b/packages/sql/pubspec.yaml
@@ -1,0 +1,18 @@
+name: conduit_sql
+description: Dialect-pluggable SQL backend toolkit for the Conduit ORM. Lets backends like Postgres and MySQL share the SQL builders and only implement dialect differences.
+version: 6.0.0
+home: https://www.theconduit.dev
+repository: https://github.com/conduit-dart/conduit
+issue_tracker: https://github.com/conduit-dart/conduit/issues
+
+environment:
+  sdk: ">=3.11.0 <4.0.0"
+resolution: workspace
+
+dependencies:
+  conduit_core: ^6.0.0
+  meta: ^1.12.0
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.25.2

--- a/packages/sql/test/dialect_test.dart
+++ b/packages/sql/test/dialect_test.dart
@@ -1,0 +1,67 @@
+import 'package:conduit_sql/conduit_sql.dart';
+import 'package:test/test.dart';
+
+/// Tiny stub dialect used only to verify the abstract surface
+/// compiles and behaves as documented. The real dialects (Postgres,
+/// MySQL) land in subsequent phases.
+class _StubDialect extends Dialect {
+  const _StubDialect();
+
+  @override
+  String get name => 'stub';
+
+  @override
+  String quoteIdentifier(String identifier) => '"$identifier"';
+
+  @override
+  String parameterReference(int index, {String? name}) => '@p$index';
+
+  @override
+  String autoIncrementColumnType() => 'BIGSERIAL';
+
+  @override
+  String? columnTypeFor(String propertyType) => switch (propertyType) {
+        'integer' => 'INTEGER',
+        'string' => 'TEXT',
+        _ => null,
+      };
+
+  @override
+  String booleanLiteral(bool value) => value ? 'TRUE' : 'FALSE';
+
+  @override
+  DialectCapabilities get capabilities => const DialectCapabilities(
+        supportsReturning: true,
+        supportsJsonColumn: true,
+      );
+}
+
+void main() {
+  const dialect = _StubDialect();
+
+  test('Dialect surface is implementable', () {
+    expect(dialect.name, 'stub');
+    expect(dialect.quoteIdentifier('foo'), '"foo"');
+    expect(dialect.parameterReference(1), '@p1');
+    expect(dialect.autoIncrementColumnType(), 'BIGSERIAL');
+    expect(dialect.columnTypeFor('integer'), 'INTEGER');
+    expect(dialect.columnTypeFor('unknown'), isNull);
+    expect(dialect.booleanLiteral(true), 'TRUE');
+    expect(dialect.booleanLiteral(false), 'FALSE');
+  });
+
+  test('DialectCapabilities default to most-portable values', () {
+    const c = DialectCapabilities();
+    expect(c.supportsReturning, isFalse);
+    expect(c.supportsUpsert, isFalse);
+    expect(c.supportsJsonColumn, isFalse);
+    expect(c.supportsCheckConstraints, isFalse);
+    expect(c.maxIdentifierLength, 63);
+  });
+
+  test('DialectCapabilities propagate overrides', () {
+    expect(dialect.capabilities.supportsReturning, isTrue);
+    expect(dialect.capabilities.supportsJsonColumn, isTrue);
+    expect(dialect.capabilities.supportsUpsert, isFalse);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ workspace:
   - packages/password_hash
   - packages/postgresql
   - packages/runtime
+  - packages/sql
   - packages/test_harness
   - packages/fs_test_agent
 
@@ -79,5 +80,6 @@ melos:
                             -V conduit_password_hash:$v \
                             -V conduit_postgresql:$v \
                             -V conduit_runtime:$v \
+                            -V conduit_sql:$v \
                             -V conduit_test:$v \
                             -V fs_test_agent:$v


### PR DESCRIPTION
## Summary

Phase 0 of the multi-dialect ORM migration. Replaces the abandoned #192 (a parallel \`packages/postgresql/\` clone for MySQL) with a shared-toolkit approach: extract the dialect-neutral SQL builders out of \`packages/postgresql/\` once, then add MySQL — and later SQLite, MSSQL, etc. — as small adapter packages on top.

## What's in this PR

- **[\`docs/GENERAL_ORM.md\`](docs/GENERAL_ORM.md)** — architecture + chunked migration plan.
  - Survey of the 2144 lines in \`packages/postgresql/lib/src/\` shows ~1100 of them are already dialect-neutral SQL construction (\`builders/*\`, \`query_builder\`, \`row_instantiator\`, \`query_reduce\`).
  - Goal: move those into \`conduit_sql\` once, then reduce each backend to ~600-800 lines of dialect-specific code.
  - 6 phases, each independently shippable; postgres keeps working at every step.
  - 6 explicit open questions (migrations DDL, connection pooling, transaction isolation, capability negotiation, NoSQL out-of-scope reasoning, RETURNING shim placement).

- **\`packages/sql/\`** (\`conduit_sql\`) — new package skeleton with the \`Dialect\` abstract interface and \`DialectCapabilities\`.
  - Capability surface comes from cataloguing every PG-specific decision in \`postgresql_persistent_store.dart\` and \`postgresql_schema_generator.dart\`: identifier quoting, parameter syntax, auto-increment column type, DDL type names, boolean literal, and feature flags (\`RETURNING\`, upsert, JSON column, \`CHECK\` constraints, max identifier length).

- **3 unit tests** verifying the abstract surface compiles and behaves as documented.
- Workspace + melos \`sync-version\` registration.

## What's NOT in this PR (deferred)

- Phase 1: extract shared builders out of \`packages/postgresql/\` into \`packages/sql/\`.
- Phases 2-3: reduce \`packages/postgresql/\` to a thin dialect adapter (\`PostgresDialect\`).
- Phase 4: \`packages/mysql/\` (the actual second backend).
- Phase 5 (optional): \`packages/sqlite/\`.

Each lands as its own PR, in order, per \`docs/GENERAL_ORM.md\` §5.

## Why this and not \`feature/mysql-orm\`

PR #192 (closed) tried to add MySQL by copying \`packages/postgresql/\` to \`packages/mysql/\` and editing in place. That branch sat idle for 3 years because every Postgres improvement on master required a manual re-clone. This PR avoids that trap: there will only ever be one copy of the SQL builders.

## Test plan

- [x] \`dart pub get\` resolves the workspace with the new package
- [x] \`dart analyze packages/sql\` — no issues
- [x] \`dart test packages/sql\` — 3/3 passing
- [x] Existing \`packages/postgresql\` and \`packages/core\` analyze unchanged (no production code modified yet)
- [ ] CI smoke + unit on Linux + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)