### PR TITLE
test(core): make websocket_test 'chat' deterministic

### DIFF
--- a/packages/core/test/http/websocket_test.dart
+++ b/packages/core/test/http/websocket_test.dart
@@ -104,6 +104,26 @@ void main() {
       final rxUser1 = user1.stream.asBroadcastStream();
       final rxUser2 = user2.stream.asBroadcastStream();
 
+      // Wait for both client-side handshakes to complete. This also
+      // forces the server's `WebSocketTransformer.upgrade` futures to
+      // resolve, so `_socket["user1"]` and `_socket["user2"]` are
+      // populated before the first cross-user send below.
+      await user1.ready;
+      await user2.ready;
+
+      // Server-side, `newChat` sets `_socket[user]` and then attaches
+      // the listener in two synchronous statements. Run a self-ping
+      // through each client so the test only proceeds once both
+      // sockets are end-to-end wired (registration + listener +
+      // round-trip). Without this, sending user1→user2 immediately
+      // after `await user2.ready` could land at the server before
+      // user2's listener is attached, dropping the message and
+      // hanging the test until the 2-minute file-level timeout.
+      user1.sink.add('{"to": "user1", "msg": "ready1"}');
+      expect(await rxUser1.first, 'ready1');
+      user2.sink.add('{"to": "user2", "msg": "ready2"}');
+      expect(await rxUser2.first, 'ready2');
+
       const sentMsg1 = "hello user 2";
       const send1 = '{"to": "user2", "msg": "$sentMsg1"}';
 


### PR DESCRIPTION
## Summary

PR #257's CI surfaced a flaky test in `packages/core/test/http/websocket_test.dart: Upgrade to WebSocket chat`. macOS unit job hit \`TimeoutException after 0:02:00\` while Linux passed; with one merge of #257's branch, it'd flip the other way. Symptom on every run that fails:

\`\`\`
+650 -1: test/http/websocket_test.dart: Upgrade to WebSocket chat [E]
  TimeoutException after 0:02:00.000000: Test timed out after 2 minutes.
\`\`\`

## Root cause

Race between client and server-side socket registration:

1. \`user1\` + \`user2\` both \`WebSocketChannel.connect(...)\` in parallel.
2. Test immediately calls \`user1.sink.add(send1)\` where \`send1\` targets \`user2\`.
3. Server receives \`user1\`'s message via \`user1\`'s listener and runs \`handleEvent\` which looks up \`_socket["user2"]\`.
4. \`_socket["user2"]\` isn't populated yet — \`user2\`'s \`WebSocketTransformer.upgrade\` future hasn't resolved server-side.
5. Message drops; test hangs on \`rxUser2.first\` until the 2-minute file-level \`@Timeout\` fires.

## Fix

Two-step synchronization in the test body:

1. \`await user1.ready\` / \`await user2.ready\` — both client-side handshakes complete, which forces the server's \`WebSocketTransformer.upgrade\` Future to resolve and \`newChat\` to populate \`_socket[user]\`.
2. **Self-ping handshake** — each user sends a message addressed to themselves through the chat protocol and waits for its echo. This proves the full registration chain is wired (\`_socket[user]\` set + listener attached + round-trip works). Without it, the listener-attach microtask can still trail \`_socket[user] = ...\`, so a cross-user send right after \`await ready\` could land before \`user2\`'s listener is up.

## Test plan

- [x] \`dart test test/http/websocket_test.dart\` x 5 consecutive runs in \`dart:beta\` Docker — all 4 tests green every time.
- [ ] Watch GHA Linux + macOS unit jobs after merge to confirm flakiness gone across both platforms.

## Why test-only fix

\`ChatController.newChat\` sets \`_socket[user]\` then attaches the listener in two synchronous statements. Not trying to fix that ordering server-side because it's a test controller (lives in the test file, not production code), and reordering would change the race surface elsewhere in the same class without delivering a real correctness fix to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)