### PR TITLE
fix(ci): reconcile Release workflow with workspace SDK floor 3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,11 +62,15 @@ jobs:
       startsWith(github.event.head_commit.message, 'chore')
     runs-on: ubuntu-latest
     strategy:
+        # PR #250 raised the workspace SDK floor to >=3.12.0-0. Until
+        # Dart 3.12 ships in the `stable` channel, the `dart:stable` /
+        # `dart:latest` Docker images carry Dart 3.11.x and `dart pub
+        # global activate -spath packages/cli` fails on the SDK
+        # constraint. Build only against `beta` for now; restore the
+        # `main` / `stable` matrix entries once Dart 3.12 is GA.
         matrix:
           dart_channel:
-            - main
             - beta
-            - stable
     steps:
     - uses: actions/checkout@v4
     - name: Compute the release tag
@@ -102,12 +106,17 @@ jobs:
         registry: ghcr.io
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.CONDUIT_PAT }}
-    - name: Pull Prereequisites
-      run: docker pull ghcr.io/cirruslabs/flutter:latest
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PAT }}
+    # The cirruslabs/flutter:latest image bundles Dart 3.11.x; the
+    # workspace SDK floor is >=3.12.0-0 (PR #250). Build only the
+    # `aot-builder` stage of Dockerfile.flutter-aot, which uses
+    # `dart:beta` and does the workspace bootstrap. The Flutter
+    # downstream stage stays defined for local-dev use but is
+    # excluded from the published image until the Flutter image
+    # ships Dart 3.12.
     - name: Build
-      run: docker buildx build --platform linux/amd64,linux/arm64/v8 --file docker/Dockerfile.flutter --tag conduitdart/conduit:${{ env.release_tag }}-flutter --push .
+      run: docker buildx build --platform linux/amd64,linux/arm64/v8 --target aot-builder --file docker/Dockerfile.flutter-aot --tag conduitdart/conduit:${{ env.release_tag }}-flutter --push .


### PR DESCRIPTION
## Summary

The release run [25383304650](https://github.com/conduit-dart/conduit/actions/runs/25383304650) on commit \`7daad2d5\` (\`chore(release): publish packages\`) failed at every docker job:

| Job | Result |
|---|---|
| docker (main) | cancelled (matrix fail-fast) |
| docker (beta) | cancelled |
| **docker (stable)** | failed — SDK constraint |
| **docker-flutter** | failed — SDK constraint |

Both `stable` and `docker-flutter` trip on:

```
Because conduit_workspace requires SDK version >=3.12.0-0 <4.0.0,
version solving failed.
ERROR: process "/bin/sh -c dart pub global activate -spath packages/cli"
did not complete successfully: exit code: 1
```

PR #250 raised the workspace SDK floor to 3.12 (for analyzer 12). Until Dart 3.12 ships in `stable`, the docker base images that track stable carry Dart 3.11.x:

| Dockerfile | Base | Dart |
|---|---|---|
| Dockerfile.stable | `dart:stable` | 3.11.5 ❌ |
| Dockerfile.main | `dart:latest` | 3.11.5 ❌ (`dart:latest` ≡ stable; there's no `dart:main` tag) |
| Dockerfile.flutter | `cirruslabs/flutter:latest` | bundles 3.11.x ❌ |
| Dockerfile.beta | `dart:beta` | 3.12 ✓ |
| Dockerfile.flutter-aot (stage 1: `aot-builder`) | `dart:beta` | 3.12 ✓ |

## Approach

1. **`docker` matrix → `[beta]`** until Dart 3.12 reaches stable. Matrix scaffolding + a comment kept so re-adding `stable` later is a one-line change.
2. **`docker-flutter` → `Dockerfile.flutter-aot --target aot-builder`** — only build the `dart:beta` workspace stage. The downstream Flutter stage stays in the Dockerfile for local-dev use but is excluded from the published image until the cirruslabs Flutter image ships Dart 3.12. Dropped the now-unused `Pull Prereequisites` step.

## Test plan

- [x] `docker build -f docker/Dockerfile.beta .` — clean.
- [x] `docker build --target aot-builder -f docker/Dockerfile.flutter-aot .` — clean.
- [ ] Wait for the next \`chore\` commit on master to trigger the Release workflow and confirm both jobs go green.

## Follow-up

When Dart 3.12 hits the stable channel, restore `stable` to the matrix (and decide whether `main` is still meaningful given there's no `dart:main` tag). At that point, also consider whether `Dockerfile.flutter` (single-stage Flutter image) is still needed or whether `Dockerfile.flutter-aot` fully supplants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)