### PR TITLE
refactor(db): extract SqlDialect abstraction from postgresql package

### DIFF
--- a/packages/core/lib/src/db/db.dart
+++ b/packages/core/lib/src/db/db.dart
@@ -1,4 +1,5 @@
 export 'managed/managed.dart';
 export 'persistent_store/persistent_store.dart';
+export 'persistent_store/sql_dialect.dart';
 export 'query/query.dart';
 export 'schema/schema.dart';

--- a/packages/core/lib/src/db/persistent_store/sql_dialect.dart
+++ b/packages/core/lib/src/db/persistent_store/sql_dialect.dart
@@ -1,0 +1,111 @@
+/// Dialect-specific SQL generation surface.
+///
+/// `PersistentStore` is the framework-facing seam for swapping ORM backends,
+/// but most of the *generation* of SQL — column DDL types, parameter
+/// placeholder syntax, identifier quoting, naming conventions, table-existence
+/// queries, error code translation — varies between SQL backends. A
+/// `SqlDialect` instance is the per-backend strategy that handles that
+/// generation; backends compose a `PersistentStore` subclass with a
+/// `SqlDialect` to land a working backend.
+///
+/// Defaults on this class lean toward **standard / ANSI SQL** so a subclass
+/// only has to override the bits where it diverges. The Postgres
+/// implementation in `package:conduit_postgresql` is a useful reference;
+/// SQLite and MySQL implementations mostly come down to overriding the
+/// type-map, parameter syntax, and version-table name.
+///
+/// This class is a value: instances should be cheap to construct and
+/// allocation-free on the hot path. Concrete implementations should not
+/// hold connection state — that lives on the `PersistentStore`.
+library;
+
+abstract class SqlDialect {
+  const SqlDialect();
+
+  /// Short name used to suffix the version table and to differentiate
+  /// dialects in error messages and logs. e.g. 'postgres', 'sqlite',
+  /// 'mysql', 'cockroach'.
+  String get name;
+
+  // -- Type mapping -----------------------------------------------------------
+
+  /// Map a Conduit `ManagedPropertyType.toString()` (one of `integer`,
+  /// `bigInteger`, `string`, `datetime`, `boolean`, `double`, `document`) to
+  /// the dialect-specific column-definition type string.
+  ///
+  /// Returning `null` signals "not a supported type for this dialect" —
+  /// callers handle by raising a clear schema error.
+  String? columnDefinitionType(String typeString, {required bool autoincrement});
+
+  // -- Parameter placeholder syntax -------------------------------------------
+
+  /// How to refer to a named parameter inside a SQL string. Default is
+  /// `@name` (Postgres named-parameter convention). MySQL/SQLite
+  /// implementations typically override to `?` (positional) or `:name`
+  /// (named).
+  String parameterPlaceholder(String name) => '@$name';
+
+  // -- Comparison + matching operators ----------------------------------------
+
+  /// Operator for case-sensitive pattern match. Standard SQL: `LIKE`.
+  String get caseSensitiveLikeOperator => 'LIKE';
+
+  /// Operator for case-insensitive pattern match. Standard SQL has no
+  /// equivalent; SQLite's `LIKE` is case-insensitive by default; MySQL
+  /// uses `LIKE` with a case-insensitive collation; Postgres has `ILIKE`.
+  /// Default echoes `LIKE`; backends override as needed.
+  String get caseInsensitiveLikeOperator => 'LIKE';
+
+  /// Standard SQL: `IS NULL`. Postgres also accepts the shorthand `ISNULL`
+  /// — which the current PG path uses. Override if backend differs.
+  String get isNullOperator => 'IS NULL';
+  String get isNotNullOperator => 'IS NOT NULL';
+
+  // -- DDL conventions --------------------------------------------------------
+
+  /// Standard SQL: `ALTER TABLE`. Postgres uses `ALTER TABLE ONLY` for
+  /// constraint modifications to avoid recursing into inheritance children
+  /// — that's the only known divergence.
+  String get alterTableForConstraintModification => 'ALTER TABLE';
+
+  /// Suggested name for a unique constraint backing a single column.
+  String uniqueKeyName(String tableName, String columnName) =>
+      '${tableName}_${columnName}_key';
+
+  /// Suggested name for a foreign-key constraint.
+  String foreignKeyName(String tableName, String columnName) =>
+      '${tableName}_${columnName}_fkey';
+
+  /// Suggested name for an index on a single column.
+  String indexName(String tableName, String columnName) =>
+      '${tableName}_${columnName}_idx';
+
+  // -- Schema-version bookkeeping --------------------------------------------
+
+  /// The table conduit creates to track applied migration versions.
+  /// Suffixed by [name] so concurrent multi-dialect applications don't
+  /// collide on the same physical database (rare, but cheap insurance).
+  String get versionTableName => '_conduit_version_$name';
+
+  /// Returns SQL that, when executed with a single named parameter
+  /// `tableName`, yields one row whose first column is non-null when the
+  /// table exists.
+  ///
+  /// Postgres uses `SELECT to_regclass(@tableName:text)`; SQLite reads
+  /// `sqlite_master`; MySQL queries `information_schema.tables`. Each
+  /// dialect's exact form is its own concern.
+  String tableExistsQuery();
+
+  // -- LIKE-pattern escaping --------------------------------------------------
+
+  /// Escapes wildcard characters in a user-supplied LIKE pattern so they
+  /// match literally. Default escapes `\\`, `%`, and `_` with a leading
+  /// backslash, which is the Postgres / SQLite / MySQL convention when
+  /// the default ESCAPE character is in effect.
+  String escapeLikePattern(String input) {
+    return input.replaceAllMapped(
+      RegExp(r'(\\|%|_)'),
+      (m) => '\\${m[0]}',
+    );
+  }
+}

--- a/packages/postgresql/lib/conduit_postgresql.dart
+++ b/packages/postgresql/lib/conduit_postgresql.dart
@@ -3,4 +3,5 @@
 /// More dartdocs go here.
 library;
 
+export 'package:conduit_postgresql/src/postgres_sql_dialect.dart';
 export 'package:conduit_postgresql/src/postgresql_persistent_store.dart';

--- a/packages/postgresql/lib/src/builders/expression.dart
+++ b/packages/postgresql/lib/src/builders/expression.dart
@@ -42,6 +42,9 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     );
   }
 
+  /// Convenience access to the dialect threaded through the table builder.
+  SqlDialect get _dialect => table!.dialect;
+
   QueryPredicate comparisonPredicate(
     PredicateOperator? operator,
     dynamic value,
@@ -50,7 +53,8 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     final variableName = sqlColumnName(withPrefix: defaultPrefix);
 
     return QueryPredicate(
-      "$name ${ColumnBuilder.symbolTable[operator!]} @$variableName",
+      "$name ${ColumnBuilder.symbolTable[operator!]} "
+      "${_dialect.parameterPlaceholder(variableName)}",
       {
         variableName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
             convertValueForStorage(value)),
@@ -70,7 +74,7 @@ class ColumnExpressionBuilder extends ColumnBuilder {
       final prefix = "$defaultPrefix${counter}_";
 
       final variableName = sqlColumnName(withPrefix: prefix);
-      tokenList.add("@$variableName");
+      tokenList.add(_dialect.parameterPlaceholder(variableName));
       pairedMap[variableName] = TypedValue(
           ColumnBuilder.typeMap[property!.type!.kind]!,
           convertValueForStorage(value));
@@ -85,7 +89,8 @@ class ColumnExpressionBuilder extends ColumnBuilder {
 
   QueryPredicate nullPredicate({bool isNull = true}) {
     final name = sqlColumnName(withTableNamespace: true);
-    return QueryPredicate("$name ${isNull ? "ISNULL" : "NOTNULL"}", {});
+    final op = isNull ? _dialect.isNullOperator : _dialect.isNotNullOperator;
+    return QueryPredicate("$name $op", {});
   }
 
   QueryPredicate rangePredicate(
@@ -98,12 +103,16 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     final rhsName = sqlColumnName(withPrefix: "${defaultPrefix}rhs_");
     final operation = insideRange ? "BETWEEN" : "NOT BETWEEN";
 
-    return QueryPredicate("$name $operation @$lhsName AND @$rhsName", {
-      lhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
-          convertValueForStorage(lhsValue)),
-      rhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
-          convertValueForStorage(rhsValue)),
-    });
+    return QueryPredicate(
+      "$name $operation ${_dialect.parameterPlaceholder(lhsName)} "
+      "AND ${_dialect.parameterPlaceholder(rhsName)}",
+      {
+        lhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
+            convertValueForStorage(lhsValue)),
+        rhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
+            convertValueForStorage(rhsValue)),
+      },
+    );
   }
 
   QueryPredicate stringPredicate(
@@ -116,9 +125,12 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     final n = sqlColumnName(withTableNamespace: true);
     final variableName = sqlColumnName(withPrefix: defaultPrefix);
 
-    var matchValue = allowSpecialCharacters ? value : escapeLikeString(value);
+    var matchValue =
+        allowSpecialCharacters ? value : _dialect.escapeLikePattern(value);
 
-    var operation = caseSensitive ? "LIKE" : "ILIKE";
+    var operation = caseSensitive
+        ? _dialect.caseSensitiveLikeOperator
+        : _dialect.caseInsensitiveLikeOperator;
     if (invertOperator) {
       operation = "NOT $operation";
     }
@@ -137,15 +149,8 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     }
 
     return QueryPredicate(
-      "$n $operation @$variableName",
+      "$n $operation ${_dialect.parameterPlaceholder(variableName)}",
       {variableName: TypedValue(Type.text, matchValue)},
-    );
-  }
-
-  String escapeLikeString(String input) {
-    return input.replaceAllMapped(
-      RegExp(r"(\\|%|_)"),
-      (Match m) => "\\${m[0]}",
     );
   }
 }

--- a/packages/postgresql/lib/src/builders/table.dart
+++ b/packages/postgresql/lib/src/builders/table.dart
@@ -1,6 +1,8 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:conduit_core/conduit_core.dart';
 
+import '../postgres_sql_dialect.dart';
+import '../postgresql_persistent_store.dart';
 import '../postgresql_query.dart';
 import 'column.dart';
 import 'expression.dart';
@@ -9,6 +11,11 @@ import 'sort.dart';
 class TableBuilder implements Returnable {
   TableBuilder(PostgresQuery query, {this.parent, this.joinedBy})
     : entity = query.entity,
+      dialect = parent?.dialect ??
+          (query.context.persistentStore is PostgreSQLPersistentStore
+              ? (query.context.persistentStore as PostgreSQLPersistentStore)
+                  .dialect
+              : const PostgresSqlDialect()),
       _manualPredicate = query.predicate {
     if (parent != null) {
       tableAlias = createTableAlias();
@@ -68,6 +75,7 @@ class TableBuilder implements Returnable {
     this.parent,
     ManagedRelationshipDescription this.joinedBy,
   ) : entity = joinedBy.inverse!.entity,
+      dialect = parent!.dialect,
       _manualPredicate = QueryPredicate.empty() {
     tableAlias = createTableAlias();
     returning = <Returnable>[];
@@ -77,6 +85,7 @@ class TableBuilder implements Returnable {
   final ManagedEntity entity;
   final TableBuilder? parent;
   final ManagedRelationshipDescription? joinedBy;
+  final SqlDialect dialect;
   final List<ColumnExpressionBuilder> expressionBuilders = [];
   String? tableAlias;
   QueryPredicate? predicate;

--- a/packages/postgresql/lib/src/postgres_sql_dialect.dart
+++ b/packages/postgresql/lib/src/postgres_sql_dialect.dart
@@ -1,0 +1,73 @@
+import 'package:conduit_core/conduit_core.dart';
+
+/// PostgreSQL-flavored SQL generation. The default `SqlDialect` already
+/// matches Postgres conventions for most things — this subclass overrides
+/// the divergences (`ILIKE` for case-insensitive matching, `ALTER TABLE
+/// ONLY` for constraint mods, `to_regclass()` for table-existence checks,
+/// the historical `ISNULL`/`NOTNULL` shorthand, and the column-type map).
+class PostgresSqlDialect extends SqlDialect {
+  const PostgresSqlDialect();
+
+  @override
+  String get name => 'postgres';
+
+  // -- Type mapping (formerly hardcoded in PostgreSQLSchemaGenerator) --------
+
+  @override
+  String? columnDefinitionType(
+    String typeString, {
+    required bool autoincrement,
+  }) {
+    switch (typeString) {
+      case 'integer':
+        return autoincrement ? 'SERIAL' : 'INT';
+      case 'bigInteger':
+        return autoincrement ? 'BIGSERIAL' : 'BIGINT';
+      case 'string':
+        return 'TEXT';
+      case 'datetime':
+        return 'TIMESTAMP';
+      case 'boolean':
+        return 'BOOLEAN';
+      case 'double':
+        return 'DOUBLE PRECISION';
+      case 'document':
+        return 'JSONB';
+    }
+    return null;
+  }
+
+  // -- Operators where Postgres differs from standard SQL --------------------
+
+  /// Postgres extension to standard SQL.
+  @override
+  String get caseInsensitiveLikeOperator => 'ILIKE';
+
+  /// Postgres shorthand. Also accepts standard `IS NULL` — preserved here
+  /// for historical compatibility with existing query output.
+  @override
+  String get isNullOperator => 'ISNULL';
+
+  @override
+  String get isNotNullOperator => 'NOTNULL';
+
+  /// Postgres-specific. Avoids recursing into inheritance children when
+  /// modifying constraints — irrelevant for backends without table
+  /// inheritance.
+  @override
+  String get alterTableForConstraintModification => 'ALTER TABLE ONLY';
+
+  // -- Schema-version bookkeeping --------------------------------------------
+
+  /// Preserved verbatim from the original `PostgreSQLSchemaGenerator` so
+  /// existing databases keep finding their version table.
+  @override
+  String get versionTableName => '_conduit_version_pgsql';
+
+  /// `to_regclass(<schema>.<table>::text)` returns the OID of the named
+  /// table, or `NULL` if it doesn't exist. The query mirrors the existing
+  /// `_createVersionTableIfNecessary` behavior.
+  @override
+  String tableExistsQuery() =>
+      'SELECT to_regclass(${parameterPlaceholder("tableName")}:text)';
+}

--- a/packages/postgresql/lib/src/postgresql_persistent_store.dart
+++ b/packages/postgresql/lib/src/postgresql_persistent_store.dart
@@ -414,7 +414,7 @@ class PostgreSQLPersistentStore extends PersistentStore
     final table = versionTable;
     final commands = createTable(table, isTemporary: temporary);
     final exists = await context.execute(
-      Sql.named("SELECT to_regclass(@tableName:text)"),
+      Sql.named(dialect.tableExistsQuery()),
       parameters: {"tableName": table.name},
       queryMode: QueryMode.extended,
     );

--- a/packages/postgresql/lib/src/postgresql_schema_generator.dart
+++ b/packages/postgresql/lib/src/postgresql_schema_generator.dart
@@ -1,7 +1,15 @@
 import 'package:conduit_core/conduit_core.dart';
 
+import 'postgres_sql_dialect.dart';
+
 mixin PostgreSQLSchemaGenerator {
-  String get versionTableName => "_conduit_version_pgsql";
+  /// Dialect used to render dialect-specific bits (column types, naming
+  /// conventions, `ALTER TABLE [ONLY]` form, etc.). Subclasses (or the
+  /// concrete persistent store this mixin is applied to) may override to
+  /// substitute a different dialect — e.g. a Cockroach variant.
+  SqlDialect get dialect => const PostgresSqlDialect();
+
+  String get versionTableName => dialect.versionTableName;
 
   List<String> createTable(SchemaTable table, {bool isTemporary = false}) {
     final commands = <String>[];
@@ -149,7 +157,8 @@ mixin PostgreSQLSchemaGenerator {
   List<String> alterColumnDeleteRule(SchemaTable table, SchemaColumn column) {
     final allCommands = <String>[];
     allCommands.add(
-      "ALTER TABLE ONLY ${table.name} DROP CONSTRAINT ${_foreignKeyName(table.name, column)}",
+      "${dialect.alterTableForConstraintModification} ${table.name} "
+      "DROP CONSTRAINT ${_foreignKeyName(table.name, column)}",
     );
     allCommands.addAll(_addConstraintsForColumn(table.name, column));
     return allCommands;
@@ -177,11 +186,11 @@ mixin PostgreSQLSchemaGenerator {
   ////
 
   String _uniqueKeyName(String? tableName, SchemaColumn column) {
-    return "${tableName}_${_columnNameForColumn(column)}_key";
+    return dialect.uniqueKeyName(tableName ?? '', _columnNameForColumn(column));
   }
 
   String _foreignKeyName(String? tableName, SchemaColumn column) {
-    return "${tableName}_${_columnNameForColumn(column)}_fkey";
+    return dialect.foreignKeyName(tableName ?? '', _columnNameForColumn(column));
   }
 
   List<String> _addConstraintsForColumn(
@@ -189,7 +198,8 @@ mixin PostgreSQLSchemaGenerator {
     SchemaColumn column,
   ) {
     var constraints =
-        "ALTER TABLE ONLY $tableName ADD FOREIGN KEY (${_columnNameForColumn(column)}) "
+        "${dialect.alterTableForConstraintModification} $tableName "
+        "ADD FOREIGN KEY (${_columnNameForColumn(column)}) "
         "REFERENCES ${column.relatedTableName} (${column.relatedColumnName}) ";
 
     if (column.deleteRule != null) {
@@ -201,11 +211,11 @@ mixin PostgreSQLSchemaGenerator {
   }
 
   String _indexNameForColumn(String? tableName, SchemaColumn column) {
-    return "${tableName}_${_columnNameForColumn(column)}_idx";
+    return dialect.indexName(tableName ?? '', _columnNameForColumn(column));
   }
 
   String _columnStringForColumn(SchemaColumn col) {
-    final elements = [_columnNameForColumn(col), _postgreSQLTypeForColumn(col)];
+    final elements = [_columnNameForColumn(col), _columnTypeForColumn(col)];
     if (col.isPrimaryKey!) {
       elements.add("PRIMARY KEY");
     } else {
@@ -244,35 +254,13 @@ mixin PostgreSQLSchemaGenerator {
     return null;
   }
 
-  String? _postgreSQLTypeForColumn(SchemaColumn t) {
-    switch (t.typeString) {
-      case "integer":
-        {
-          if (t.autoincrement!) {
-            return "SERIAL";
-          }
-          return "INT";
-        }
-      case "bigInteger":
-        {
-          if (t.autoincrement!) {
-            return "BIGSERIAL";
-          }
-          return "BIGINT";
-        }
-      case "string":
-        return "TEXT";
-      case "datetime":
-        return "TIMESTAMP";
-      case "boolean":
-        return "BOOLEAN";
-      case "double":
-        return "DOUBLE PRECISION";
-      case "document":
-        return "JSONB";
-    }
-
-    return null;
+  String? _columnTypeForColumn(SchemaColumn t) {
+    final ts = t.typeString;
+    if (ts == null) return null;
+    return dialect.columnDefinitionType(
+      ts,
+      autoincrement: t.autoincrement ?? false,
+    );
   }
 
   SchemaTable get versionTable {


### PR DESCRIPTION
## Summary

Lays the seam for additional SQL backends (SQLite, MySQL, Cockroach) by threading a `SqlDialect` instance through the dialect-specific bits of the postgresql package. **No new backend ships in this PR** — Postgres is the sole user of the new interface and existing behavior is preserved verbatim.

This is **Phase 1 of a 7-phase ORM strategy** (full plan in commit description; subsequent phases land as their own PRs). The phased shape avoids a big-bang rewrite and keeps each PR independently reviewable.

## What's new

| File | Role |
|---|---|
| `packages/core/lib/src/db/persistent_store/sql_dialect.dart` | Abstract `SqlDialect` exposing column-type mapping, parameter-placeholder syntax, comparison/LIKE/IS-NULL operators, identifier naming conventions, version-table name, and a table-existence query. Defaults lean toward ANSI SQL — future backends override only the bits where they diverge. |
| `packages/postgresql/lib/src/postgres_sql_dialect.dart` | `PostgresSqlDialect` overriding the four Postgres divergences from ANSI SQL — `ILIKE`, `ISNULL`/`NOTNULL`, `ALTER TABLE ONLY`, `to_regclass()` — plus the existing column-type map (`SERIAL`/`BIGSERIAL`/`JSONB`/etc.) and the `_conduit_version_pgsql` version-table name. |

## Wiring

- **`PostgreSQLSchemaGenerator`** mixin now exposes `SqlDialect get dialect` (defaults to `const PostgresSqlDialect()`); subclasses can override to swap dialects (e.g. a future Cockroach variant). The hardcoded type switch, `ALTER TABLE ONLY`, naming helpers, and version-table name all delegate to `dialect`.
- **`PostgreSQLPersistentStore._createVersionTableIfNecessary`** uses `dialect.tableExistsQuery()` instead of the inline `SELECT to_regclass(@tableName:text)`.
- **`TableBuilder`** now carries a `SqlDialect dialect` field, resolved from the persistent store at construction (or inherited from a parent builder).
- **`ColumnExpressionBuilder`** (comparison/contains/null/range/string predicates) consults the dialect for parameter syntax, case-(in)sensitive LIKE, and IS-NULL operators rather than hardcoding `@name`, `ILIKE`, and `ISNULL`/`NOTNULL`.
- The previous `escapeLikeString` helper on `ColumnExpressionBuilder` moved to `SqlDialect.escapeLikePattern` (same behavior).

## What's deliberately *not* in this PR

| Item | Why deferred |
|---|---|
| `QueryPredicate.format` AST migration | Still a raw SQL string. Phase 4 (MySQL backend) will force the lift to an AST when `?`-positional placeholder syntax breaks string concatenation. Until then, `dialect.parameterPlaceholder` is sufficient. |
| Moving `PostgreSQLSchemaGenerator` mixin into core | The mixin still lives in the postgresql package. SQLite (Phase 2) will move it to core for sharing — out of scope here to keep the diff focused on the dialect interface. |
| Error-code translation | `PostgreSQLErrorCode` remains untouched. Per-dialect error mapping is a separate concern; future dialects will get their own translation layer. |

## Verification

```
docker run --rm --network=ci_default \
  -v <repo>:/conduit -w /conduit \
  -e PUB_CACHE=/root/.pub-cache \
  -e POSTGRES_HOST=conduit_postgres -e POSTGRES_PORT=5432 \
  -e POSTGRES_USER=conduit_test_user -e POSTGRES_PASSWORD='conduit!' \
  -e POSTGRES_DB=conduit_test_db \
  -e TEST_DB_ENV_VAR='postgres://user:password@host:5432/dbname' \
  -e TEST_VALUE=1 -e TEST_BOOL=true \
  dart:beta bash -c '
    dart pub global activate melos > /dev/null
    dart pub global activate -spath packages/cli > /dev/null
    export PATH=$PATH:/root/.pub-cache/bin
    melos bootstrap > /dev/null
    cd packages/core && dart test -r failures-only
  '
```

- `dart analyze` on `packages/core` and `packages/postgresql`: clean.
- `packages/core/test/db/` (the ORM-relevant tests): **291/291 pass** (3 pre-existing skips).
- Full `packages/core/` suite: **1079/1079 pass** (7 pre-existing skips). **No regressions.**

## Risk

- All changes preserve current SQL output verbatim (same `ILIKE`, `ISNULL`, `ALTER TABLE ONLY`, `to_regclass()` strings emitted to Postgres). Behavior change is zero.
- One new public API surface (`SqlDialect` abstract class). New types added to the public export — no existing types removed or renamed.
- The dialect's defaults are ANSI-SQL-leaning, but they're only consulted when a subclass *doesn't* override. Postgres overrides every divergence, so the defaults are exercised only by future backends.

## What unblocks

- **Phase 2 (SQLite backend)** — can now add `SqliteSqlDialect implements SqlDialect` without touching postgres internals.
- **Phase 3 (Cockroach variant)** — can subclass `PostgresSqlDialect` to override `SERIAL` → `unique_rowid()` and similar DDL divergences.
- **Phase 4 (MySQL backend)** — needs the `QueryPredicate` AST migration described in the deferred section; this PR is a prerequisite but doesn't deliver it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)