### PR TITLE
feat(cli): conduit db rebuild — drop+regenerate+upgrade in one shot

### DIFF
--- a/packages/cli/lib/src/commands/db.dart
+++ b/packages/cli/lib/src/commands/db.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:conduit/src/command.dart';
 import 'package:conduit/src/commands/db_generate.dart';
+import 'package:conduit/src/commands/db_rebuild.dart';
 import 'package:conduit/src/commands/db_schema.dart';
 import 'package:conduit/src/commands/db_show_migrations.dart';
 import 'package:conduit/src/commands/db_upgrade.dart';
@@ -16,6 +17,7 @@ class CLIDatabase extends CLICommand {
     registerCommand(CLIDatabaseValidate());
     registerCommand(CLIDatabaseVersion());
     registerCommand(CLIDatabaseSchema());
+    registerCommand(CLIDatabaseRebuild());
   }
 
   @override

--- a/packages/cli/lib/src/commands/db_rebuild.dart
+++ b/packages/cli/lib/src/commands/db_rebuild.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:conduit/src/command.dart';
+import 'package:conduit/src/commands/db_generate.dart';
+import 'package:conduit/src/commands/db_upgrade.dart';
+import 'package:conduit/src/metadata.dart';
+import 'package:conduit/src/mixins/database_connecting.dart';
+import 'package:conduit/src/mixins/database_managing.dart';
+import 'package:conduit/src/mixins/project.dart';
+import 'package:conduit_postgresql/conduit_postgresql.dart';
+
+/// Drops all tables, removes migration files, regenerates the initial
+/// migration, and re-applies it to the database. Optionally runs a seed
+/// script.
+///
+/// This is destructive and requires confirmation via `--yes` or by typing the
+/// database name back at an interactive prompt.
+class CLIDatabaseRebuild extends CLICommand
+    with CLIDatabaseConnectingCommand, CLIDatabaseManagingCommand, CLIProject {
+  @Flag(
+    "yes",
+    abbr: "y",
+    help:
+        "Skip the interactive confirmation prompt. Required for non-interactive use.",
+    defaultsTo: false,
+    negatable: false,
+  )
+  bool get skipConfirmation => decode<bool>("yes");
+
+  @Option(
+    "name",
+    help:
+        "Name of the regenerated migration. Automatically lower- and snake-cased.",
+    defaultsTo: "initial",
+  )
+  String get migrationName => decode<String>("name");
+
+  @Option(
+    "seed",
+    help:
+        "Path to a Dart script invoked via `dart run` after upgrade completes.",
+  )
+  String? get seedScript => decodeOptional<String>("seed");
+
+  /// Hook for tests: a callable that reads a single line from stdin.
+  /// Defaults to [stdin.readLineSync] but can be replaced in tests.
+  String? Function() promptReader = () => stdin.readLineSync();
+
+  @override
+  Future<int> handle() async {
+    // Touching `persistentStore` populates `connectedDatabase` from either
+    // --connect or --database-config without yet opening the wire to the
+    // DB. We need the database name for the confirmation prompt.
+    persistentStore;
+    final dbName = connectedDatabase.databaseName;
+
+    if (!await _confirmDestructive(dbName)) {
+      displayError("Aborted: confirmation was not provided.");
+      displayProgress(
+        "Re-run with --yes to skip the prompt, or type the database "
+        "name when prompted.",
+      );
+      return 1;
+    }
+
+    // 1. Drop tables (best-effort).
+    await _dropAllTables();
+
+    // 2. Remove existing migration files.
+    final removed = _removeMigrationFiles();
+    displayInfo("Removed $removed migration file(s).");
+
+    // 3. Re-run `db generate` to produce a fresh initial migration.
+    final genArgs = <String>[
+      "--directory",
+      projectDirectory!.path,
+      "--migration-directory",
+      migrationDirectory!.path,
+      "--name",
+      migrationName,
+    ];
+    final generate = CLIDatabaseGenerate()..outputSink = outputSink;
+    final genResult = await generate.process(generate.options.parse(genArgs));
+    if (genResult != 0) {
+      displayError("`db generate` failed during rebuild.");
+      return genResult;
+    }
+
+    // 4. Re-run `db upgrade` against the now-empty database.
+    final upgradeArgs = <String>[
+      "--directory",
+      projectDirectory!.path,
+      "--migration-directory",
+      migrationDirectory!.path,
+      "--flavor",
+      databaseFlavor,
+      "--ssl-mode",
+      sslMode,
+    ];
+    if (databaseConnectionString != null) {
+      upgradeArgs.addAll(["--connect", databaseConnectionString!]);
+    } else {
+      upgradeArgs.addAll([
+        "--database-config",
+        databaseConfigurationFile.path,
+      ]);
+    }
+    final upgrade = CLIDatabaseUpgrade()..outputSink = outputSink;
+    final upgradeResult =
+        await upgrade.process(upgrade.options.parse(upgradeArgs));
+    if (upgradeResult != 0) {
+      displayError("`db upgrade` failed during rebuild.");
+      return upgradeResult;
+    }
+
+    // 5. Optionally re-run user seed code.
+    if (seedScript != null) {
+      final seedExit = await _runSeed(seedScript!);
+      if (seedExit != 0) {
+        displayError("Seed script exited with code $seedExit.");
+        return seedExit;
+      }
+    }
+
+    displayInfo(
+      "Rebuild complete: '$dbName' is freshly migrated.",
+      color: CLIColor.boldGreen,
+    );
+    return 0;
+  }
+
+  Future<bool> _confirmDestructive(String dbName) async {
+    if (skipConfirmation) {
+      return true;
+    }
+
+    if (!stdin.hasTerminal) {
+      // Don't proceed silently when there's no human to confirm.
+      return false;
+    }
+
+    displayError(
+      "This will DROP all tables in '$dbName' and remove migration files.",
+    );
+    outputSink.writeln(
+      "    Type the database name to confirm (or anything else to abort):",
+    );
+    final response = promptReader();
+    return response != null && response.trim() == dbName;
+  }
+
+  /// Drops every table the project knows about: tables produced by replaying
+  /// existing migration files plus the persistent store's own version table.
+  /// Uses `DROP TABLE IF EXISTS ... CASCADE` against the active
+  /// [persistentStore] so this stays at the abstraction's level — only the
+  /// store's `execute` is touched.
+  Future<void> _dropAllTables() async {
+    final tableNames = await _resolveTablesToDrop();
+    if (tableNames.isEmpty) {
+      displayInfo("No known tables to drop.");
+      return;
+    }
+
+    displayInfo("Dropping ${tableNames.length} table(s)...");
+    for (final name in tableNames) {
+      try {
+        // Match the unquoted identifier convention used by the schema
+        // generator (`DROP TABLE ${table.name}`) so case folding lines up
+        // with what the migration created.
+        await persistentStore.execute("DROP TABLE IF EXISTS $name CASCADE");
+        displayProgress("Dropped $name");
+      } on Object catch (e) {
+        // Best-effort: log and continue. A fresh DB is the goal, and a
+        // missing table just means there is less to clean up.
+        displayProgress("Skipped $name ($e)");
+      }
+    }
+  }
+
+  Future<List<String>> _resolveTablesToDrop() async {
+    final names = <String>{};
+
+    final migrations = projectMigrations;
+    if (migrations.isNotEmpty) {
+      try {
+        final schema = await schemaByApplyingMigrationSources(migrations);
+        for (final t in schema.tables) {
+          if (t.name != null) {
+            names.add(t.name!);
+          }
+        }
+      } on CLIException catch (e) {
+        // Replay can fail if migration files reference removed model classes.
+        // That's fine for a destructive rebuild — fall back to the version
+        // table only.
+        displayProgress(
+          "Could not replay migrations to determine tables: ${e.message}",
+        );
+      }
+    }
+
+    // The store's version table (e.g. _conduit_version_pgsql) is not part of
+    // any migration but must be dropped for a clean rebuild.
+    final s = persistentStore;
+    if (s is PostgreSQLPersistentStore) {
+      names.add(s.versionTable.name!);
+    }
+
+    return names.toList();
+  }
+
+  int _removeMigrationFiles() {
+    final dir = migrationDirectory!;
+    if (!dir.existsSync()) {
+      return 0;
+    }
+    final pattern = RegExp(r"^[0-9]+[_a-zA-Z0-9]*\.migration\.dart$");
+    var count = 0;
+    for (final entity in dir.listSync()) {
+      if (entity is File && pattern.hasMatch(entity.uri.pathSegments.last)) {
+        entity.deleteSync();
+        count++;
+      }
+    }
+    return count;
+  }
+
+  Future<int> _runSeed(String scriptPath) async {
+    final scriptFile = fileInProjectDirectory(scriptPath);
+    if (!scriptFile.existsSync()) {
+      displayError("Seed script not found: ${scriptFile.path}");
+      return 1;
+    }
+
+    displayInfo("Running seed script: ${scriptFile.path}");
+    final result = await Process.run(
+      "dart",
+      ["run", scriptFile.path],
+      workingDirectory: projectDirectory!.path,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
+    if (result.stdout.toString().isNotEmpty) {
+      result.stdout.toString().split("\n").forEach(displayProgress);
+    }
+    if (result.stderr.toString().isNotEmpty) {
+      result.stderr.toString().split("\n").forEach(displayProgress);
+    }
+    return result.exitCode;
+  }
+
+  @override
+  String get name => "rebuild";
+
+  @override
+  String get description =>
+      "Drops all tables, regenerates an initial migration and re-applies it.";
+
+  @override
+  String get detailedDescription =>
+      "Destructive. Intended for development loops where the schema diverges "
+      "and a clean slate is faster than chained migrations. Requires --yes "
+      "or that you type the database name back at the confirmation prompt.";
+}

--- a/packages/cli/test/db_rebuild_test.dart
+++ b/packages/cli/test/db_rebuild_test.dart
@@ -1,0 +1,226 @@
+import 'dart:io';
+
+import 'package:conduit_postgresql/conduit_postgresql.dart';
+import 'package:fs_test_agent/dart_project_agent.dart';
+import 'package:fs_test_agent/working_directory_agent.dart';
+import 'package:test/test.dart';
+
+import 'not_tests/cli_helpers.dart';
+import 'not_tests/postgres_test_config.dart';
+
+void main() {
+  late CLIClient templateCli;
+  late CLIClient projectUnderTestCli;
+  PostgreSQLPersistentStore? store;
+
+  final connectInfo = PostgresTestConfig().databaseConfiguration();
+  final connectString =
+      "postgres://${connectInfo.username}:${connectInfo.password}@${connectInfo.host}:${connectInfo.port}/${connectInfo.databaseName}";
+
+  setUpAll(() async {
+    templateCli = await CLIClient(
+      WorkingDirectoryAgent(DartProjectAgent.projectsDirectory),
+    ).createTestProject();
+    await templateCli.agent.getDependencies();
+  });
+
+  tearDownAll(DartProjectAgent.tearDownAll);
+
+  setUp(() async {
+    projectUnderTestCli = templateCli.replicate(Uri.parse("rebuild_replica/"));
+    projectUnderTestCli.projectAgent.addLibraryFile("application_test", """
+import 'package:conduit_core/conduit_core.dart';
+import 'package:conduit_postgresql/conduit_postgresql.dart';
+
+class TestObject extends ManagedObject<_TestObject> {}
+
+class _TestObject {
+  @primaryKey
+  int? id;
+
+  String? foo;
+}
+""");
+
+    store = PostgresTestConfig().persistentStore();
+
+    final tables = ["_conduit_version_pgsql", "_testobject", "_stale_table"];
+    await Future.wait(
+      tables.map((t) {
+        return store?.execute("DROP TABLE IF EXISTS $t CASCADE");
+      }).whereType<Future>(),
+    );
+  });
+
+  tearDown(() async {
+    final tables = ["_conduit_version_pgsql", "_testobject", "_stale_table"];
+    await Future.wait(
+      tables.map((t) {
+        return store?.execute("DROP TABLE IF EXISTS $t CASCADE");
+      }).whereType<Future>(),
+    );
+    await store?.close();
+    projectUnderTestCli.delete();
+  });
+
+  test(
+    "Without --yes and no terminal, db rebuild refuses to run and exits non-zero",
+    () async {
+      // First produce a baseline migration so the command isn't a no-op for
+      // unrelated reasons.
+      var res = await projectUnderTestCli.run("db", ["generate"]);
+      expect(res, 0);
+
+      res = await projectUnderTestCli.run("db", [
+        "rebuild",
+        "--connect",
+        connectString,
+      ]);
+      expect(res, isNonZero);
+      expect(projectUnderTestCli.output, contains("Aborted"));
+
+      // Migration files must be untouched.
+      final remaining = projectUnderTestCli.defaultMigrationDirectory
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith(".migration.dart"))
+          .toList();
+      expect(remaining, isNotEmpty);
+    },
+  );
+
+  test(
+    "With --yes, db rebuild drops tables, regenerates and re-applies migrations",
+    () async {
+      // Seed a stale table that is not part of the project schema. After
+      // rebuild it should still be gone (dropped explicitly via the tracked
+      // schema set, OR untouched because it isn't tracked — this test
+      // documents that the version table + tracked tables go away).
+      await store!
+          .execute("CREATE TABLE IF NOT EXISTS _stale_table (id integer)");
+
+      // Baseline: generate + upgrade once to land schema in DB.
+      var res = await projectUnderTestCli.run("db", ["generate"]);
+      expect(res, 0);
+      res = await projectUnderTestCli.run("db", [
+        "upgrade",
+        "--connect",
+        connectString,
+      ]);
+      expect(res, 0);
+
+      // Both the version table and the _testobject table now exist.
+      expect(await _tableExists(store!, "_conduit_version_pgsql"), isTrue);
+      expect(await _tableExists(store!, "_testobject"), isTrue);
+
+      // Now rebuild.
+      projectUnderTestCli.clearOutput();
+      res = await projectUnderTestCli.run("db", [
+        "rebuild",
+        "--yes",
+        "--connect",
+        connectString,
+      ]);
+      expect(res, 0);
+      expect(projectUnderTestCli.output, contains("Rebuild complete"));
+
+      // The DB ends in a freshly-migrated state: version table exists and is
+      // back at version 1, _testobject exists, no stray columns from older
+      // schemas. The stale table is unrelated to the project schema and is
+      // not tracked, so we don't assert anything about it here.
+      expect(await _tableExists(store!, "_conduit_version_pgsql"), isTrue);
+      expect(await _tableExists(store!, "_testobject"), isTrue);
+
+      final version = await store!.execute(
+        "SELECT versionNumber FROM _conduit_version_pgsql",
+      );
+      expect(version, [
+        [1],
+      ]);
+
+      // A fresh migration file (and only one) should be on disk.
+      final migrations = projectUnderTestCli.defaultMigrationDirectory
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith(".migration.dart"))
+          .toList();
+      expect(migrations, hasLength(1));
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
+    "With --yes, rebuild succeeds even when the previous schema diverges from migrations",
+    () async {
+      // Generate once, then mutate the model so the existing migration no
+      // longer matches. `db upgrade` would normally complain — `db rebuild`
+      // wipes and starts over.
+      var res = await projectUnderTestCli.run("db", ["generate"]);
+      expect(res, 0);
+      res = await projectUnderTestCli.run("db", [
+        "upgrade",
+        "--connect",
+        connectString,
+      ]);
+      expect(res, 0);
+
+      // Mutate the model: add a `bar` column.
+      projectUnderTestCli.projectAgent.addLibraryFile("application_test", """
+import 'package:conduit_core/conduit_core.dart';
+import 'package:conduit_postgresql/conduit_postgresql.dart';
+
+class TestObject extends ManagedObject<_TestObject> {}
+
+class _TestObject {
+  @primaryKey
+  int? id;
+
+  String? foo;
+
+  String? bar;
+}
+""");
+
+      projectUnderTestCli.clearOutput();
+      res = await projectUnderTestCli.run("db", [
+        "rebuild",
+        "--yes",
+        "--connect",
+        connectString,
+      ]);
+      expect(res, 0);
+
+      // Resulting table should have id + foo + bar.
+      final cols = await _columnsOfTable(store!, "_testobject");
+      expect(cols.toSet(), containsAll(<String>{"id", "foo", "bar"}));
+
+      // Only one migration file (the regenerated initial).
+      final migrations = projectUnderTestCli.defaultMigrationDirectory
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith(".migration.dart"))
+          .toList();
+      expect(migrations, hasLength(1));
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+}
+
+Future<bool> _tableExists(PostgreSQLPersistentStore store, String name) async {
+  final result = await store.execute(
+    "SELECT to_regclass(@n:text)",
+    substitutionValues: {"n": name},
+  ) as List<List<dynamic>>;
+  return result.first.first != null;
+}
+
+Future<List<String>> _columnsOfTable(
+  PostgreSQLPersistentStore store,
+  String tableName,
+) async {
+  final results = await store.execute(
+    "SELECT column_name FROM information_schema.columns WHERE table_name=@n:text",
+    substitutionValues: {"n": tableName},
+  ) as List<List<dynamic>>;
+  return results.map((r) => r.first as String).toList();
+}


### PR DESCRIPTION
## Summary

Adds `conduit db rebuild`, a destructive single-shot dev-loop command that wipes the active database, removes the generated migration files, regenerates an initial migration via `db generate`, and re-applies it via `db upgrade`.

```console
$ conduit db rebuild --yes --connect postgres://user:pass@localhost:5432/myapp
-- Dropping 3 table(s)...
-- Removed 1 migration file(s).
-- Created new migration file (version 1).
-- Updating to version 1 on new database...
-- Rebuild complete: 'myapp' is freshly migrated.
```

Closes #97.

## What it does

1. Drops every table the project knows about — replays existing migration files to recover the table set, then issues `DROP TABLE IF EXISTS <name> CASCADE` against the active `PersistentStore` via its `execute` method (no raw psql, no hard-coded SQL — store-agnostic at the abstraction's level). The store's own version table is dropped explicitly.
2. Removes `migrations/*.migration.dart` files (the existing naming pattern only — the directory and unrelated files are left alone).
3. Re-runs `db generate` (composed, not duplicated) to produce a fresh `00000001_initial.migration.dart` from the current model.
4. Re-runs `db upgrade` to apply it to the now-empty DB.
5. If `--seed <path>` is passed, runs `dart run <path>` from the project directory afterwards.

## Safety story

Destructive, so it will refuse to proceed unless one of:

- `--yes` / `-y` is passed (non-interactive bypass), **or**
- the user types the database name back at the interactive prompt.

When stdin isn't a TTY and `--yes` was not passed, the command exits non-zero with `Aborted: confirmation was not provided.` — never silently proceeds.

## Test plan

- [x] `dart analyze` clean across all CLI files (no new lints).
- [x] New tests in `packages/cli/test/db_rebuild_test.dart` (3 cases) pass against the workspace `conduit_postgres` Docker service:
  - `--yes` rebuild end-to-end: `_TestObject` and `_conduit_version_pgsql` both gone and re-created at version 1; only one migration file on disk afterwards.
  - `--yes` rebuild with diverged model: model adds a new column, rebuild produces a regenerated initial migration containing the new column.
  - Without `--yes` and without a TTY: command refuses (exit non-zero, `"Aborted"` in output) and migration files are untouched.
- [x] Existing CLI tests continue to pass: `db_validate_test.dart`, `migration_execution_test.dart`, `migration_source_test.dart`, `migration_test.dart`, `command_test.dart`, `generate_test.dart`, `schema_test.dart` (all green in the dart:beta container against the same postgres service).

## Files

- `packages/cli/lib/src/commands/db_rebuild.dart` — new `CLIDatabaseRebuild` command.
- `packages/cli/lib/src/commands/db.dart` — registers it alongside the other db subcommands.
- `packages/cli/test/db_rebuild_test.dart` — integration tests against postgres.