### PR TITLE
feat(build_runner): specialize body cast for known container types

### DIFF
--- a/packages/build_runner/lib/src/controller_builder.dart
+++ b/packages/build_runner/lib/src/controller_builder.dart
@@ -391,10 +391,78 @@ ${applySrc.toString().trimRight()}
             return $typeSrc()..read((v as RequestBody).as());
           }''';
         }
+        // Specialize known container types to skip the
+        // RuntimeContext.coerce → slow_coerce.cast<T> dispatch (which
+        // does a per-call T.toString() switch). Falls back to the
+        // generic .as<T>() path for types we don't recognize, so
+        // existing apps see no behavior change.
+        final fast = _emitFastBodyCast(b.type);
+        if (fast != null) return fast;
         return '(v) { return (v as RequestBody).as<$typeSrc>(); }';
       default:
         return '(v) { return v; }';
     }
+  }
+
+  /// Emits a specialized body-cast closure for known primitive
+  /// container types, bypassing the generic `RequestBody.as<T>()` →
+  /// `RuntimeContext.coerce<T>()` → `slow_coerce.cast<T>()` chain.
+  ///
+  /// Returns `null` for types we don't specialize (e.g. complex
+  /// generics, user-defined types) so the caller falls back to the
+  /// generic path — existing apps preserve their current behavior.
+  String? _emitFastBodyCast(DartType t) {
+    final raw = _typeSource(t);
+    // Direct dynamic / Object / Object? — no coercion needed.
+    if (raw == 'dynamic' || raw == 'Object' || raw == 'Object?') {
+      return '(v) { return (v as RequestBody).decoded as $raw; }';
+    }
+    // Map<String, dynamic> — already the natural decoded shape for
+    // application/json object payloads.
+    if (raw == 'Map<String, dynamic>' || raw == 'Map<String, dynamic>?') {
+      return '(v) { return (v as RequestBody).decoded as $raw; }';
+    }
+    // List<X> for primitive X — codec yields List<dynamic>, copy
+    // through the typed `.from` constructor.
+    if (raw.startsWith('List<') && raw.endsWith('>')) {
+      final inner = raw.substring(5, raw.length - 1);
+      const primitives = {
+        'int', 'num', 'double', 'String', 'bool',
+        'int?', 'num?', 'double?', 'String?', 'bool?',
+        'Map<String, dynamic>',
+      };
+      if (primitives.contains(inner)) {
+        return '''(v) {
+          final decoded = (v as RequestBody).decoded;
+          if (decoded is! List) {
+            throw Response.badRequest(
+              body: {"error": "request entity was unexpected type"},
+            );
+          }
+          return $raw.from(decoded);
+        }''';
+      }
+    }
+    // Map<String, X> for primitive X.
+    if (raw.startsWith('Map<String, ') && raw.endsWith('>')) {
+      final inner = raw.substring(12, raw.length - 1);
+      const primitives = {
+        'int', 'num', 'double', 'String', 'bool',
+        'int?', 'num?', 'double?', 'String?', 'bool?',
+      };
+      if (primitives.contains(inner)) {
+        return '''(v) {
+          final decoded = (v as RequestBody).decoded;
+          if (decoded is! Map<String, dynamic>) {
+            throw Response.badRequest(
+              body: {"error": "request entity was unexpected type"},
+            );
+          }
+          return $raw.from(decoded);
+        }''';
+      }
+    }
+    return null;
   }
 
   String _emitElementDecoder(DartType t) {

--- a/packages/build_runner/test/controller_builder_test.dart
+++ b/packages/build_runner/test/controller_builder_test.dart
@@ -242,4 +242,86 @@ class Plain {}
     expect(out.dart, isNull);
     expect(out.json, isNull);
   });
+
+  test(
+      'emits specialized body cast for List<int> instead of generic '
+      '.as<T>()', () async {
+    final out = await _runBuilder('''
+import 'package:conduit_core/conduit_core.dart';
+
+class IntListController extends ResourceController {
+  @Operation.post()
+  Future<dynamic> create(@Bind.body() List<int> ids) async => null;
+}
+''');
+    final dart = out.dart!;
+    // Specialized path: `.decoded` accessor + `List<int>.from(...)` ctor.
+    expect(dart, contains('(v as RequestBody).decoded'));
+    expect(dart, contains('List<int>.from(decoded)'));
+    // No fall-back to the generic dispatch.
+    expect(dart, isNot(contains('as RequestBody).as<List<int>>()')));
+  });
+
+  test('emits specialized body cast for Map<String, dynamic>', () async {
+    final out = await _runBuilder('''
+import 'package:conduit_core/conduit_core.dart';
+
+class MapController extends ResourceController {
+  @Operation.post()
+  Future<dynamic> create(@Bind.body() Map<String, dynamic> body) async =>
+      null;
+}
+''');
+    final dart = out.dart!;
+    expect(
+      dart,
+      contains('(v as RequestBody).decoded as Map<String, dynamic>'),
+    );
+    expect(
+      dart,
+      isNot(contains('as RequestBody).as<Map<String, dynamic>>()')),
+    );
+  });
+
+  test('falls back to .as<T>() for unrecognized custom types', () async {
+    final out = await _runBuilder('''
+import 'package:conduit_core/conduit_core.dart';
+
+class CustomBody {}
+
+class CustomController extends ResourceController {
+  @Operation.post()
+  Future<dynamic> create(@Bind.body() CustomBody body) async => null;
+}
+''');
+    final dart = out.dart!;
+    // Custom non-Serializable type: keep the generic dispatch path
+    // so RuntimeContext.coerce semantics + error responses are
+    // unchanged for app-defined types.
+    expect(dart, contains('(v as RequestBody).as<CustomBody>()'));
+    expect(dart, isNot(contains('.decoded')));
+  });
+
+  test(
+      'specialized path still routes Serializable through the .read() '
+      'pattern (unchanged)', () async {
+    final out = await _runBuilder('''
+import 'package:conduit_core/conduit_core.dart';
+
+class Payload extends Serializable {
+  @override
+  void read(Map<String, dynamic> obj) {}
+}
+
+class SerCtrl extends ResourceController {
+  @Operation.post()
+  Future<dynamic> create(@Bind.body() Payload body) async => null;
+}
+''');
+    final dart = out.dart!;
+    expect(dart, contains('Payload()..read'));
+    // Should NOT use .decoded — Serializable.read takes the full
+    // request body via .as() as before.
+    expect(dart, isNot(contains('.decoded')));
+  });
 }

--- a/packages/core/lib/src/http/body_decoder.dart
+++ b/packages/core/lib/src/http/body_decoder.dart
@@ -128,6 +128,23 @@ abstract class BodyDecoder {
     return _cast<T>(_decodedData);
   }
 
+  /// The post-decode payload, as a `dynamic` view of the codec's output.
+  ///
+  /// This is the unchecked / un-coerced sibling of [as] — same `hasBeenDecoded`
+  /// guard, no [RuntimeContext.coerce] dispatch. Intended for AOT-emitted
+  /// resource controllers that already know the bound type at codegen time
+  /// and can do their own specialized cast (e.g.
+  /// `List<int>.from(body.decoded as List)`), avoiding the per-request
+  /// `T.toString()` switch in `slow_coerce.cast`. The
+  /// `controller_builder` emits this path for known primitive container
+  /// types; the [as] path remains for `Serializable` and unknown types.
+  dynamic get decoded {
+    if (!hasBeenDecoded) {
+      throw StateError("Attempted to access request body without decoding it.");
+    }
+    return _decodedData;
+  }
+
   T _cast<T>(dynamic body) {
     try {
       return RuntimeContext.current.coerce<T>(body);


### PR DESCRIPTION
## Summary

The AOT path for \`@Bind.body()\` parameters has been routing every request through:

\`\`\`
RequestBody.as<T>()
  → RuntimeContext.current.coerce<T>(body)
  → slow_coerce.cast<T>(input)
  → T.toString() + string-switch + List<X>.from(...)
\`\`\`

The \`T.toString()\` allocation and string-prefix dispatch happen on every body bind, even when the bound type is one the build_runner already knows from the source. \`ResourceControllerBuilder\` has the \`DartType\` of every binding — emit a specialized cast directly instead of dispatching through the generic helper.

## What's specialized

Skip the runtime helper entirely for:
- \`dynamic\` / \`Object\` / \`Object?\`
- \`Map<String, dynamic>(?)\`
- \`List<X>\` for \`X in {int, num, double, String, bool}\` (+ nullables) + \`List<Map<String, dynamic>>\`
- \`Map<String, X>\` for the same primitive set

All other types (custom Serializable subclasses, app-defined classes) keep the existing \`.as<T>()\` path. The Serializable detection (\`Payload()..read(...)\`) is unchanged and still wins.

## Generated output

For \`@Bind.body() List<int> ids\`:

\`\`\`dart
// before
decoder: (v) { return (v as RequestBody).as<List<int>>(); }

// after
decoder: (v) {
  final decoded = (v as RequestBody).decoded;
  if (decoded is! List) {
    throw Response.badRequest(
      body: {"error": "request entity was unexpected type"},
    );
  }
  return List<int>.from(decoded);
}
\`\`\`

The specialized path lets \`dart compile exe\` inline \`List<int>.from\` directly; the dispatch through \`RuntimeContext\` + \`slow_coerce.cast\` is gone from the hot path for stdlib containers.

## API additions

\`BodyDecoder.decoded\` — new public getter. Same \`hasBeenDecoded\` guard as \`.as<T>()\`, returns \`_decodedData\` as \`dynamic\` without going through the coercion layer. Made public so the build_runner-emitted code can reach it. Existing \`.as<T>()\` and \`.decode<T>()\` are untouched.

## Test plan

- [x] \`packages/build_runner\`: 28 → 32 tests (+4 new — specialized List<int>, specialized Map<String,dynamic>, custom-type fallback, Serializable unchanged).
- [x] \`packages/core\`: 1059/1059 pass; new \`decoded\` getter doesn't conflict.
- [x] \`bash ci/template-aot-smoke.sh\`: green end-to-end (scaffold → build_runner → AOT compile → bind → curl /example returns \`{\"key\":\"value\"}\`).
- [x] \`dart analyze\` clean on both packages.

## Pairs with #55

TechEmpower follow-up tracking issue conduit-dart#55 will quantify the actual throughput delta. This PR is a reasoned codegen improvement; without TFB numbers it ships on the strength of "fewer allocations + one fewer dispatch hop on the request hot path", not a measured win. Will revisit numbers once the TFB harness lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)