### PR TITLE
fix(http)!: safer CORS default + runtime guard against credentialed wildcard

### DIFF
--- a/packages/core/lib/src/http/cors_policy.dart
+++ b/packages/core/lib/src/http/cors_policy.dart
@@ -28,7 +28,13 @@ class CORSPolicy {
 
   CORSPolicy._defaults() {
     allowedOrigins = ["*"];
-    allowCredentials = true;
+    // The default is `false` because the dangerous combination
+    // `allowCredentials = true` + `allowedOrigins = ["*"]` effectively
+    // grants credentialed cross-origin access to every requesting site
+    // (CSRF surface). Apps that need credentialed CORS must opt in *and*
+    // specify concrete origins; the runtime guard in [headersForRequest]
+    // enforces that.
+    allowCredentials = false;
     exposedResponseHeaders = [];
     allowedMethods = ["POST", "PUT", "DELETE", "GET"];
     allowedRequestHeaders = [
@@ -111,6 +117,7 @@ class CORSPolicy {
   /// This will add Access-Control-Allow-Origin, Access-Control-Expose-Headers and Access-Control-Allow-Credentials
   /// depending on the this policy.
   Map<String, dynamic> headersForRequest(Request request) {
+    validateConfiguration();
     final origin = request.raw.headers.value("origin");
 
     final headers = <String, dynamic>{};
@@ -126,6 +133,28 @@ class CORSPolicy {
     }
 
     return headers;
+  }
+
+  /// Refuses to emit a credentialed-CORS response if [allowedOrigins] is
+  /// `["*"]` or empty. Such a configuration grants credentialed access
+  /// to every requesting origin (CSRF surface) — a misconfiguration the
+  /// CORS spec (RFC 6454 §7.3) explicitly forbids.
+  ///
+  /// Called from [headersForRequest] and [preflightResponse], so the
+  /// dangerous combination is caught at first use, not at construction
+  /// (the policy is mutable post-construction; ctor-time validation
+  /// would miss runtime mutations). Exposed publicly so callers can
+  /// validate eagerly during ApplicationChannel setup.
+  void validateConfiguration() {
+    if (!allowCredentials) return;
+    if (allowedOrigins.isEmpty || allowedOrigins.contains("*")) {
+      throw StateError(
+        "CORSPolicy: allowCredentials=true with a wildcard or empty "
+        "allowedOrigins effectively grants credentialed cross-origin "
+        "access to every site (CSRF surface). Specify exact origins, or "
+        "set allowCredentials=false.",
+      );
+    }
   }
 
   /// Whether or not this policy allows the Origin of the [request].
@@ -182,6 +211,7 @@ class CORSPolicy {
   /// to this policy.
   /// This method is invoked internally by [Controller]s that have a [Controller.policy].
   Response preflightResponse(Request req) {
+    validateConfiguration();
     final headers = {
       "Access-Control-Allow-Origin": req.raw.headers.value("origin"),
       "Access-Control-Allow-Methods": allowedMethods.join(", "),

--- a/packages/core/test/http/cors_policy_guard_test.dart
+++ b/packages/core/test/http/cors_policy_guard_test.dart
@@ -1,0 +1,59 @@
+import 'package:conduit_core/conduit_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CORSPolicy default', () {
+    test('does NOT enable allowCredentials out of the box', () {
+      // Regression guard: the previous default was `true` paired with
+      // `allowedOrigins = ["*"]`, which effectively allowed credentialed
+      // CORS from every origin. The new default opts users out; they
+      // must explicitly turn credentials on with a concrete origin list.
+      final p = CORSPolicy();
+      expect(p.allowCredentials, isFalse);
+      expect(p.allowedOrigins, ["*"]);
+    });
+
+    test('default policy passes validateConfiguration', () {
+      // Whatever else the default does, it must not be self-rejecting.
+      // (Apps that never override the policy still need to start.)
+      CORSPolicy().validateConfiguration();
+    });
+  });
+
+  group('CORSPolicy.validateConfiguration', () {
+    test('throws on allowCredentials + wildcard origins', () {
+      final p = CORSPolicy()
+        ..allowCredentials = true; // wildcard origins still default
+      expect(p.validateConfiguration, throwsStateError);
+    });
+
+    test('throws on allowCredentials + empty origins', () {
+      final p = CORSPolicy()
+        ..allowCredentials = true
+        ..allowedOrigins = <String>[];
+      expect(p.validateConfiguration, throwsStateError);
+    });
+
+    test('accepts allowCredentials + concrete origins', () {
+      final p = CORSPolicy()
+        ..allowCredentials = true
+        ..allowedOrigins = ["http://example.com"];
+      // Should not throw.
+      p.validateConfiguration();
+    });
+
+    test('accepts wildcard origins when credentials are off', () {
+      // The pre-existing public-API permissive case still works.
+      final p = CORSPolicy()..allowCredentials = false;
+      expect(p.allowedOrigins, ["*"]);
+      p.validateConfiguration();
+    });
+
+    test('accepts empty origins when credentials are off', () {
+      final p = CORSPolicy()
+        ..allowCredentials = false
+        ..allowedOrigins = <String>[];
+      p.validateConfiguration();
+    });
+  });
+}

--- a/packages/core/test/http/cors_test.dart
+++ b/packages/core/test/http/cors_test.dart
@@ -738,6 +738,20 @@ class NoPolicyController extends ResourceController {
 }
 
 class DefaultPolicyController extends ResourceController {
+  DefaultPolicyController() {
+    // The framework default is now `allowCredentials = false` (the dangerous
+    // wildcard+credentials combo no longer ships out of the box). These
+    // tests exercise the credentialed-CORS path, so opt in with a concrete
+    // allow-list covering every origin the suite uses.
+    policy!.allowCredentials = true;
+    policy!.allowedOrigins = const [
+      "http://abc.com",
+      "http://exclusive.com",
+      "http://foobar.com",
+      "http://www.a.com",
+    ];
+  }
+
   @Operation.get()
   Future<Response> getAll() async {
     return Response.ok("getAll");
@@ -770,6 +784,8 @@ class RestrictiveNoCredsOriginController extends ResourceController {
 class RestrictiveOriginController extends ResourceController {
   RestrictiveOriginController() {
     policy!.allowedOrigins = ["http://exclusive.com"];
+    // Concrete origin list, so credentialed CORS is safe to opt into.
+    policy!.allowCredentials = true;
     policy!.exposedResponseHeaders = ["foobar", "x-foo"];
   }
 
@@ -798,6 +814,16 @@ class OptionsController extends ResourceController {
 class SingleMethodController extends ResourceController {
   SingleMethodController() {
     policy!.allowedMethods = ["GET"];
+    // The preflight assertions below expect credentialed CORS. Match the
+    // suite's pattern: opt into credentials explicitly with a concrete
+    // allow-list. (Identical set to DefaultPolicyController's.)
+    policy!.allowCredentials = true;
+    policy!.allowedOrigins = const [
+      "http://abc.com",
+      "http://exclusive.com",
+      "http://foobar.com",
+      "http://www.a.com",
+    ];
   }
 }
 


### PR DESCRIPTION
> ⚠ **Breaking change** for apps that relied on the previous CORS default.
> Migration is one line per controller — see [Migration](#migration).

## Why

The previous `CORSPolicy._defaults()` paired:

\`\`\`dart
allowedOrigins   = ["*"]
allowCredentials = true
\`\`\`

Conduit echoes the request origin (not `"*"`) into `Access-Control-Allow-Origin`, so the response is spec-compliant. **But** the server effectively allows credentialed cross-origin access from every requesting site. Per RFC 6454 §7.3 that combination is a CSRF surface; it should ship as opt-in, not as the out-of-the-box default. That's the change.

## What lands

### 1. Safer default (`packages/core/lib/src/http/cors_policy.dart`)

\`\`\`diff
   CORSPolicy._defaults() {
     allowedOrigins = ["*"];
-    allowCredentials = true;
+    allowCredentials = false;
\`\`\`

Apps that need credentialed CORS must opt in explicitly **and** provide a concrete `allowedOrigins` list.

### 2. Runtime guard (new `validateConfiguration()`)

\`\`\`dart
void validateConfiguration() {
  if (!allowCredentials) return;
  if (allowedOrigins.isEmpty || allowedOrigins.contains("*")) {
    throw StateError(
      "CORSPolicy: allowCredentials=true with a wildcard or empty "
      "allowedOrigins effectively grants credentialed cross-origin "
      "access to every site (CSRF surface). Specify exact origins, or "
      "set allowCredentials=false.",
    );
  }
}
\`\`\`

Called from `headersForRequest` and `preflightResponse` so a runtime mutation that leaves the policy dangerous fails fast at first use. **Constructor-time** validation would miss mutations after construction (the policy is mutable). Exposed publicly so apps can call it eagerly during `ApplicationChannel` setup if they prefer fail-fast at boot.

### 3. Test fanout (`packages/core/test/http/cors_test.dart`)

Three test controllers needed an explicit credentialed opt-in (they all have concrete origin lists, so the safety bar is satisfied):

| Controller | Change |
|---|---|
| `DefaultPolicyController` | Add `allowCredentials = true` + 4-origin concrete allow-list (covers every origin the suite uses) |
| `RestrictiveOriginController` | Add `allowCredentials = true` (already had a concrete allow-list) |
| `SingleMethodController` | Add `allowCredentials = true` + same 4-origin allow-list |
| `RestrictiveNoCredsOriginController` | **No change** — already explicit `allowCredentials = false` |

### 4. New unit tests (`packages/core/test/http/cors_policy_guard_test.dart`)

7 new tests:
- Default policy is no longer credentialed (regression guard).
- Default policy passes `validateConfiguration` (smoke).
- `validateConfiguration` throws on credentials + wildcard origins.
- `validateConfiguration` throws on credentials + empty origins.
- Accepts credentials + concrete origins.
- Accepts wildcard origins when credentials are off.
- Accepts empty origins when credentials are off.

## Migration

If your app relied on the previous default, add **two lines** at the top of your `ApplicationChannel.prepare()` (or your custom Controller's constructor):

\`\`\`dart
final p = CORSPolicy.defaultPolicy;
p.allowCredentials = true;
p.allowedOrigins = ["https://your-app.example.com", "https://staging.example.com"];
\`\`\`

If your app never used `Access-Control-Allow-Credentials: true`, **no change required** — the new default already gives you that behavior.

If you hit a `StateError` at first request, the message tells you which combination tripped it.

## Verification

\`\`\`
docker run --rm --network=ci_default \
  -v <repo>:/conduit -w /conduit \
  -e PUB_CACHE=/root/.pub-cache \
  -e POSTGRES_HOST=conduit_postgres -e POSTGRES_PORT=5432 \
  -e POSTGRES_USER=conduit_test_user -e POSTGRES_PASSWORD='conduit!' \
  -e POSTGRES_DB=conduit_test_db \
  -e TEST_DB_ENV_VAR='postgres://user:password@host:5432/dbname' \
  -e TEST_VALUE=1 -e TEST_BOOL=true \
  dart:beta bash -c '
    dart pub global activate melos > /dev/null
    dart pub global activate -spath packages/cli > /dev/null
    export PATH=\$PATH:/root/.pub-cache/bin
    melos bootstrap > /dev/null
    cd packages/core && dart test -r failures-only test/http/
  '
\`\`\`

- `dart analyze` on touched files: clean.
- New guard tests: **7/7 pass.**
- Existing `cors_test.dart`: **36/36 pass** (after the test-controller updates).
- Full `packages/core/test/http/` suite: **373/373 pass** (4 pre-existing skips, 0 regressions).

## Versioning

This is the missing CORS finding from #260's audit pass. Recommend tagging the next release as a **minor (or major) bump** with a CHANGELOG entry — the default change is observable to consumers.

## Risk

- Apps with credentialed CORS over wildcards in prod **today** will throw at first request after upgrade. The error message is unambiguous; migration is two lines.
- All other CORS configurations (no credentials, or credentials with concrete origins) are unaffected.
- No public API removed; one new public method (`validateConfiguration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)