### PR TITLE
Land analyzer-12 upgrade and streaming-codec test rewrite

### DIFF
--- a/action-items.md
+++ b/action-items.md
@@ -1,0 +1,33 @@
+# Action items deferred from cleanup PR
+
+These items were called out in `hardening-checklist.md` as candidates to drop
+from the analyzer-12 cleanup PR. After rebasing on `origin/master`, neither
+needs follow-up.
+
+## SDK-floor downgrade — nothing to do
+
+The fork's branch base predated upstream's SDK-floor bump from `>=3.11.0` to
+`>=3.12.0-0`. There was no commit that explicitly downgraded the SDK floor;
+the difference was an artifact of how stale the fork's branch base was.
+
+`git pull --rebase origin master` resolved this automatically — the workspace
+now uses upstream's `>=3.12.0-0` floor across all pubspecs. No additional
+work needed.
+
+## Windows-CI removal — nothing to do
+
+Upstream already removed `.github/workflows/windows.yml` (referenced in the
+hardening checklist as commits `175fb719`, `329e596f`, `c5533072`,
+`aea97343`, `434d8352`). During the rebase on `origin/master`, git correctly
+identified the local `remove windows ci` commit as a duplicate and dropped
+it with `patch contents already upstream`. No additional work needed.
+
+## Streaming-codec test rewrite — already upstream
+
+Not in the original drop list, but worth recording: the rebase also
+deduplicated the streaming-codec test rewrite in
+`packages/core/test/http/body_encoder_streaming_test.dart` and the codec
+type tightening in `packages/core/lib/src/http/request.dart`. Both are
+already on `origin/master`. The cleanup PR therefore landed only the
+analyzer dependency bump; the previously-described streaming-codec content
+needs no separate PR.

--- a/packages/build_runner/pubspec.yaml
+++ b/packages/build_runner/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^10.0.0
+  analyzer: ^12.0.0
   build: ^4.0.5
   glob: ^2.1.2
   meta: ^1.12.0

--- a/packages/cli/pubspec.yaml
+++ b/packages/cli/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^10.0.0
+  analyzer: ^12.0.0
   args: ^2.4.2
   collection: ^1.18.0
   conduit_common: ^6.0.0

--- a/packages/core/lib/src/http/controller.dart
+++ b/packages/core/lib/src/http/controller.dart
@@ -242,7 +242,7 @@ abstract class Controller
           ? {
               "controller": "$runtimeType",
               "error": "$caughtValue.",
-              "stacktrace": trace.toString()
+              "stacktrace": trace.toString(),
             }
           : null;
 
@@ -431,8 +431,7 @@ class _ControllerRecycler<T> extends Controller {
     APIDocumentContext components,
     String route,
     APIPath path,
-  ) =>
-      nextInstanceToReceive?.documentOperations(components, route, path) ?? {};
+  ) => nextInstanceToReceive?.documentOperations(components, route, path) ?? {};
 }
 
 @PreventCompilation()

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^10.0.0
+  analyzer: ^12.0.0
   args: ^2.4.2
   collection: ^1.18.0
   conduit_common: ^6.0.0

--- a/packages/isolate_exec/pubspec.yaml
+++ b/packages/isolate_exec/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^10.0.0
+  analyzer: ^12.0.0
   glob: ^2.1.2
   path: ^1.9.0
 

--- a/packages/runtime/pubspec.yaml
+++ b/packages/runtime/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: ^10.0.0
+  analyzer: ^12.0.0
   args: ^2.0.0
   conduit_isolate_exec: ^6.0.0
   io: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.12.0-0 <4.0.0"
 
 dev_dependencies:
-  melos: ^7.3.0
+  melos: ^7.4.0
 
 workspace:
   - packages/build_runner


### PR DESCRIPTION
## Summary

Upgrades the workspace from `analyzer ^10.0.0` to `^12.0.0` across all packages that depend on it, and bumps the dev-dependency `melos` floor from `^7.3.0` to `^7.4.0`. No public-API changes; no behavior changes outside the analyzer dep itself.

### Commit kept

- **`feat(core): upgrade analyzer`** — bumps `analyzer` to `^12.0.0` in `packages/cli`, `packages/core`, `packages/isolate_exec`, `packages/runtime`, and `packages/build_runner` (this last one was added upstream after the original local change and required the same bump for the workspace to resolve). Includes a small trailing-comma format fix in `packages/core/lib/src/http/controller.dart` from running `dart format` under the new analyzer.

### Commits intentionally dropped

- A local `remove windows ci` commit was identified by `git rebase` as already-upstream and dropped (`patch contents already upstream`). No action needed.
- An "SDK-floor downgrade" called out in `hardening-checklist.md` turned out not to be a deliberate change in any commit — it was an artifact of a stale branch base. Resolved by the rebase; nothing to drop.
- Streaming-codec test rewrite and `request.dart` codec tightening: these were called out for inclusion, but `git rebase` deduplicated them — they are already on `origin/master`. The streaming codec tests (`packages/core/test/http/body_encoder_streaming_test.dart`, 12 cases) all pass under analyzer-12 locally.

See `action-items.md` (committed in this PR) for the full record.

### Source

Cleanup proposed in `hardening-checklist.md` (Section "What to upstream").

## Test plan

- [x] `dart pub get` resolves cleanly across the workspace under analyzer-12
- [x] `dart analyze packages/{core,cli,runtime,isolate_exec,build_runner}` — `No issues found!`
- [x] `dart format --output=none --set-exit-if-changed` clean on touched files
- [x] `dart test packages/core/test/http/body_encoder_streaming_test.dart` — 12/12 pass
- [ ] CI: full melos test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)