### PR TITLE
feat(sqlite): add conduit_sqlite backend (schema + raw execute; ORM path deferred)

### DIFF
--- a/packages/core/lib/src/db/db.dart
+++ b/packages/core/lib/src/db/db.dart
@@ -1,4 +1,5 @@
 export 'managed/managed.dart';
 export 'persistent_store/persistent_store.dart';
+export 'persistent_store/sql_dialect.dart';
 export 'query/query.dart';
 export 'schema/schema.dart';

--- a/packages/core/lib/src/db/persistent_store/sql_dialect.dart
+++ b/packages/core/lib/src/db/persistent_store/sql_dialect.dart
@@ -1,0 +1,111 @@
+/// Dialect-specific SQL generation surface.
+///
+/// `PersistentStore` is the framework-facing seam for swapping ORM backends,
+/// but most of the *generation* of SQL — column DDL types, parameter
+/// placeholder syntax, identifier quoting, naming conventions, table-existence
+/// queries, error code translation — varies between SQL backends. A
+/// `SqlDialect` instance is the per-backend strategy that handles that
+/// generation; backends compose a `PersistentStore` subclass with a
+/// `SqlDialect` to land a working backend.
+///
+/// Defaults on this class lean toward **standard / ANSI SQL** so a subclass
+/// only has to override the bits where it diverges. The Postgres
+/// implementation in `package:conduit_postgresql` is a useful reference;
+/// SQLite and MySQL implementations mostly come down to overriding the
+/// type-map, parameter syntax, and version-table name.
+///
+/// This class is a value: instances should be cheap to construct and
+/// allocation-free on the hot path. Concrete implementations should not
+/// hold connection state — that lives on the `PersistentStore`.
+library;
+
+abstract class SqlDialect {
+  const SqlDialect();
+
+  /// Short name used to suffix the version table and to differentiate
+  /// dialects in error messages and logs. e.g. 'postgres', 'sqlite',
+  /// 'mysql', 'cockroach'.
+  String get name;
+
+  // -- Type mapping -----------------------------------------------------------
+
+  /// Map a Conduit `ManagedPropertyType.toString()` (one of `integer`,
+  /// `bigInteger`, `string`, `datetime`, `boolean`, `double`, `document`) to
+  /// the dialect-specific column-definition type string.
+  ///
+  /// Returning `null` signals "not a supported type for this dialect" —
+  /// callers handle by raising a clear schema error.
+  String? columnDefinitionType(String typeString, {required bool autoincrement});
+
+  // -- Parameter placeholder syntax -------------------------------------------
+
+  /// How to refer to a named parameter inside a SQL string. Default is
+  /// `@name` (Postgres named-parameter convention). MySQL/SQLite
+  /// implementations typically override to `?` (positional) or `:name`
+  /// (named).
+  String parameterPlaceholder(String name) => '@$name';
+
+  // -- Comparison + matching operators ----------------------------------------
+
+  /// Operator for case-sensitive pattern match. Standard SQL: `LIKE`.
+  String get caseSensitiveLikeOperator => 'LIKE';
+
+  /// Operator for case-insensitive pattern match. Standard SQL has no
+  /// equivalent; SQLite's `LIKE` is case-insensitive by default; MySQL
+  /// uses `LIKE` with a case-insensitive collation; Postgres has `ILIKE`.
+  /// Default echoes `LIKE`; backends override as needed.
+  String get caseInsensitiveLikeOperator => 'LIKE';
+
+  /// Standard SQL: `IS NULL`. Postgres also accepts the shorthand `ISNULL`
+  /// — which the current PG path uses. Override if backend differs.
+  String get isNullOperator => 'IS NULL';
+  String get isNotNullOperator => 'IS NOT NULL';
+
+  // -- DDL conventions --------------------------------------------------------
+
+  /// Standard SQL: `ALTER TABLE`. Postgres uses `ALTER TABLE ONLY` for
+  /// constraint modifications to avoid recursing into inheritance children
+  /// — that's the only known divergence.
+  String get alterTableForConstraintModification => 'ALTER TABLE';
+
+  /// Suggested name for a unique constraint backing a single column.
+  String uniqueKeyName(String tableName, String columnName) =>
+      '${tableName}_${columnName}_key';
+
+  /// Suggested name for a foreign-key constraint.
+  String foreignKeyName(String tableName, String columnName) =>
+      '${tableName}_${columnName}_fkey';
+
+  /// Suggested name for an index on a single column.
+  String indexName(String tableName, String columnName) =>
+      '${tableName}_${columnName}_idx';
+
+  // -- Schema-version bookkeeping --------------------------------------------
+
+  /// The table conduit creates to track applied migration versions.
+  /// Suffixed by [name] so concurrent multi-dialect applications don't
+  /// collide on the same physical database (rare, but cheap insurance).
+  String get versionTableName => '_conduit_version_$name';
+
+  /// Returns SQL that, when executed with a single named parameter
+  /// `tableName`, yields one row whose first column is non-null when the
+  /// table exists.
+  ///
+  /// Postgres uses `SELECT to_regclass(@tableName:text)`; SQLite reads
+  /// `sqlite_master`; MySQL queries `information_schema.tables`. Each
+  /// dialect's exact form is its own concern.
+  String tableExistsQuery();
+
+  // -- LIKE-pattern escaping --------------------------------------------------
+
+  /// Escapes wildcard characters in a user-supplied LIKE pattern so they
+  /// match literally. Default escapes `\\`, `%`, and `_` with a leading
+  /// backslash, which is the Postgres / SQLite / MySQL convention when
+  /// the default ESCAPE character is in effect.
+  String escapeLikePattern(String input) {
+    return input.replaceAllMapped(
+      RegExp(r'(\\|%|_)'),
+      (m) => '\\${m[0]}',
+    );
+  }
+}

--- a/packages/postgresql/lib/conduit_postgresql.dart
+++ b/packages/postgresql/lib/conduit_postgresql.dart
@@ -3,4 +3,5 @@
 /// More dartdocs go here.
 library;
 
+export 'package:conduit_postgresql/src/postgres_sql_dialect.dart';
 export 'package:conduit_postgresql/src/postgresql_persistent_store.dart';

--- a/packages/postgresql/lib/src/builders/expression.dart
+++ b/packages/postgresql/lib/src/builders/expression.dart
@@ -42,6 +42,9 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     );
   }
 
+  /// Convenience access to the dialect threaded through the table builder.
+  SqlDialect get _dialect => table!.dialect;
+
   QueryPredicate comparisonPredicate(
     PredicateOperator? operator,
     dynamic value,
@@ -50,7 +53,8 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     final variableName = sqlColumnName(withPrefix: defaultPrefix);
 
     return QueryPredicate(
-      "$name ${ColumnBuilder.symbolTable[operator!]} @$variableName",
+      "$name ${ColumnBuilder.symbolTable[operator!]} "
+      "${_dialect.parameterPlaceholder(variableName)}",
       {
         variableName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
             convertValueForStorage(value)),
@@ -70,7 +74,7 @@ class ColumnExpressionBuilder extends ColumnBuilder {
       final prefix = "$defaultPrefix${counter}_";
 
       final variableName = sqlColumnName(withPrefix: prefix);
-      tokenList.add("@$variableName");
+      tokenList.add(_dialect.parameterPlaceholder(variableName));
       pairedMap[variableName] = TypedValue(
           ColumnBuilder.typeMap[property!.type!.kind]!,
           convertValueForStorage(value));
@@ -85,7 +89,8 @@ class ColumnExpressionBuilder extends ColumnBuilder {
 
   QueryPredicate nullPredicate({bool isNull = true}) {
     final name = sqlColumnName(withTableNamespace: true);
-    return QueryPredicate("$name ${isNull ? "ISNULL" : "NOTNULL"}", {});
+    final op = isNull ? _dialect.isNullOperator : _dialect.isNotNullOperator;
+    return QueryPredicate("$name $op", {});
   }
 
   QueryPredicate rangePredicate(
@@ -98,12 +103,16 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     final rhsName = sqlColumnName(withPrefix: "${defaultPrefix}rhs_");
     final operation = insideRange ? "BETWEEN" : "NOT BETWEEN";
 
-    return QueryPredicate("$name $operation @$lhsName AND @$rhsName", {
-      lhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
-          convertValueForStorage(lhsValue)),
-      rhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
-          convertValueForStorage(rhsValue)),
-    });
+    return QueryPredicate(
+      "$name $operation ${_dialect.parameterPlaceholder(lhsName)} "
+      "AND ${_dialect.parameterPlaceholder(rhsName)}",
+      {
+        lhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
+            convertValueForStorage(lhsValue)),
+        rhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
+            convertValueForStorage(rhsValue)),
+      },
+    );
   }
 
   QueryPredicate stringPredicate(
@@ -116,9 +125,12 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     final n = sqlColumnName(withTableNamespace: true);
     final variableName = sqlColumnName(withPrefix: defaultPrefix);
 
-    var matchValue = allowSpecialCharacters ? value : escapeLikeString(value);
+    var matchValue =
+        allowSpecialCharacters ? value : _dialect.escapeLikePattern(value);
 
-    var operation = caseSensitive ? "LIKE" : "ILIKE";
+    var operation = caseSensitive
+        ? _dialect.caseSensitiveLikeOperator
+        : _dialect.caseInsensitiveLikeOperator;
     if (invertOperator) {
       operation = "NOT $operation";
     }
@@ -137,15 +149,8 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     }
 
     return QueryPredicate(
-      "$n $operation @$variableName",
+      "$n $operation ${_dialect.parameterPlaceholder(variableName)}",
       {variableName: TypedValue(Type.text, matchValue)},
-    );
-  }
-
-  String escapeLikeString(String input) {
-    return input.replaceAllMapped(
-      RegExp(r"(\\|%|_)"),
-      (Match m) => "\\${m[0]}",
     );
   }
 }

--- a/packages/postgresql/lib/src/builders/table.dart
+++ b/packages/postgresql/lib/src/builders/table.dart
@@ -1,6 +1,8 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:conduit_core/conduit_core.dart';
 
+import '../postgres_sql_dialect.dart';
+import '../postgresql_persistent_store.dart';
 import '../postgresql_query.dart';
 import 'column.dart';
 import 'expression.dart';
@@ -9,6 +11,11 @@ import 'sort.dart';
 class TableBuilder implements Returnable {
   TableBuilder(PostgresQuery query, {this.parent, this.joinedBy})
     : entity = query.entity,
+      dialect = parent?.dialect ??
+          (query.context.persistentStore is PostgreSQLPersistentStore
+              ? (query.context.persistentStore as PostgreSQLPersistentStore)
+                  .dialect
+              : const PostgresSqlDialect()),
       _manualPredicate = query.predicate {
     if (parent != null) {
       tableAlias = createTableAlias();
@@ -68,6 +75,7 @@ class TableBuilder implements Returnable {
     this.parent,
     ManagedRelationshipDescription this.joinedBy,
   ) : entity = joinedBy.inverse!.entity,
+      dialect = parent!.dialect,
       _manualPredicate = QueryPredicate.empty() {
     tableAlias = createTableAlias();
     returning = <Returnable>[];
@@ -77,6 +85,7 @@ class TableBuilder implements Returnable {
   final ManagedEntity entity;
   final TableBuilder? parent;
   final ManagedRelationshipDescription? joinedBy;
+  final SqlDialect dialect;
   final List<ColumnExpressionBuilder> expressionBuilders = [];
   String? tableAlias;
   QueryPredicate? predicate;

--- a/packages/postgresql/lib/src/postgres_sql_dialect.dart
+++ b/packages/postgresql/lib/src/postgres_sql_dialect.dart
@@ -1,0 +1,73 @@
+import 'package:conduit_core/conduit_core.dart';
+
+/// PostgreSQL-flavored SQL generation. The default `SqlDialect` already
+/// matches Postgres conventions for most things — this subclass overrides
+/// the divergences (`ILIKE` for case-insensitive matching, `ALTER TABLE
+/// ONLY` for constraint mods, `to_regclass()` for table-existence checks,
+/// the historical `ISNULL`/`NOTNULL` shorthand, and the column-type map).
+class PostgresSqlDialect extends SqlDialect {
+  const PostgresSqlDialect();
+
+  @override
+  String get name => 'postgres';
+
+  // -- Type mapping (formerly hardcoded in PostgreSQLSchemaGenerator) --------
+
+  @override
+  String? columnDefinitionType(
+    String typeString, {
+    required bool autoincrement,
+  }) {
+    switch (typeString) {
+      case 'integer':
+        return autoincrement ? 'SERIAL' : 'INT';
+      case 'bigInteger':
+        return autoincrement ? 'BIGSERIAL' : 'BIGINT';
+      case 'string':
+        return 'TEXT';
+      case 'datetime':
+        return 'TIMESTAMP';
+      case 'boolean':
+        return 'BOOLEAN';
+      case 'double':
+        return 'DOUBLE PRECISION';
+      case 'document':
+        return 'JSONB';
+    }
+    return null;
+  }
+
+  // -- Operators where Postgres differs from standard SQL --------------------
+
+  /// Postgres extension to standard SQL.
+  @override
+  String get caseInsensitiveLikeOperator => 'ILIKE';
+
+  /// Postgres shorthand. Also accepts standard `IS NULL` — preserved here
+  /// for historical compatibility with existing query output.
+  @override
+  String get isNullOperator => 'ISNULL';
+
+  @override
+  String get isNotNullOperator => 'NOTNULL';
+
+  /// Postgres-specific. Avoids recursing into inheritance children when
+  /// modifying constraints — irrelevant for backends without table
+  /// inheritance.
+  @override
+  String get alterTableForConstraintModification => 'ALTER TABLE ONLY';
+
+  // -- Schema-version bookkeeping --------------------------------------------
+
+  /// Preserved verbatim from the original `PostgreSQLSchemaGenerator` so
+  /// existing databases keep finding their version table.
+  @override
+  String get versionTableName => '_conduit_version_pgsql';
+
+  /// `to_regclass(<schema>.<table>::text)` returns the OID of the named
+  /// table, or `NULL` if it doesn't exist. The query mirrors the existing
+  /// `_createVersionTableIfNecessary` behavior.
+  @override
+  String tableExistsQuery() =>
+      'SELECT to_regclass(${parameterPlaceholder("tableName")}:text)';
+}

--- a/packages/postgresql/lib/src/postgresql_persistent_store.dart
+++ b/packages/postgresql/lib/src/postgresql_persistent_store.dart
@@ -414,7 +414,7 @@ class PostgreSQLPersistentStore extends PersistentStore
     final table = versionTable;
     final commands = createTable(table, isTemporary: temporary);
     final exists = await context.execute(
-      Sql.named("SELECT to_regclass(@tableName:text)"),
+      Sql.named(dialect.tableExistsQuery()),
       parameters: {"tableName": table.name},
       queryMode: QueryMode.extended,
     );

--- a/packages/postgresql/lib/src/postgresql_schema_generator.dart
+++ b/packages/postgresql/lib/src/postgresql_schema_generator.dart
@@ -1,7 +1,15 @@
 import 'package:conduit_core/conduit_core.dart';
 
+import 'postgres_sql_dialect.dart';
+
 mixin PostgreSQLSchemaGenerator {
-  String get versionTableName => "_conduit_version_pgsql";
+  /// Dialect used to render dialect-specific bits (column types, naming
+  /// conventions, `ALTER TABLE [ONLY]` form, etc.). Subclasses (or the
+  /// concrete persistent store this mixin is applied to) may override to
+  /// substitute a different dialect — e.g. a Cockroach variant.
+  SqlDialect get dialect => const PostgresSqlDialect();
+
+  String get versionTableName => dialect.versionTableName;
 
   List<String> createTable(SchemaTable table, {bool isTemporary = false}) {
     final commands = <String>[];
@@ -149,7 +157,8 @@ mixin PostgreSQLSchemaGenerator {
   List<String> alterColumnDeleteRule(SchemaTable table, SchemaColumn column) {
     final allCommands = <String>[];
     allCommands.add(
-      "ALTER TABLE ONLY ${table.name} DROP CONSTRAINT ${_foreignKeyName(table.name, column)}",
+      "${dialect.alterTableForConstraintModification} ${table.name} "
+      "DROP CONSTRAINT ${_foreignKeyName(table.name, column)}",
     );
     allCommands.addAll(_addConstraintsForColumn(table.name, column));
     return allCommands;
@@ -177,11 +186,11 @@ mixin PostgreSQLSchemaGenerator {
   ////
 
   String _uniqueKeyName(String? tableName, SchemaColumn column) {
-    return "${tableName}_${_columnNameForColumn(column)}_key";
+    return dialect.uniqueKeyName(tableName ?? '', _columnNameForColumn(column));
   }
 
   String _foreignKeyName(String? tableName, SchemaColumn column) {
-    return "${tableName}_${_columnNameForColumn(column)}_fkey";
+    return dialect.foreignKeyName(tableName ?? '', _columnNameForColumn(column));
   }
 
   List<String> _addConstraintsForColumn(
@@ -189,7 +198,8 @@ mixin PostgreSQLSchemaGenerator {
     SchemaColumn column,
   ) {
     var constraints =
-        "ALTER TABLE ONLY $tableName ADD FOREIGN KEY (${_columnNameForColumn(column)}) "
+        "${dialect.alterTableForConstraintModification} $tableName "
+        "ADD FOREIGN KEY (${_columnNameForColumn(column)}) "
         "REFERENCES ${column.relatedTableName} (${column.relatedColumnName}) ";
 
     if (column.deleteRule != null) {
@@ -201,11 +211,11 @@ mixin PostgreSQLSchemaGenerator {
   }
 
   String _indexNameForColumn(String? tableName, SchemaColumn column) {
-    return "${tableName}_${_columnNameForColumn(column)}_idx";
+    return dialect.indexName(tableName ?? '', _columnNameForColumn(column));
   }
 
   String _columnStringForColumn(SchemaColumn col) {
-    final elements = [_columnNameForColumn(col), _postgreSQLTypeForColumn(col)];
+    final elements = [_columnNameForColumn(col), _columnTypeForColumn(col)];
     if (col.isPrimaryKey!) {
       elements.add("PRIMARY KEY");
     } else {
@@ -244,35 +254,13 @@ mixin PostgreSQLSchemaGenerator {
     return null;
   }
 
-  String? _postgreSQLTypeForColumn(SchemaColumn t) {
-    switch (t.typeString) {
-      case "integer":
-        {
-          if (t.autoincrement!) {
-            return "SERIAL";
-          }
-          return "INT";
-        }
-      case "bigInteger":
-        {
-          if (t.autoincrement!) {
-            return "BIGSERIAL";
-          }
-          return "BIGINT";
-        }
-      case "string":
-        return "TEXT";
-      case "datetime":
-        return "TIMESTAMP";
-      case "boolean":
-        return "BOOLEAN";
-      case "double":
-        return "DOUBLE PRECISION";
-      case "document":
-        return "JSONB";
-    }
-
-    return null;
+  String? _columnTypeForColumn(SchemaColumn t) {
+    final ts = t.typeString;
+    if (ts == null) return null;
+    return dialect.columnDefinitionType(
+      ts,
+      autoincrement: t.autoincrement ?? false,
+    );
   }
 
   SchemaTable get versionTable {

--- a/packages/sqlite/lib/conduit_sqlite.dart
+++ b/packages/sqlite/lib/conduit_sqlite.dart
@@ -1,0 +1,17 @@
+/// SQLite backend for the Conduit ORM.
+///
+/// **v0 scope: schema management + migrations + raw SQL execution.** The
+/// full ORM query path (`Query<T>` → predicates → joins → mapped
+/// results) is deferred until conduit's query builders move out of the
+/// postgresql package into core; until then, `newQuery<T>` throws
+/// `UnimplementedError`.
+///
+/// Why ship before the ORM path is wired: the schema + migration half
+/// is what closes the test-harness gap — apps can run migrations
+/// against an in-memory SQLite database without standing up Postgres in
+/// Docker.
+library;
+
+export 'package:conduit_sqlite/src/sqlite_persistent_store.dart';
+export 'package:conduit_sqlite/src/sqlite_schema_generator.dart';
+export 'package:conduit_sqlite/src/sqlite_sql_dialect.dart';

--- a/packages/sqlite/lib/src/sqlite_persistent_store.dart
+++ b/packages/sqlite/lib/src/sqlite_persistent_store.dart
@@ -1,0 +1,369 @@
+import 'dart:async';
+
+import 'package:conduit_core/conduit_core.dart';
+import 'package:sqlite3/sqlite3.dart' as s3;
+
+import 'sqlite_schema_generator.dart';
+
+/// SQLite-backed `PersistentStore`. **v0 scope: schema management +
+/// migrations + raw `execute` / `executeQuery` / `transaction` only.**
+/// The full ORM query path (`newQuery<T>`) is deferred until the query
+/// builders are extracted from the postgresql package into core; until
+/// then this store throws `UnimplementedError` from `newQuery`.
+///
+/// Why ship before the ORM path is wired: the schema management half is
+/// what closes the test-harness gap (in-memory SQLite for migrations and
+/// fixture seeding without Docker). Apps that want full ORM queries
+/// against SQLite should track the multi-backend ORM roadmap; for now,
+/// postgres remains the only backend with `newQuery` support.
+///
+/// Two factories:
+///
+/// * [SqlitePersistentStore.file] — opens a database at the given path,
+///   creating it if absent.
+/// * [SqlitePersistentStore.memory] — opens a transient in-memory
+///   database; gone when the process or the store is closed.
+class SqlitePersistentStore extends PersistentStore with SqliteSchemaGenerator {
+  SqlitePersistentStore._(this._database);
+
+  /// Open or create a SQLite database at [path]. Foreign-key enforcement
+  /// is enabled by default (off historically; documented to be the
+  /// default in v3.6+).
+  factory SqlitePersistentStore.file(String path) {
+    final db = s3.sqlite3.open(path);
+    db.execute('PRAGMA foreign_keys = ON');
+    return SqlitePersistentStore._(db);
+  }
+
+  /// Open a transient in-memory SQLite database. The database lives only
+  /// for the lifetime of this store; no disk persistence.
+  factory SqlitePersistentStore.memory() {
+    final db = s3.sqlite3.openInMemory();
+    db.execute('PRAGMA foreign_keys = ON');
+    return SqlitePersistentStore._(db);
+  }
+
+  static final Logger _logger = Logger('conduit');
+
+  s3.Database? _database;
+  bool _inTransaction = false;
+
+  @override
+  Query<T> newQuery<T extends ManagedObject>(
+    ManagedContext context,
+    ManagedEntity entity, {
+    T? values,
+  }) {
+    throw UnimplementedError(
+      'SqlitePersistentStore.newQuery is not yet implemented. The ORM '
+      'query path (predicate construction, joins, returning rows as '
+      'ManagedObjects) requires the postgresql package\'s query builders '
+      'to be extracted into core; that refactor is tracked separately. '
+      'For now, use execute()/executeQuery() with raw SQL for arbitrary '
+      'queries against SQLite.',
+    );
+  }
+
+  @override
+  Future<dynamic> execute(
+    String sql, {
+    Map<String, dynamic>? substitutionValues,
+    Duration? timeout,
+  }) async {
+    final db = _requireOpen();
+    final start = DateTime.now();
+    try {
+      final stmt = db.prepare(sql);
+      try {
+        final params = _coerceParams(substitutionValues);
+        // `selectWith` returns rows for SELECTs and an empty result set
+        // for DML/DDL — uniform path means we don't have to sniff the
+        // statement kind from the SQL string.
+        final result = stmt.selectWith(s3.StatementParameters.named(params));
+        _logExecute(sql, substitutionValues, start);
+        return result.rows;
+      } finally {
+        stmt.dispose();
+      }
+    } on s3.SqliteException catch (e) {
+      throw _translate(e);
+    }
+  }
+
+  @override
+  Future<dynamic> executeQuery(
+    String formatString,
+    Map<String, dynamic>? values,
+    int timeoutInSeconds, {
+    PersistentStoreQueryReturnType? returnType =
+        PersistentStoreQueryReturnType.rows,
+  }) async {
+    final db = _requireOpen();
+    final start = DateTime.now();
+    try {
+      final stmt = db.prepare(formatString);
+      try {
+        final params = _coerceParams(values);
+        if (returnType == PersistentStoreQueryReturnType.rows) {
+          final result = stmt.selectWith(s3.StatementParameters.named(params));
+          _logExecute(formatString, values, start);
+          return result.rows;
+        }
+        stmt.executeWith(s3.StatementParameters.named(params));
+        _logExecute(formatString, values, start);
+        return db.updatedRows;
+      } finally {
+        stmt.dispose();
+      }
+    } on s3.SqliteException catch (e) {
+      throw _translate(e);
+    }
+  }
+
+  /// Coerce a Conduit parameter map into the form sqlite3 expects:
+  /// keys prefixed with `:` to match the placeholder in the SQL, and
+  /// values unwrapped from any driver-specific typed-value containers.
+  ///
+  /// Conduit's call sites pass `Map<String, dynamic>` with bare names
+  /// (e.g. `{'n': 42}`). The sqlite3 driver looks up parameters via
+  /// `sqlite3_bind_parameter_index` using the *full* placeholder name
+  /// including its prefix, so `:n` is the lookup key. We add the prefix
+  /// here once.
+  Map<String, Object?> _coerceParams(Map<String, dynamic>? params) {
+    if (params == null) return const {};
+    final out = <String, Object?>{};
+    for (final entry in params.entries) {
+      final key = entry.key.startsWith(':') ? entry.key : ':${entry.key}';
+      out[key] = _unwrapDriverValue(entry.value);
+    }
+    return out;
+  }
+
+  Object? _unwrapDriverValue(Object? v) {
+    if (v == null) return null;
+    // postgres `TypedValue` exposes a `.value` getter; keep this dialect
+    // independent of postgres' types by reflecting via dynamic.
+    try {
+      final dyn = v as dynamic;
+      // ignore: avoid_dynamic_calls
+      final inner = dyn.value;
+      // Avoid recursion if a driver wraps its own `value` getter back
+      // into a wrapper — single unwrap is enough for known drivers.
+      return inner ?? v;
+    } catch (_) {
+      return v;
+    }
+  }
+
+  @override
+  Future<T> transaction<T>(
+    ManagedContext transactionContext,
+    Future<T> Function(ManagedContext transaction) transactionBlock,
+  ) async {
+    final db = _requireOpen();
+    if (_inTransaction) {
+      // Use SAVEPOINT for nested transactions. The Postgres backend
+      // supports the same semantic via runTx; expose the equivalent.
+      final spName = 'sp_${DateTime.now().microsecondsSinceEpoch}';
+      db.execute('SAVEPOINT $spName');
+      try {
+        final result = await transactionBlock(transactionContext);
+        db.execute('RELEASE $spName');
+        return result;
+      } on Rollback {
+        db.execute('ROLLBACK TO $spName');
+        rethrow;
+      } catch (_) {
+        db.execute('ROLLBACK TO $spName');
+        rethrow;
+      }
+    }
+
+    _inTransaction = true;
+    db.execute('BEGIN');
+    try {
+      final result = await transactionBlock(transactionContext);
+      db.execute('COMMIT');
+      return result;
+    } on Rollback {
+      db.execute('ROLLBACK');
+      rethrow;
+    } catch (_) {
+      db.execute('ROLLBACK');
+      rethrow;
+    } finally {
+      _inTransaction = false;
+    }
+  }
+
+  @override
+  Future<int> get schemaVersion async {
+    final db = _requireOpen();
+    try {
+      final rows = db.select(
+        "SELECT versionNumber, dateOfUpgrade "
+        "FROM $versionTableName ORDER BY dateOfUpgrade ASC",
+      );
+      if (rows.isEmpty) return 0;
+      return rows.last['versionNumber'] as int;
+    } on s3.SqliteException catch (e) {
+      // SQLite returns "no such table" with code 1 + extended messaging.
+      if (e.message.contains('no such table')) {
+        return 0;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Schema> upgrade(
+    Schema fromSchema,
+    List<Migration> withMigrations, {
+    bool temporary = false,
+  }) async {
+    final db = _requireOpen();
+    Schema schema = fromSchema;
+
+    db.execute('BEGIN');
+    try {
+      await _createVersionTableIfNecessary(temporary);
+
+      withMigrations.sort((m1, m2) => m1.version!.compareTo(m2.version!));
+
+      for (final migration in withMigrations) {
+        migration.database = SchemaBuilder(
+          this,
+          schema,
+          isTemporary: temporary,
+        );
+        migration.database.store = this;
+
+        final existing = db.select(
+          "SELECT versionNumber, dateOfUpgrade FROM $versionTableName "
+          "WHERE versionNumber >= ?",
+          [migration.version],
+        );
+        if (existing.isNotEmpty) {
+          final date = existing.first['dateOfUpgrade'];
+          throw MigrationException(
+            'Trying to upgrade database to version ${migration.version}, '
+            'but that migration has already been performed on $date.',
+          );
+        }
+
+        _logger.info('Applying migration version ${migration.version}...');
+        await migration.upgrade();
+
+        for (final cmd in migration.database.commands) {
+          _logger.info('\t$cmd');
+          db.execute(cmd);
+        }
+
+        _logger.info(
+          'Seeding data from migration version ${migration.version}...',
+        );
+        await migration.seed();
+
+        db.execute(
+          "INSERT INTO $versionTableName (versionNumber, dateOfUpgrade) "
+          "VALUES (${migration.version}, "
+          "'${DateTime.now().toUtc().toIso8601String()}')",
+        );
+
+        _logger.info(
+          'Applied schema version ${migration.version} successfully.',
+        );
+
+        schema = migration.currentSchema;
+      }
+
+      db.execute('COMMIT');
+    } catch (_) {
+      db.execute('ROLLBACK');
+      rethrow;
+    }
+
+    return schema;
+  }
+
+  @override
+  Future close() async {
+    _database?.dispose();
+    _database = null;
+  }
+
+  // -- internals -------------------------------------------------------------
+
+  s3.Database _requireOpen() {
+    final db = _database;
+    if (db == null) {
+      throw QueryException.transport(
+        'SqlitePersistentStore is closed; cannot execute queries.',
+      );
+    }
+    return db;
+  }
+
+  Future _createVersionTableIfNecessary(bool temporary) async {
+    final db = _requireOpen();
+    final tbl = versionTable;
+    final commands = createTable(tbl, isTemporary: temporary);
+    final exists = db.select(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+      [tbl.name],
+    );
+    if (exists.isNotEmpty) return;
+
+    _logger.info('Initializing database...');
+    for (final cmd in commands) {
+      _logger.info('\t$cmd');
+      db.execute(cmd);
+    }
+  }
+
+  /// Translate a SQLite driver exception into one of conduit's standard
+  /// `QueryException` kinds. SQLite's primary error codes overlap with
+  /// extended codes (e.g. SQLITE_CONSTRAINT_UNIQUE = 19 + 8). We
+  /// pattern-match the message because the extended-code surface is the
+  /// most stable identifier across versions.
+  QueryException<s3.SqliteException> _translate(s3.SqliteException e) {
+    final msg = e.message;
+    if (msg.contains('UNIQUE constraint failed')) {
+      return QueryException.conflict(
+        'entity_already_exists',
+        [_extractConstraintTarget(msg)],
+        underlyingException: e,
+      );
+    }
+    if (msg.contains('NOT NULL constraint failed')) {
+      return QueryException.input(
+        'non_null_violation',
+        [_extractConstraintTarget(msg)],
+        underlyingException: e,
+      );
+    }
+    if (msg.contains('FOREIGN KEY constraint failed')) {
+      return QueryException.input(
+        'foreign_key_violation',
+        const [],
+        underlyingException: e,
+      );
+    }
+    return QueryException.transport(msg, underlyingException: e);
+  }
+
+  String _extractConstraintTarget(String msg) {
+    // Messages look like: "UNIQUE constraint failed: users.email"
+    // or "NOT NULL constraint failed: users.name"
+    final colonIdx = msg.indexOf(': ');
+    if (colonIdx == -1) return msg;
+    return msg.substring(colonIdx + 2).trim();
+  }
+
+  void _logExecute(String sql, Object? params, DateTime start) {
+    _logger.fine(() {
+      final dt = DateTime.now().difference(start).inMilliseconds;
+      return 'Query (${dt}ms) $sql ${params ?? '{}'}';
+    });
+  }
+}

--- a/packages/sqlite/lib/src/sqlite_schema_generator.dart
+++ b/packages/sqlite/lib/src/sqlite_schema_generator.dart
@@ -1,0 +1,228 @@
+import 'package:conduit_core/conduit_core.dart';
+
+import 'sqlite_sql_dialect.dart';
+
+/// Schema-generation logic for SQLite, parallel to
+/// `PostgreSQLSchemaGenerator` in `package:conduit_postgresql`. Both will
+/// move to a shared `SqlSchemaGenerator` in `package:conduit_core` once
+/// at least three SQL backends exist (the right number for an
+/// abstraction); for now the duplication is intentional and bounded.
+///
+/// **Limitations.** SQLite's `ALTER TABLE` only supports `ADD COLUMN`,
+/// `RENAME TO`, `RENAME COLUMN` (3.25+), and `DROP COLUMN` (3.35+). It
+/// has no `ALTER COLUMN` for nullability, default value, type, or
+/// uniqueness. Such operations require the documented "create temp
+/// table + copy + drop + rename" pattern, which this generator does
+/// **not** implement in v0 — it throws `UnsupportedError` instead. Apps
+/// that need column alterations against SQLite should run those
+/// migrations against Postgres in a CI step or implement the rebuild
+/// path manually.
+mixin SqliteSchemaGenerator {
+  SqlDialect get dialect => const SqliteSqlDialect();
+
+  String get versionTableName => dialect.versionTableName;
+
+  List<String> createTable(SchemaTable table, {bool isTemporary = false}) {
+    final commands = <String>[];
+
+    final columnString = table.columns.map(_columnStringForColumn).join(",");
+    commands.add(
+      "CREATE${isTemporary ? " TEMPORARY " : " "}TABLE ${table.name} ($columnString)",
+    );
+
+    final indexCommands = table.columns
+        .where(
+          (col) => col.isIndexed! && !col.isPrimaryKey!,
+        )
+        .map((col) => addIndexToColumn(table, col))
+        .expand((commands) => commands);
+    commands.addAll(indexCommands);
+
+    if (table.uniqueColumnSet != null) {
+      commands.addAll(addTableUniqueColumnSet(table));
+    }
+
+    return commands;
+  }
+
+  List<String> renameTable(SchemaTable table, String name) {
+    return ["ALTER TABLE ${table.name} RENAME TO $name"];
+  }
+
+  List<String> deleteTable(SchemaTable table) {
+    return ["DROP TABLE ${table.name}"];
+  }
+
+  List<String> addTableUniqueColumnSet(SchemaTable table) {
+    final colNames = table.uniqueColumnSet!
+        .map((name) => _columnNameForColumn(table[name]!))
+        .join(",");
+    return [
+      "CREATE UNIQUE INDEX ${table.name}_unique_idx ON ${table.name} ($colNames)"
+    ];
+  }
+
+  List<String> deleteTableUniqueColumnSet(SchemaTable table) {
+    return ["DROP INDEX IF EXISTS ${table.name}_unique_idx"];
+  }
+
+  List<String> addColumn(
+    SchemaTable table,
+    SchemaColumn column, {
+    String? unencodedInitialValue,
+  }) {
+    final commands = <String>[];
+
+    if (unencodedInitialValue != null) {
+      // SQLite supports ADD COLUMN with a DEFAULT, but not a subsequent
+      // DROP DEFAULT. Mirror the Postgres path's intent by emitting just
+      // the ADD with a DEFAULT — the value sticks. Docs note the
+      // divergence.
+      column.defaultValue = unencodedInitialValue;
+      commands.add(
+        "ALTER TABLE ${table.name} ADD COLUMN ${_columnStringForColumn(column)}",
+      );
+    } else {
+      commands.add(
+        "ALTER TABLE ${table.name} ADD COLUMN ${_columnStringForColumn(column)}",
+      );
+    }
+
+    if (column.isIndexed!) {
+      commands.addAll(addIndexToColumn(table, column));
+    }
+
+    return commands;
+  }
+
+  List<String> deleteColumn(SchemaTable table, SchemaColumn column) {
+    // Available since SQLite 3.35 (2021); package:sqlite3 ships a newer
+    // build, so this is fine.
+    return [
+      "ALTER TABLE ${table.name} DROP COLUMN ${_columnNameForColumn(column)}"
+    ];
+  }
+
+  List<String> renameColumn(
+    SchemaTable table,
+    SchemaColumn column,
+    String name,
+  ) {
+    return [
+      "ALTER TABLE ${table.name} "
+      "RENAME COLUMN ${_columnNameForColumn(column)} TO $name"
+    ];
+  }
+
+  List<String> alterColumnNullability(
+    SchemaTable table,
+    SchemaColumn column,
+    String? unencodedInitialValue,
+  ) {
+    throw UnsupportedError(
+      "alterColumnNullability against SQLite requires a table-rebuild "
+      "(create temp + copy + rename); not implemented in v0. Run this "
+      "migration against Postgres or write the rebuild manually.",
+    );
+  }
+
+  List<String> alterColumnUniqueness(SchemaTable table, SchemaColumn column) {
+    throw UnsupportedError(
+      "alterColumnUniqueness against SQLite requires a table-rebuild; "
+      "not implemented in v0.",
+    );
+  }
+
+  List<String> alterColumnDefaultValue(SchemaTable table, SchemaColumn column) {
+    throw UnsupportedError(
+      "alterColumnDefaultValue against SQLite requires a table-rebuild; "
+      "not implemented in v0.",
+    );
+  }
+
+  List<String> alterColumnDeleteRule(SchemaTable table, SchemaColumn column) {
+    throw UnsupportedError(
+      "alterColumnDeleteRule against SQLite requires a table-rebuild "
+      "(SQLite enforces foreign keys via PRAGMA foreign_keys; rule "
+      "changes need column re-creation). Not implemented in v0.",
+    );
+  }
+
+  List<String> addIndexToColumn(SchemaTable table, SchemaColumn column) {
+    return [
+      "CREATE INDEX ${dialect.indexName(table.name ?? '', _columnNameForColumn(column))} "
+      "ON ${table.name} (${_columnNameForColumn(column)})"
+    ];
+  }
+
+  List<String> renameIndex(
+    SchemaTable table,
+    SchemaColumn column,
+    String newIndexName,
+  ) {
+    // SQLite has no ALTER INDEX RENAME — drop + recreate is the
+    // documented pattern.
+    final existing = dialect.indexName(
+      table.name ?? '',
+      _columnNameForColumn(column),
+    );
+    return [
+      "DROP INDEX $existing",
+      "CREATE INDEX $newIndexName ON ${table.name} (${_columnNameForColumn(column)})",
+    ];
+  }
+
+  List<String> deleteIndexFromColumn(SchemaTable table, SchemaColumn column) {
+    return [
+      "DROP INDEX ${dialect.indexName(table.name ?? '', _columnNameForColumn(column))}"
+    ];
+  }
+
+  // -- helpers ---------------------------------------------------------------
+
+  String _columnStringForColumn(SchemaColumn col) {
+    final elements = [_columnNameForColumn(col), _columnTypeForColumn(col)];
+    if (col.isPrimaryKey!) {
+      // INTEGER PRIMARY KEY is SQLite's auto-increment idiom (aliased to
+      // ROWID); the explicit AUTOINCREMENT keyword is rarely needed.
+      elements.add("PRIMARY KEY");
+    } else {
+      elements.add(col.isNullable! ? "NULL" : "NOT NULL");
+      if (col.defaultValue != null) {
+        elements.add("DEFAULT ${col.defaultValue}");
+      }
+      if (col.isUnique!) {
+        elements.add("UNIQUE");
+      }
+    }
+    return elements.join(" ");
+  }
+
+  String _columnNameForColumn(SchemaColumn column) {
+    if (column.relatedColumnName != null) {
+      return "${column.name}_${column.relatedColumnName}";
+    }
+    return column.name;
+  }
+
+  String? _columnTypeForColumn(SchemaColumn t) {
+    final ts = t.typeString;
+    if (ts == null) return null;
+    return dialect.columnDefinitionType(
+      ts,
+      autoincrement: t.autoincrement ?? false,
+    );
+  }
+
+  SchemaTable get versionTable {
+    return SchemaTable(versionTableName, [
+      SchemaColumn.empty()
+        ..name = "versionNumber"
+        ..type = ManagedPropertyType.integer
+        ..isUnique = true,
+      SchemaColumn.empty()
+        ..name = "dateOfUpgrade"
+        ..type = ManagedPropertyType.datetime,
+    ]);
+  }
+}

--- a/packages/sqlite/lib/src/sqlite_sql_dialect.dart
+++ b/packages/sqlite/lib/src/sqlite_sql_dialect.dart
@@ -1,0 +1,110 @@
+import 'package:conduit_core/conduit_core.dart';
+
+/// SQLite-flavored SQL generation. Differs from the default `SqlDialect`
+/// (ANSI-leaning, Postgres-like) in three places:
+///
+/// 1. **Type system.** SQLite has only 5 storage classes
+///    (INTEGER, REAL, TEXT, BLOB, NULL). Conduit's `integer`, `bigInteger`,
+///    `boolean` all map to `INTEGER`; `double` maps to `REAL`; everything
+///    else (strings, JSON, datetimes) maps to `TEXT`. SQLite stores
+///    datetimes as ISO-8601 text by convention; JSON as text with no
+///    server-side validation (the `json1` extension parses it on access).
+///
+/// 2. **Auto-increment.** SQLite has implicit ROWID auto-increment for
+///    any `INTEGER PRIMARY KEY` column; the explicit `AUTOINCREMENT`
+///    keyword is rarely needed and slows inserts. Mapping a Conduit
+///    auto-increment column to plain `INTEGER PRIMARY KEY` is the
+///    idiomatic choice — but autoincrement-only columns (i.e., not
+///    primary keys) are not supported by SQLite at all and would need to
+///    be rejected at schema-validation time.
+///
+/// 3. **Parameter syntax.** The default Postgres-style `@name` is not
+///    a SQLite placeholder. SQLite accepts `:name`, `@name`, `?NNN`, or
+///    `?` — we standardize on `:name` for parity with the named-parameter
+///    semantics used throughout the framework.
+///
+/// Constraint-modification (`ALTER TABLE`) is constrained in SQLite —
+/// see `package:conduit_sqlite` docs. This dialect emits the standard
+/// `ALTER TABLE` form; backends invoking actual column alterations
+/// against SQLite need to fall back to the "create temp + copy +
+/// rename" pattern, which the schema generator handles separately.
+class SqliteSqlDialect extends SqlDialect {
+  const SqliteSqlDialect();
+
+  @override
+  String get name => 'sqlite';
+
+  // -- Type mapping ----------------------------------------------------------
+
+  @override
+  String? columnDefinitionType(
+    String typeString, {
+    required bool autoincrement,
+  }) {
+    switch (typeString) {
+      case 'integer':
+      case 'bigInteger':
+        // SQLite uses dynamic typing; INTEGER covers both 4- and 8-byte
+        // ranges. `INTEGER PRIMARY KEY` is the auto-increment idiom; the
+        // schema generator handles the PRIMARY KEY suffix separately, so
+        // we just emit INTEGER and let it compose.
+        return 'INTEGER';
+      case 'string':
+        return 'TEXT';
+      case 'datetime':
+        // ISO-8601 text by Conduit convention. SQLite has no native
+        // timestamp type; the existing `datetime()` SQL function reads
+        // and writes ISO strings.
+        return 'TEXT';
+      case 'boolean':
+        // 0/1 stored as INTEGER. The `bool` Dart values are bound as
+        // 0/1 by the driver.
+        return 'INTEGER';
+      case 'double':
+        return 'REAL';
+      case 'document':
+        // JSON stored as TEXT. The `json1` extension parses on access.
+        return 'TEXT';
+    }
+    return null;
+  }
+
+  // -- Parameter syntax ------------------------------------------------------
+
+  /// SQLite accepts `@name`, `:name`, `?NNN`, and `?`. We use `:name` for
+  /// parity with the named-parameter semantics used elsewhere.
+  @override
+  String parameterPlaceholder(String name) => ':$name';
+
+  // -- Operators where SQLite differs from standard / Postgres --------------
+
+  /// SQLite's `LIKE` is case-insensitive by default for ASCII characters;
+  /// it does not have an `ILIKE` operator. We emit `LIKE` for both
+  /// case-sensitive and case-insensitive matches. Apps requiring
+  /// strict case-sensitive `LIKE` should issue
+  /// `PRAGMA case_sensitive_like = ON;` once at connection setup; per-query
+  /// dialect divergence is not exposed here (would force a recompilation
+  /// of every prepared statement).
+  @override
+  String get caseInsensitiveLikeOperator => 'LIKE';
+
+  // SQLite uses standard `IS NULL` / `IS NOT NULL` (the inherited defaults
+  // are correct).
+
+  // SQLite's `ALTER TABLE` is the only form (no `ALTER TABLE ONLY`); the
+  // inherited default is correct.
+
+  // -- Schema-version bookkeeping --------------------------------------------
+
+  @override
+  String get versionTableName => '_conduit_version_sqlite';
+
+  /// `sqlite_master` is the canonical metadata table. The query yields
+  /// one row whose first column is the table name when it exists, or no
+  /// rows otherwise — the existence-check call site reads
+  /// `result.first.first != null`.
+  @override
+  String tableExistsQuery() =>
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name = ${parameterPlaceholder("tableName")}";
+}

--- a/packages/sqlite/pubspec.yaml
+++ b/packages/sqlite/pubspec.yaml
@@ -1,0 +1,18 @@
+name: conduit_sqlite
+description: SQLite ORM backend for conduit. Embedded / in-process; closes the test-harness gap by enabling no-Docker test fixtures.
+version: 6.0.0
+home: https://www.theconduit.dev
+repository: https://github.com/conduit-dart/conduit
+issue_tracker: https://github.com/conduit-dart/conduit/issues
+
+environment:
+  sdk: ">=3.12.0-0 <4.0.0"
+resolution: workspace
+
+dependencies:
+  conduit_core: ^6.0.0
+  sqlite3: ^2.4.0
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.25.2

--- a/packages/sqlite/test/sqlite_dialect_test.dart
+++ b/packages/sqlite/test/sqlite_dialect_test.dart
@@ -1,0 +1,207 @@
+import 'package:conduit_core/conduit_core.dart';
+import 'package:conduit_sqlite/conduit_sqlite.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SqliteSqlDialect', () {
+    const d = SqliteSqlDialect();
+
+    test('overrides parameter placeholder to :name', () {
+      expect(d.parameterPlaceholder('foo'), ':foo');
+    });
+
+    test('column types map to SQLite storage classes', () {
+      expect(d.columnDefinitionType('integer', autoincrement: false), 'INTEGER');
+      expect(d.columnDefinitionType('integer', autoincrement: true), 'INTEGER');
+      expect(d.columnDefinitionType('bigInteger', autoincrement: false), 'INTEGER');
+      expect(d.columnDefinitionType('string', autoincrement: false), 'TEXT');
+      expect(d.columnDefinitionType('datetime', autoincrement: false), 'TEXT');
+      expect(d.columnDefinitionType('boolean', autoincrement: false), 'INTEGER');
+      expect(d.columnDefinitionType('double', autoincrement: false), 'REAL');
+      expect(d.columnDefinitionType('document', autoincrement: false), 'TEXT');
+      expect(d.columnDefinitionType('unknownType', autoincrement: false), isNull);
+    });
+
+    test('LIKE is the only matching operator', () {
+      expect(d.caseSensitiveLikeOperator, 'LIKE');
+      expect(d.caseInsensitiveLikeOperator, 'LIKE');
+    });
+
+    test('IS NULL uses standard SQL form', () {
+      expect(d.isNullOperator, 'IS NULL');
+      expect(d.isNotNullOperator, 'IS NOT NULL');
+    });
+
+    test('alter-table form is the standard ALTER TABLE', () {
+      expect(d.alterTableForConstraintModification, 'ALTER TABLE');
+    });
+
+    test('version table is suffixed with backend name', () {
+      expect(d.versionTableName, '_conduit_version_sqlite');
+    });
+
+    test('table-existence query reads sqlite_master', () {
+      expect(d.tableExistsQuery(), contains('sqlite_master'));
+      expect(d.tableExistsQuery(), contains(':tableName'));
+    });
+  });
+
+  group('SqliteSchemaGenerator', () {
+    final gen = _Gen();
+
+    test('createTable emits INTEGER PRIMARY KEY for auto-incremented PK', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'id'
+          ..type = ManagedPropertyType.integer
+          ..isPrimaryKey = true
+          ..autoincrement = true
+          ..isNullable = false
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      final cmds = gen.createTable(t);
+      expect(cmds, hasLength(1));
+      expect(cmds.first, contains('CREATE TABLE users'));
+      expect(cmds.first, contains('id INTEGER PRIMARY KEY'));
+    });
+
+    test('createTable emits NOT NULL for non-nullable non-PK', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'id'
+          ..type = ManagedPropertyType.integer
+          ..isPrimaryKey = true
+          ..autoincrement = true
+          ..isNullable = false
+          ..isIndexed = false
+          ..isUnique = false,
+        SchemaColumn.empty()
+          ..name = 'email'
+          ..type = ManagedPropertyType.string
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = false
+          ..isIndexed = true
+          ..isUnique = true,
+      ]);
+      final cmds = gen.createTable(t);
+      expect(cmds.first, contains('email TEXT NOT NULL UNIQUE'));
+      // Index command emitted separately (only non-PK indexed columns).
+      expect(cmds.length, 2);
+      expect(cmds.last, contains('CREATE INDEX users_email_idx ON users (email)'));
+    });
+
+    test('alterColumnNullability throws (table-rebuild not implemented)', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'email'
+          ..type = ManagedPropertyType.string
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = true
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      expect(
+        () => gen.alterColumnNullability(t, t.columns.first, null),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('renameColumn uses SQLite ALTER TABLE RENAME COLUMN', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'email'
+          ..type = ManagedPropertyType.string
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = true
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      final cmds = gen.renameColumn(t, t.columns.first, 'address');
+      expect(cmds, hasLength(1));
+      expect(cmds.first, 'ALTER TABLE users RENAME COLUMN email TO address');
+    });
+  });
+
+  group('SqlitePersistentStore (in-memory)', () {
+    late SqlitePersistentStore store;
+
+    setUp(() {
+      store = SqlitePersistentStore.memory();
+    });
+
+    tearDown(() async {
+      await store.close();
+    });
+
+    test('execute creates a table and round-trips data', () async {
+      await store.execute('CREATE TABLE t (id INTEGER PRIMARY KEY, n TEXT)');
+      await store.execute(
+        'INSERT INTO t (n) VALUES (:n)',
+        substitutionValues: {'n': 'alice'},
+      );
+      // sqlite3's ResultSet.rows is List<List<Object?>>; positional
+      // access matches the PostgreSQL store's `mappedRows` shape so the
+      // surface is uniform.
+      final rows = await store.execute('SELECT n FROM t') as List;
+      expect(rows, hasLength(1));
+      expect(rows.first[0], 'alice');
+    });
+
+    // newQuery's throwsUnimplementedError contract is documented in the
+    // source and asserted by the type system (the override exists). A
+    // direct test would require constructing a ManagedDataModel + entity,
+    // which is heavier than the contract is worth at this layer; skip
+    // here, cover end-to-end once the ORM path is wired.
+
+    test('schemaVersion returns 0 when version table missing', () async {
+      expect(await store.schemaVersion, 0);
+    });
+
+    test('transaction commits on success', () async {
+      await store.execute('CREATE TABLE t (n INTEGER)');
+      await store.transaction(
+        ManagedContext(ManagedDataModel(const []), store),
+        (txn) async {
+          await store.execute(
+            'INSERT INTO t (n) VALUES (:n)',
+            substitutionValues: {'n': 1},
+          );
+          await store.execute(
+            'INSERT INTO t (n) VALUES (:n)',
+            substitutionValues: {'n': 2},
+          );
+        },
+      );
+      final rows = await store.execute('SELECT count(*) FROM t') as List;
+      expect(rows.first[0], 2);
+    });
+
+    test('transaction rolls back on Rollback', () async {
+      await store.execute('CREATE TABLE t (n INTEGER)');
+      await expectLater(
+        store.transaction(
+          ManagedContext(ManagedDataModel(const []), store),
+          (txn) async {
+            await store.execute(
+              'INSERT INTO t (n) VALUES (:n)',
+              substitutionValues: {'n': 1},
+            );
+            throw Rollback('user-triggered');
+          },
+        ),
+        throwsA(isA<Rollback>()),
+      );
+      final rollbackRows =
+          await store.execute('SELECT count(*) FROM t') as List;
+      expect(rollbackRows.first[0], 0);
+    });
+  });
+}
+
+/// Bare adapter so test cases can call mixin methods without instantiating
+/// a full SqlitePersistentStore.
+class _Gen with SqliteSchemaGenerator {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ workspace:
   - packages/password_hash
   - packages/postgresql
   - packages/runtime
+  - packages/sqlite
   - packages/test_harness
   - packages/fs_test_agent
 
@@ -84,5 +85,6 @@ melos:
                             -V conduit_password_hash:$v \
                             -V conduit_postgresql:$v \
                             -V conduit_runtime:$v \
+                            -V conduit_sqlite:$v \
                             -V conduit_test:$v \
                             -V fs_test_agent:$v


### PR DESCRIPTION
> ⚠ **Stacked on #263** — base is `refactor/sql-dialect`, not `master`. Once #263 lands and rebases, this PR's base will retarget to `master`.

## Summary

Lands a SQLite backend on top of the `SqlDialect` abstraction from #263. Closes the test-harness gap: apps can run migrations against an in-memory SQLite database without standing up Postgres in Docker. **Phase 2 of the 7-phase ORM strategy** (sequenced PRs; SQLite-first per user prioritization).

## What's in the package

| File | Role |
|---|---|
| `packages/sqlite/lib/src/sqlite_sql_dialect.dart` | Dialect overrides: 5-storage-class type map (INTEGER/REAL/TEXT), `:name` parameter syntax, standard `IS NULL`/`IS NOT NULL`, `_conduit_version_sqlite` version table, `sqlite_master` table-existence query. |
| `packages/sqlite/lib/src/sqlite_schema_generator.dart` | Mixin emitting SQLite-flavored DDL. `alterColumn*` operations throw `UnsupportedError` (SQLite has no native `ALTER COLUMN`; would require a "create temp + copy + rename" rebuild path — deferred). |
| `packages/sqlite/lib/src/sqlite_persistent_store.dart` | File + in-memory factories, raw `execute`/`executeQuery`/`transaction` (BEGIN/COMMIT + SAVEPOINT for nested), `upgrade()` for migrations against an embedded version table, driver-error → `QueryException` translation (UNIQUE / NOT NULL / FOREIGN KEY constraint failures). |
| `packages/sqlite/lib/conduit_sqlite.dart` | Public umbrella export. |
| `packages/sqlite/test/sqlite_dialect_test.dart` | 15 tests covering dialect overrides, schema generation, raw execute, schema versioning, transaction commit + `Rollback` rollback. |

## What's deferred

| Item | Why |
|---|---|
| **`newQuery<T>` throws `UnimplementedError`** | The full ORM query path lives in the postgresql package's query builders (`packages/postgresql/lib/src/builders/`), which import postgres-driver types (`TypedValue`, `Type`). Until those builders move to core (or get refactored to use a dialect-agnostic binding type), only Postgres has working `newQuery`. Docs note this clearly; raw `execute()` works for arbitrary queries against SQLite today. The query-builder extraction is a focused refactor of its own — likely absorbed into Phase 4 when MySQL forces the AST migration. |
| **Column-altering migrations** | The SQLite "create temp + copy + rename" rebuild path is non-trivial and not needed for the immediate test-harness use case. Apps that need such migrations should run them against Postgres in CI (or implement the rebuild manually). Documented in source. |

## Workspace + dependency

- `pubspec.yaml`: adds `packages/sqlite` to the melos workspace and threads `conduit_sqlite:$v` through `sync-version`.
- `packages/sqlite/pubspec.yaml`: depends on `sqlite3: ^2.4.0` (active, ~10M downloads/week) + `conduit_core: ^6.0.0`.

## Verification

```
docker run --rm -v <repo>:/conduit -w /conduit \
  -e PUB_CACHE=/root/.pub-cache \
  dart:beta bash -c '
    apt-get update && apt-get install -y libsqlite3-dev
    dart pub global activate melos > /dev/null
    export PATH=$PATH:/root/.pub-cache/bin
    melos bootstrap > /dev/null
    cd packages/sqlite && dart analyze && dart test
  '
```

- `dart analyze packages/sqlite`: clean.
- `cd packages/sqlite && dart test`: **15/15 pass.**
- Other workspace packages unaffected (changes scoped to `packages/sqlite/` and the workspace pubspec).

## What unblocks

Phase 5 (multi-backend test harness) can now use `SqlitePersistentStore.memory()` for in-process test fixtures. The query-builder extraction needed for full ORM SQLite support is folded into Phase 4 (MySQL + AST migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)