### PR TITLE
chore(runtime): add bench/ scaffold for coerce + json codec baselines

### DIFF
--- a/packages/runtime/bench/README.md
+++ b/packages/runtime/bench/README.md
@@ -1,0 +1,95 @@
+# bench/ — runtime microbenchmarks
+
+Baseline performance harness for `conduit_runtime`. Not a regression
+gate yet — captures numbers so PRs touching the hot paths have
+something to compare against.
+
+## Run
+
+```bash
+cd packages/runtime
+dart run bench/coerce_bench.dart
+dart run bench/json_codec_bench.dart
+```
+
+Each script prints one line per benchmark in the form:
+
+```
+<name>(RunTime): <us> us.
+```
+
+`benchmark_harness` runs each `run()` body for ~2s, divides by the iteration
+count, and reports the per-iteration time. Numbers are deterministic to
+within ~3% on a quiet host.
+
+## Benchmarks
+
+### `coerce_bench.dart`
+
+Targets `slow_coerce.cast<T>` over the three type-variant shapes most
+commonly hit by ResourceController body-cast paths:
+
+| Bench | Fixture |
+|---|---|
+| `cast<List<int>>` | 100-element int list |
+| `cast<List<Map<String, dynamic>>>` | 50-row table-shaped list |
+| `cast<Map<String, dynamic>>` | 20-key flat map |
+
+Captures the baseline against which PRs that change the cast path (e.g.
+PR #259's AOT specialization) can be A/B'd.
+
+### `json_codec_bench.dart`
+
+`dart:convert` floor under every JSON-shaped request the framework
+serves. Conduit doesn't ship its own JSON codec, so this is a pure
+SDK-level baseline — useful for spotting regressions in the SDK or in
+host configuration (CPU governor, debug build, etc.).
+
+| Bench | Payload |
+|---|---|
+| `json.encode List[1000 maps]` | Typical "list endpoint" response body |
+| `json.decode List[1000 maps]` | Typical request body parse |
+| `json.encode Map[20 keys]` | Typical "single resource" response |
+| `json.decode Map[20 keys]` | Typical "single resource" parse |
+
+## Baseline numbers (captured 2026-05-05, dart:beta in Docker on snowman)
+
+These are starting reference points — re-capture on the PR's host before
+A/B-comparing against a change.
+
+| Bench | RunTime |
+|---|---|
+| `cast<List<int>>` (n=100) | ~5.2 µs |
+| `cast<List<Map<String, dynamic>>>` (n=50) | ~5.0 µs |
+| `cast<Map<String, dynamic>>` (keys=20) | ~2.2 µs |
+| `json.encode List[1000 maps]` | ~3.7 ms |
+| `json.decode List[1000 maps]` | ~2.4 ms |
+| `json.encode Map[20 keys]` | ~13.2 µs |
+| `json.decode Map[20 keys]` | ~10.2 µs |
+
+## Adding a new bench
+
+1. New file `bench/<thing>_bench.dart` with one or more
+   `BenchmarkBase` subclasses + a `main()` that calls `.report()` on each.
+2. Update this README's table.
+3. Run it locally on a quiet host; capture the numbers in the PR
+   description as the new baseline.
+
+## Future scope (deferred)
+
+The original sanity-check plan listed two more benches that need
+fixtures larger than fits in this PR:
+
+- `router_bench.dart` — 1k requests through a 100-route Router.
+  Needs a host fixture; lives more naturally in `packages/core/bench/`.
+- `startup_bench.dart` — `MirrorContext()` instantiation cost on a
+  ~50-controller / ~20-ManagedObject fixture. Needs a synthetic app
+  scaffold; warrants its own follow-up.
+
+## Why no CI gate yet
+
+Benchmark numbers vary by host, CPU governor state, neighbor processes,
+and Dart SDK version. Add CI assertions only after the noise floor is
+measured across a few hosts (laptop, CI runner, Woodpecker) and a stable
+threshold is identified. Until then the harness exists for ad-hoc
+before/after comparison on PRs that touch hot paths.

--- a/packages/runtime/bench/coerce_bench.dart
+++ b/packages/runtime/bench/coerce_bench.dart
@@ -1,0 +1,65 @@
+// Microbenchmark for `slow_coerce.cast<T>` over the type variants the
+// runtime hits hottest in real apps: `List<int>`, `List<Map<String,
+// dynamic>>`, and `Map<String, dynamic>`. Captures a baseline so PRs
+// touching the cast path (e.g. PR #259's AOT specialization) have
+// numbers to compare against.
+//
+// Run: `dart run bench/coerce_bench.dart`
+//
+// This is a baseline harness — not a regression gate. Add CI assertions
+// in a follow-up PR once the noise floor is measured across a few
+// hosts.
+library;
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:conduit_runtime/slow_coerce.dart' as coerce;
+
+class _CastListIntBench extends BenchmarkBase {
+  _CastListIntBench(this.fixture) : super('cast<List<int>> (n=${fixture.length})');
+  final List<dynamic> fixture;
+
+  @override
+  void run() {
+    coerce.cast<List<int>>(fixture);
+  }
+}
+
+class _CastListMapBench extends BenchmarkBase {
+  _CastListMapBench(this.fixture)
+      : super('cast<List<Map<String, dynamic>>> (n=${fixture.length})');
+  final List<dynamic> fixture;
+
+  @override
+  void run() {
+    coerce.cast<List<Map<String, dynamic>>>(fixture);
+  }
+}
+
+class _CastMapStringDynamicBench extends BenchmarkBase {
+  _CastMapStringDynamicBench(this.fixture)
+      : super('cast<Map<String, dynamic>> (keys=${fixture.length})');
+  final Map<String, dynamic> fixture;
+
+  @override
+  void run() {
+    coerce.cast<Map<String, dynamic>>(fixture);
+  }
+}
+
+void main() {
+  // Realistic small-payload sizes: a 100-element int list, a 50-row
+  // table-shaped list, and a 20-key flat map. Larger sizes scale linearly
+  // through `from(...)` and don't reveal anything new.
+  final intList = List<dynamic>.generate(100, (i) => i);
+  final mapList = List<dynamic>.generate(
+    50,
+    (i) => <String, dynamic>{'id': i, 'name': 'row-$i', 'active': i.isEven},
+  );
+  final flatMap = <String, dynamic>{
+    for (var i = 0; i < 20; i++) 'k$i': i.isEven ? i : 'v$i',
+  };
+
+  _CastListIntBench(intList).report();
+  _CastListMapBench(mapList).report();
+  _CastMapStringDynamicBench(flatMap).report();
+}

--- a/packages/runtime/bench/json_codec_bench.dart
+++ b/packages/runtime/bench/json_codec_bench.dart
@@ -1,0 +1,79 @@
+// Microbenchmark for `dart:convert` JSON encode/decode at request-payload
+// scales. Conduit doesn't ship its own JSON codec — it uses
+// `dart:convert` directly — so this baseline measures the floor under
+// every JSON-handling request the framework serves.
+//
+// Two payload shapes:
+//   - 1000-element list of small flat maps (typical "list endpoint" body)
+//   - 1 deep map with 20 keys (typical "single resource" body)
+//
+// Run: `dart run bench/json_codec_bench.dart`
+library;
+
+import 'dart:convert';
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+class _EncodeListBench extends BenchmarkBase {
+  _EncodeListBench(this.payload)
+      : super('json.encode List[${(payload as List).length} maps]');
+  final Object payload;
+
+  @override
+  void run() {
+    json.encode(payload);
+  }
+}
+
+class _DecodeListBench extends BenchmarkBase {
+  _DecodeListBench(this.encoded) : super('json.decode List[1000 maps]');
+  final String encoded;
+
+  @override
+  void run() {
+    json.decode(encoded);
+  }
+}
+
+class _EncodeMapBench extends BenchmarkBase {
+  _EncodeMapBench(this.payload) : super('json.encode Map[20 keys]');
+  final Object payload;
+
+  @override
+  void run() {
+    json.encode(payload);
+  }
+}
+
+class _DecodeMapBench extends BenchmarkBase {
+  _DecodeMapBench(this.encoded) : super('json.decode Map[20 keys]');
+  final String encoded;
+
+  @override
+  void run() {
+    json.decode(encoded);
+  }
+}
+
+void main() {
+  final listPayload = List<Map<String, dynamic>>.generate(
+    1000,
+    (i) => {
+      'id': i,
+      'name': 'item-$i',
+      'active': i.isEven,
+      'score': i * 0.5,
+    },
+  );
+  final encodedList = json.encode(listPayload);
+
+  final mapPayload = <String, dynamic>{
+    for (var i = 0; i < 20; i++) 'k$i': i.isEven ? i : 'v$i',
+  };
+  final encodedMap = json.encode(mapPayload);
+
+  _EncodeListBench(listPayload).report();
+  _DecodeListBench(encodedList).report();
+  _EncodeMapBench(mapPayload).report();
+  _DecodeMapBench(encodedMap).report();
+}

--- a/packages/runtime/pubspec.yaml
+++ b/packages/runtime/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   yaml: ^3.1.2
 
 dev_dependencies:
+  benchmark_harness: ^2.3.0
   fs_test_agent:
     path: ../fs_test_agent
   lints: ^6.0.0


### PR DESCRIPTION
## Summary

Establishes a microbenchmark harness under `packages/runtime/bench/` so PRs that touch the cast or codec hot paths have something to A/B against. **Baselines first — no CI gate yet.** Add regression assertions in a follow-up once the noise floor is measured across a few hosts.

## What's in this PR

| File | Role |
|---|---|
| `packages/runtime/bench/coerce_bench.dart` | 3 benches over `slow_coerce.cast<T>` for `List<int>`, `List<Map<String, dynamic>>`, `Map<String, dynamic>` |
| `packages/runtime/bench/json_codec_bench.dart` | 4 benches over `dart:convert` encode/decode at request-payload scales |
| `packages/runtime/bench/README.md` | Run instructions, baseline table, "adding a bench" doc, deferred-scope notes |
| `packages/runtime/pubspec.yaml` | `benchmark_harness: ^2.3.0` as a dev-dep (active, last release 2025-09) |

## Baseline numbers (captured 2026-05-05, dart:beta in the project Docker harness)

| Bench | RunTime |
|---|---|
| `cast<List<int>>` (n=100) | ~5.2 µs |
| `cast<List<Map<String, dynamic>>>` (n=50) | ~5.0 µs |
| `cast<Map<String, dynamic>>` (keys=20) | ~2.2 µs |
| `json.encode List[1000 maps]` | ~3.7 ms |
| `json.decode List[1000 maps]` | ~2.4 ms |
| `json.encode Map[20 keys]` | ~13.2 µs |
| `json.decode Map[20 keys]` | ~10.2 µs |

These are starting reference points — re-capture on the PR's host before A/B-comparing against a change. `benchmark_harness` runs each `run()` body for ~2s and reports per-iteration time; numbers are deterministic to within ~3% on a quiet host.

## Why now

PR #259 specialized the body-cast codegen for known container types but landed without before/after measurements. This PR is the substrate that makes the next round of cast-path PRs measurable.

## Why not router + startup benches

The original sanity-checks plan listed two more benches that this PR explicitly defers:

- **`router_bench.dart`** — 1k requests through a 100-route Router. Lives more naturally in `packages/core/bench/` since Router is in core; needs a host-controller fixture.
- **`startup_bench.dart`** — `MirrorContext()` instantiation cost on a ~50-controller / ~20-ManagedObject fixture. Needs a synthetic app scaffold large enough to be representative.

Both are reasonable follow-ups; neither blocks landing this scaffold.

## Why no CI gate

Benchmark numbers vary by host, CPU governor state, neighbor processes, and Dart SDK version. Add CI assertions only after the noise floor is measured across a few hosts (laptop, CI runner, Woodpecker) and a stable threshold is identified. Until then the harness exists for ad-hoc before/after comparison on PRs that touch the relevant code.

## Verification

\`\`\`
cd packages/runtime
dart run bench/coerce_bench.dart        # 3 lines of timing output
dart run bench/json_codec_bench.dart    # 4 lines of timing output
dart analyze bench/                     # clean
\`\`\`

All three executed in the project's standard Docker harness; numbers above were the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)