### PR TITLE
feat(graph): add conduit_graph package — GraphNode/GraphEdge type system + GraphPersistentStore abstraction

### DIFF
--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -1,0 +1,97 @@
+# conduit_graph
+
+Type-system foundation for an Object-Graph Mapper (OGM) on top of [Conduit](https://github.com/conduit-dart/conduit).
+
+This package ships **only the type system + abstract store contract**. The Neo4j backend that consumes it is the follow-up phase (P6b) and is not part of this release.
+
+## Why a parallel hierarchy, not a generalization of the SQL ORM
+
+Conduit's `ManagedObject<T>`, `ManagedRelationshipType` (`hasOne` / `hasMany` / `belongsTo`), `Schema*`, and `QueryPredicate.format` are SQL-bound. Force-fitting graphs into them creates a graph adapter that pretends to be SQL — wrong abstraction. Graph backends need:
+
+- **First-class typed edges with edge-properties.** SQL foreign keys cannot represent a property *on the relationship itself* (`(:User)-[:Friend {since: …}]->(:User)`). This is the load-bearing distinction.
+- **Multi-label nodes.** First-class in Neo4j; awkward in SQL.
+- **Pattern-based queries** instead of `QueryPredicate.format` strings.
+- **Schemaless properties by default.** Graph DBs are flexible by nature; we deliberately do not bring `Schema*` over.
+
+So `conduit_graph` is a **parallel** hierarchy. `GraphNode<T>` rhymes with `ManagedObject<T>` but does not inherit from it. `GraphPersistentStore` rhymes with `PersistentStore` but does not inherit from it. Apps that need both can hold a `ManagedContext` and a `GraphContext` side by side on `ApplicationChannel`.
+
+## Four primary surfaces
+
+| Surface | Role |
+|--|--|
+| `GraphNode<T>` | A node — labels + property bag, no foreign keys |
+| `GraphEdge<From, To>` | A typed edge — generic-enforced endpoints, with its own property bag |
+| `GraphPersistentStore` | Backend contract: `match`, `create`, `createEdge`, `traverse`, `cypher`, `close` |
+| `GraphPattern` / `GraphQuery` | Closure-built, dialect-agnostic query DSL that compiles to a structured AST |
+
+Plus `GraphContext` + `GraphDataModel` for type registration and dispatch, and `GraphException` + subclasses for errors.
+
+## Worked example
+
+```dart
+import 'package:conduit_graph/conduit_graph.dart';
+
+class User extends GraphNode<User> {
+  User({String? name, int? age}) : super(labels: [GraphLabel('User')]) {
+    if (name != null) this['name'] = name;
+    if (age != null) this['age'] = age;
+  }
+  String? get name => this['name'] as String?;
+  int? get age => this['age'] as int?;
+}
+
+class Friend extends GraphEdge<User, User> {
+  Friend({required User from, required User to, DateTime? since})
+      : super(label: GraphLabel('Friend'), from: from, to: to) {
+    if (since != null) this['since'] = since;
+  }
+}
+
+Future<void> main() async {
+  final store = MyInMemoryStore(); // implements GraphPersistentStore
+  final ctx = GraphContext.withTypes(
+    persistentStore: store,
+    registerNodes: (m) => m..registerNode<User>(),
+    registerEdges: (m) => m..registerEdge<Friend, User, User>(),
+  );
+
+  final alice = await ctx.insertNode(User(name: 'alice', age: 30));
+  final bob = await ctx.insertNode(User(name: 'bob', age: 28));
+  await ctx.insertEdge(Friend(from: alice, to: bob, since: DateTime.now()));
+
+  // Closure-built pattern query — Cypher-shaped, dialect-agnostic.
+  final adultFriends = await ctx.graph
+      .match<User>(
+        (u) => u.connectedTo<Friend>(
+          direction: GraphRelationshipDirection.outgoing,
+        ),
+      )
+      .where((u) => u['age'].greaterThan(21))
+      .fetch();
+}
+```
+
+The `where(…)` closure compiles to a structured `GraphFilterExpression` AST — **not** a `QueryPredicate.format` string. Backends render it in their native dialect. The Neo4j backend in P6b emits `MATCH (u:User)-[:Friend]->(:User) WHERE u.age > $p0 RETURN u`.
+
+## The `cypher()` escape hatch is mandatory
+
+The closure DSL won't cover everything (recursive paths, vendor procedures, projections you can't express as a filter). Every `GraphPersistentStore` exposes a raw query method from day one:
+
+```dart
+final rows = await ctx.cypher(
+  r'MATCH (n:User) WHERE n.age > $min RETURN n.name, n.age',
+  params: {'min': 21},
+);
+```
+
+This is a deliberate design choice — surfacing the escape hatch immediately keeps users from hitting a wall the first time the DSL falls short.
+
+## What we deliberately don't ship in v0
+
+- **No migration system.** Graph migrations are out of scope; users run raw Cypher scripts.
+- **No `Schema*` enforcement.** `GraphPropertyType` labels properties for serialization but does not validate them.
+- **No backend.** This package is the abstraction; bring your own `GraphPersistentStore` or wait for P6b.
+
+## What's next
+
+P6b — `conduit_neo4j`, a `GraphPersistentStore` backed by the Bolt protocol. It will consume the AST that `GraphQuery.fetch()` emits and round-trip results back into typed `GraphNode<T>` subclasses.

--- a/packages/graph/analysis_options.yaml
+++ b/packages/graph/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/graph/lib/conduit_graph.dart
+++ b/packages/graph/lib/conduit_graph.dart
@@ -1,0 +1,50 @@
+/// Type-system foundation for an Object-Graph Mapper (OGM).
+///
+/// `conduit_graph` is a **parallel** hierarchy to the Conduit SQL ORM
+/// — not an adapter. Graph databases need:
+///
+/// - first-class typed edges (with their own properties — SQL FKs
+///   cannot represent these)
+/// - multi-label nodes
+/// - pattern-based queries instead of `QueryPredicate.format` strings
+/// - a schemaless property bag by default
+///
+/// Forcing those concepts onto `ManagedObject` would create a graph
+/// adapter that pretends to be SQL. Instead, we expose:
+///
+/// - `GraphNode<T>` — analogue of `ManagedObject<T>`
+/// - `GraphEdge<From, To>` — typed, generic-enforced endpoints, with
+///   a property bag
+/// - `GraphPersistentStore` — backend contract; ships an always-on
+///   `cypher()` escape hatch from day one
+/// - `GraphContext` + `GraphDataModel` — registry & dispatch
+/// - `GraphPattern` / `GraphQuery` — closure-built, dialect-agnostic
+///   query DSL that compiles to a structured AST (not a SQL
+///   predicate string)
+///
+/// The Neo4j backend is the follow-up phase (P6b); this package ships
+/// only the type system and abstract store contract.
+library;
+
+// Types
+export 'src/types/graph_backing.dart';
+export 'src/types/graph_edge.dart';
+export 'src/types/graph_label.dart';
+export 'src/types/graph_node.dart';
+export 'src/types/graph_property_type.dart';
+export 'src/types/graph_relationship_direction.dart';
+
+// Errors
+export 'src/errors/graph_exception.dart';
+
+// Query DSL
+export 'src/query/graph_filter.dart';
+export 'src/query/graph_pattern.dart';
+export 'src/query/graph_query.dart';
+
+// Store
+export 'src/store/graph_persistent_store.dart';
+
+// Context
+export 'src/context/graph_context.dart';
+export 'src/context/graph_data_model.dart';

--- a/packages/graph/lib/src/context/graph_context.dart
+++ b/packages/graph/lib/src/context/graph_context.dart
@@ -1,0 +1,100 @@
+import '../query/graph_pattern.dart';
+import '../query/graph_query.dart';
+import '../store/graph_persistent_store.dart';
+import '../types/graph_edge.dart';
+import '../types/graph_label.dart';
+import '../types/graph_node.dart';
+import '../types/graph_relationship_direction.dart';
+import 'graph_data_model.dart';
+
+/// Top-level handle for graph-backed work.
+///
+/// Analogue of conduit core's `ManagedContext`: holds a backing
+/// [GraphPersistentStore] plus the [GraphDataModel] registry of node
+/// and edge types. Lives on `ApplicationChannel` alongside
+/// `ManagedContext` for apps that use both SQL and graph storage.
+class GraphContext {
+  GraphContext(this.dataModel, this.persistentStore);
+
+  /// Convenience constructor — registers types via [registerNodes] /
+  /// [registerEdges] callbacks instead of pre-built [GraphDataModel].
+  factory GraphContext.withTypes({
+    required GraphPersistentStore persistentStore,
+    void Function(GraphDataModel model)? registerNodes,
+    void Function(GraphDataModel model)? registerEdges,
+  }) {
+    final model = GraphDataModel();
+    registerNodes?.call(model);
+    registerEdges?.call(model);
+    return GraphContext(model, persistentStore);
+  }
+
+  final GraphDataModel dataModel;
+  final GraphPersistentStore persistentStore;
+
+  /// Entry point for the closure-built query DSL.
+  ///
+  /// ```dart
+  /// final adults = await context.graph.match<User>(
+  ///   (u) => u.connectedTo<Friend>(direction: GraphRelationshipDirection.outgoing),
+  /// ).where((u) => u['age'].greaterThan(21)).fetch();
+  /// ```
+  late final GraphQueryEntry graph = GraphQueryEntry._(this);
+
+  /// Persist a node through the backing store.
+  Future<N> insertNode<N extends GraphNode<N>>(N node) =>
+      persistentStore.create(node);
+
+  /// Persist an edge through the backing store.
+  Future<E> insertEdge<E extends GraphEdge<dynamic, dynamic>>(E edge) =>
+      persistentStore.createEdge<E>(edge);
+
+  /// Walk an edge type from [from] and return the nodes on the far side.
+  Future<List<N>> traverse<N extends GraphNode<N>>(
+    GraphNode<dynamic> from,
+    Type edgeKind, {
+    GraphRelationshipDirection direction =
+        GraphRelationshipDirection.outgoing,
+  }) =>
+      persistentStore.traverse<N>(from, edgeKind, direction: direction);
+
+  /// Always-on raw-Cypher escape hatch — convenience pass-through to
+  /// [GraphPersistentStore.cypher].
+  Future<List<Map<String, Object?>>> cypher(
+    String rawQuery, {
+    Map<String, Object?> params = const {},
+  }) =>
+      persistentStore.cypher(rawQuery, params: params);
+
+  /// Close the backing store. Safe to call more than once.
+  Future<void> close() => persistentStore.close();
+}
+
+/// Sub-handle used as the entry point for the query DSL.
+///
+/// Lets callers write `context.graph.match<User>(…)` (mirrors how
+/// `Query<User>(context)` reads in the SQL ORM).
+final class GraphQueryEntry {
+  GraphQueryEntry._(this._context);
+
+  final GraphContext _context;
+
+  /// Build a runnable [GraphQuery] from a closure-built pattern.
+  GraphQuery<N> match<N extends GraphNode<N>>(
+    void Function(GraphPatternNode<N>) builder, {
+    String variable = 'n',
+    GraphLabel? label,
+  }) {
+    final entity = _context.dataModel.nodeEntities[N];
+    final pattern = GraphPattern<N>.build(
+      builder,
+      variable: variable,
+      label: label ?? entity?.label,
+      nodeType: N,
+    );
+    return GraphQuery<N>(
+      pattern: pattern,
+      executor: _context.persistentStore.executeQuery,
+    );
+  }
+}

--- a/packages/graph/lib/src/context/graph_data_model.dart
+++ b/packages/graph/lib/src/context/graph_data_model.dart
@@ -1,0 +1,122 @@
+import '../errors/graph_exception.dart';
+import '../types/graph_edge.dart';
+import '../types/graph_label.dart';
+import '../types/graph_node.dart';
+
+/// Description of a registered node type.
+///
+/// Mirrors the role conduit core's `ManagedEntity` plays in the SQL
+/// ORM, but graph-flavored: a label and a Dart [Type], no column
+/// definitions, no schema enforcement.
+class GraphNodeEntity {
+  GraphNodeEntity({required this.type, required this.label});
+
+  /// The Dart node subclass.
+  final Type type;
+
+  /// The default label used when matching this type in a pattern.
+  final GraphLabel label;
+
+  @override
+  String toString() => 'GraphNodeEntity($type, label=${label.name})';
+}
+
+/// Description of a registered edge type.
+class GraphEdgeEntity {
+  GraphEdgeEntity({
+    required this.type,
+    required this.label,
+    this.fromType,
+    this.toType,
+  });
+
+  /// The Dart edge subclass.
+  final Type type;
+
+  /// The default label used when matching this type in a pattern.
+  final GraphLabel label;
+
+  /// Source node Dart type, if known at registration time.
+  final Type? fromType;
+
+  /// Target node Dart type, if known at registration time.
+  final Type? toType;
+
+  @override
+  String toString() =>
+      'GraphEdgeEntity($type, label=${label.name}, $fromType -> $toType)';
+}
+
+/// Registry of node and edge types known to a [GraphContext].
+///
+/// Mirrors `ManagedDataModel` — the collection of entities the context
+/// can resolve.
+class GraphDataModel {
+  GraphDataModel();
+
+  final Map<Type, GraphNodeEntity> _nodes = {};
+  final Map<Type, GraphEdgeEntity> _edges = {};
+
+  /// Register a node type. The [label] defaults to the type's name.
+  GraphNodeEntity registerNode<T extends GraphNode<T>>({
+    GraphLabel? label,
+  }) {
+    final entity = GraphNodeEntity(
+      type: T,
+      label: label ?? GraphLabel(T.toString()),
+    );
+    _nodes[T] = entity;
+    return entity;
+  }
+
+  /// Register an edge type. The [label] defaults to the type's name.
+  GraphEdgeEntity registerEdge<
+      E extends GraphEdge<From, To>,
+      From extends GraphNode<From>,
+      To extends GraphNode<To>>({
+    GraphLabel? label,
+  }) {
+    final entity = GraphEdgeEntity(
+      type: E,
+      label: label ?? GraphLabel(E.toString()),
+      fromType: From,
+      toType: To,
+    );
+    _edges[E] = entity;
+    return entity;
+  }
+
+  /// Look up a registered node type. Throws [GraphInvalidQuery] if
+  /// unknown.
+  GraphNodeEntity nodeEntityFor(Type type) {
+    final entity = _nodes[type];
+    if (entity == null) {
+      throw GraphInvalidQuery(
+        "node type '$type' is not registered with this GraphDataModel",
+      );
+    }
+    return entity;
+  }
+
+  /// Look up a registered edge type. Throws [GraphInvalidQuery] if
+  /// unknown.
+  GraphEdgeEntity edgeEntityFor(Type type) {
+    final entity = _edges[type];
+    if (entity == null) {
+      throw GraphInvalidQuery(
+        "edge type '$type' is not registered with this GraphDataModel",
+      );
+    }
+    return entity;
+  }
+
+  /// All registered node entities, keyed by Dart type.
+  Map<Type, GraphNodeEntity> get nodeEntities => Map.unmodifiable(_nodes);
+
+  /// All registered edge entities, keyed by Dart type.
+  Map<Type, GraphEdgeEntity> get edgeEntities => Map.unmodifiable(_edges);
+
+  /// True iff [type] has been registered as either a node or an edge.
+  bool isRegistered(Type type) =>
+      _nodes.containsKey(type) || _edges.containsKey(type);
+}

--- a/packages/graph/lib/src/errors/graph_exception.dart
+++ b/packages/graph/lib/src/errors/graph_exception.dart
@@ -1,0 +1,47 @@
+/// Base class for all conduit_graph exceptions.
+///
+/// Deliberately *not* a subclass of conduit core's `QueryException` —
+/// graph errors live in a parallel domain and tunneling them through
+/// the SQL exception type would force callers to catch errors that
+/// don't apply.
+sealed class GraphException implements Exception {
+  GraphException(this.message, {this.cause});
+
+  /// A short human-readable description of what went wrong.
+  final String message;
+
+  /// The underlying cause, if this exception wraps another. Common
+  /// when adapting a backend driver's error.
+  final Object? cause;
+
+  @override
+  String toString() {
+    final c = cause == null ? '' : ' (cause: $cause)';
+    return '$runtimeType: $message$c';
+  }
+}
+
+/// Connectivity / handshake / transport-level failure talking to the
+/// graph backend.
+final class GraphConnectionError extends GraphException {
+  GraphConnectionError(super.message, {super.cause});
+}
+
+/// A backend-level constraint was violated (uniqueness, required-key,
+/// etc). Note that conduit_graph itself does not enforce a schema —
+/// this is reserved for backends that do.
+final class GraphConstraintViolation extends GraphException {
+  GraphConstraintViolation(super.message, {super.cause});
+}
+
+/// A node, edge, or relationship endpoint referenced by a query was
+/// not found.
+final class GraphNotFoundError extends GraphException {
+  GraphNotFoundError(super.message, {super.cause});
+}
+
+/// The query was malformed or referenced a node/edge type that the
+/// context does not know about.
+final class GraphInvalidQuery extends GraphException {
+  GraphInvalidQuery(super.message, {super.cause});
+}

--- a/packages/graph/lib/src/query/graph_filter.dart
+++ b/packages/graph/lib/src/query/graph_filter.dart
@@ -1,0 +1,186 @@
+import '../errors/graph_exception.dart';
+
+/// Comparison operators that a where-clause filter can express.
+///
+/// Backends translate these to their native query language; the DSL
+/// itself is dialect-agnostic.
+enum GraphFilterOperator {
+  equal,
+  notEqual,
+  greaterThan,
+  greaterThanOrEqual,
+  lessThan,
+  lessThanOrEqual,
+  contains, // string contains / array contains, backend-defined
+  startsWith,
+  endsWith,
+  inList,
+  isNull,
+  isNotNull,
+}
+
+/// Logical connector for compound filter expressions.
+enum GraphFilterCombinator { and, or }
+
+/// A structured filter expression — the AST the where-clause closure
+/// compiles to.
+///
+/// This is **not** a string. The query DSL refuses to lower to a SQL
+/// `QueryPredicate.format` — it emits a tree that backends render in
+/// their own dialect (Cypher, openCypher, Gremlin, …).
+sealed class GraphFilterExpression {
+  const GraphFilterExpression();
+
+  /// Combine this expression with [other] using AND.
+  GraphFilterExpression and(GraphFilterExpression other) =>
+      GraphCompoundFilter(GraphFilterCombinator.and, [this, other]);
+
+  /// Combine this expression with [other] using OR.
+  GraphFilterExpression or(GraphFilterExpression other) =>
+      GraphCompoundFilter(GraphFilterCombinator.or, [this, other]);
+}
+
+/// A leaf filter: `<property> <op> <value?>`.
+final class GraphPropertyFilter extends GraphFilterExpression {
+  const GraphPropertyFilter({
+    required this.property,
+    required this.operator,
+    this.value,
+  });
+
+  final String property;
+  final GraphFilterOperator operator;
+  final Object? value;
+
+  @override
+  String toString() => 'GraphPropertyFilter($property ${operator.name} $value)';
+}
+
+/// A compound expression — n-ary AND or OR.
+final class GraphCompoundFilter extends GraphFilterExpression {
+  GraphCompoundFilter(this.combinator, List<GraphFilterExpression> children)
+      : children = List.unmodifiable(children) {
+    if (children.isEmpty) {
+      throw GraphInvalidQuery(
+        'compound filter must have at least one child',
+      );
+    }
+  }
+
+  final GraphFilterCombinator combinator;
+  final List<GraphFilterExpression> children;
+
+  @override
+  String toString() => 'GraphCompoundFilter(${combinator.name}, $children)';
+}
+
+/// A logical NOT.
+final class GraphNotFilter extends GraphFilterExpression {
+  const GraphNotFilter(this.child);
+
+  final GraphFilterExpression child;
+
+  @override
+  String toString() => 'GraphNotFilter($child)';
+}
+
+/// Helper for the closure-built where-clause.
+///
+/// User code calls bare property accessors via [GraphWhereProxy]; the
+/// proxy returns [GraphFilterTerm] objects whose comparison operators
+/// are overloaded to record [GraphPropertyFilter] expressions instead
+/// of evaluating against runtime values.
+///
+/// (This mirrors the proxy-based predicate building in conduit core's
+/// `Query<T>.where` — structurally borrowed, graph-shaped output.)
+class GraphFilterTerm {
+  GraphFilterTerm(this._property);
+
+  final String _property;
+
+  GraphFilterExpression equalTo(Object? value) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.equal,
+        value: value,
+      );
+
+  GraphFilterExpression notEqualTo(Object? value) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.notEqual,
+        value: value,
+      );
+
+  GraphFilterExpression greaterThan(Object value) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.greaterThan,
+        value: value,
+      );
+
+  GraphFilterExpression greaterThanOrEqualTo(Object value) =>
+      GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.greaterThanOrEqual,
+        value: value,
+      );
+
+  GraphFilterExpression lessThan(Object value) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.lessThan,
+        value: value,
+      );
+
+  GraphFilterExpression lessThanOrEqualTo(Object value) =>
+      GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.lessThanOrEqual,
+        value: value,
+      );
+
+  GraphFilterExpression contains(Object value) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.contains,
+        value: value,
+      );
+
+  GraphFilterExpression startsWith(String value) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.startsWith,
+        value: value,
+      );
+
+  GraphFilterExpression endsWith(String value) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.endsWith,
+        value: value,
+      );
+
+  GraphFilterExpression isIn(List<Object?> values) => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.inList,
+        value: List<Object?>.unmodifiable(values),
+      );
+
+  GraphFilterExpression get isNull => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.isNull,
+      );
+
+  GraphFilterExpression get isNotNull => GraphPropertyFilter(
+        property: _property,
+        operator: GraphFilterOperator.isNotNull,
+      );
+}
+
+/// The proxy passed to a `where` closure. Property accesses return
+/// [GraphFilterTerm] objects.
+class GraphWhereProxy {
+  GraphWhereProxy();
+
+  /// Look up a property as a filter term.
+  ///
+  /// Use either `proxy['age']` or `proxy.property('age')` — the second
+  /// reads better in builder chains.
+  GraphFilterTerm operator [](String property) => GraphFilterTerm(property);
+
+  GraphFilterTerm property(String name) => GraphFilterTerm(name);
+}

--- a/packages/graph/lib/src/query/graph_pattern.dart
+++ b/packages/graph/lib/src/query/graph_pattern.dart
@@ -1,0 +1,137 @@
+import '../types/graph_label.dart';
+import '../types/graph_node.dart';
+import '../types/graph_relationship_direction.dart';
+
+/// A node-shaped step inside a [GraphPattern].
+///
+/// Wraps the user's anchor variable and any chained relationship
+/// hops emitted by [GraphPatternNode.connectedTo].
+class GraphPatternNode<N extends GraphNode<N>> {
+  GraphPatternNode({
+    required this.variable,
+    required this.label,
+    this.nodeType,
+  });
+
+  /// The query-binding variable name (e.g. `u` in `(u:User)`).
+  final String variable;
+
+  /// The label this pattern step matches.
+  final GraphLabel label;
+
+  /// The Dart [Type] this step resolves to, when known. The Neo4j
+  /// backend uses this to map results back into typed nodes.
+  final Type? nodeType;
+
+  /// Outgoing/incoming/undirected hops captured on this node.
+  final List<GraphPatternRelationship> _relationships = [];
+
+  List<GraphPatternRelationship> get relationships =>
+      List.unmodifiable(_relationships);
+
+  /// Records a relationship from this node to a node of label
+  /// [edgeLabel] (defaults to the runtime [Type] name of [E]).
+  ///
+  /// `connectedTo<Friend>(direction: outgoing)` captures the hop
+  /// `(u)-[:Friend]->(:?)`. The terminal node label / type is filled
+  /// in by the backend renderer when it lowers the pattern.
+  GraphPatternNode<N> connectedTo<E>({
+    GraphRelationshipDirection direction =
+        GraphRelationshipDirection.outgoing,
+    GraphLabel? edgeLabel,
+    Type? toType,
+    GraphLabel? toLabel,
+    String? toVariable,
+  }) {
+    _relationships.add(
+      GraphPatternRelationship(
+        edgeLabel: edgeLabel ?? GraphLabel(E.toString()),
+        edgeType: E,
+        direction: direction,
+        toLabel: toLabel,
+        toType: toType,
+        toVariable: toVariable,
+      ),
+    );
+    return this;
+  }
+
+  @override
+  String toString() {
+    final rels = _relationships.isEmpty ? '' : ', $_relationships';
+    return 'GraphPatternNode($variable:${label.name}$rels)';
+  }
+}
+
+/// A relationship hop captured inside a [GraphPatternNode].
+class GraphPatternRelationship {
+  const GraphPatternRelationship({
+    required this.edgeLabel,
+    required this.direction,
+    this.edgeType,
+    this.toLabel,
+    this.toType,
+    this.toVariable,
+  });
+
+  /// Edge label (e.g. `Friend`).
+  final GraphLabel edgeLabel;
+
+  /// The Dart edge [Type], when known.
+  final Type? edgeType;
+
+  /// Direction of this hop.
+  final GraphRelationshipDirection direction;
+
+  /// Terminal node label, when the user pinned one.
+  final GraphLabel? toLabel;
+
+  /// Terminal node Dart type, when the user pinned one.
+  final Type? toType;
+
+  /// Terminal node binding variable, when the user pinned one.
+  final String? toVariable;
+
+  @override
+  String toString() {
+    return 'GraphPatternRelationship'
+        '(${direction.name}, '
+        ':${edgeLabel.name}'
+        '${toLabel == null ? '' : ' -> :${toLabel!.name}'})';
+  }
+}
+
+/// Closure-built node pattern.
+///
+/// Cypher-shaped: a single anchor node with zero or more chained
+/// relationship hops. Compiles to a structured AST — the renderer for
+/// each backend turns it into the target query string.
+///
+/// This type is the **only** public surface for building a pattern
+/// from a closure; backends consume its [root].
+class GraphPattern<N extends GraphNode<N>> {
+  GraphPattern._(this.root);
+
+  /// Build a pattern by calling [builder] with a fresh
+  /// [GraphPatternNode] anchored on label [label] (or `T.toString()`).
+  factory GraphPattern.build(
+    void Function(GraphPatternNode<N>) builder, {
+    String variable = 'n',
+    GraphLabel? label,
+    Type? nodeType,
+  }) {
+    final root = GraphPatternNode<N>(
+      variable: variable,
+      label: label ?? GraphLabel(N.toString()),
+      nodeType: nodeType ?? N,
+    );
+    builder(root);
+    return GraphPattern._(root);
+  }
+
+  /// The anchor node of the pattern.
+  final GraphPatternNode<N> root;
+
+  @override
+  String toString() => 'GraphPattern(root=$root)';
+}

--- a/packages/graph/lib/src/query/graph_query.dart
+++ b/packages/graph/lib/src/query/graph_query.dart
@@ -1,0 +1,135 @@
+import '../errors/graph_exception.dart';
+import '../types/graph_node.dart';
+import 'graph_filter.dart';
+import 'graph_pattern.dart';
+
+/// Sort direction for `orderBy`.
+enum GraphSortDirection { ascending, descending }
+
+/// A single ordering term: property + direction.
+class GraphOrderBy {
+  const GraphOrderBy(this.property, this.direction);
+
+  final String property;
+  final GraphSortDirection direction;
+
+  @override
+  String toString() => 'GraphOrderBy($property ${direction.name})';
+}
+
+/// Forward declaration of the executor a [GraphQuery] runs against.
+///
+/// Defined as a typedef rather than a direct import of
+/// [GraphPersistentStore] so this file does not have to depend on the
+/// store layer — the store layer already depends on this file. The
+/// real signature lines up with [GraphPersistentStore.executeQuery].
+typedef GraphQueryExecutor = Future<List<N>>
+    Function<N extends GraphNode<N>>(GraphQuery<N> query);
+
+/// A chainable, dialect-agnostic graph query.
+///
+/// Wraps a [GraphPattern] with optional `where`, `orderBy`, `limit`,
+/// and `offset`. **Does not** lower to a `QueryPredicate.format`
+/// string — the where-clause closure compiles to a structured
+/// [GraphFilterExpression] that backends render in their native query
+/// language.
+///
+/// ```dart
+/// final q = context.graph.match<User>(
+///   (u) => u.connectedTo<Friend>(),
+/// ).where((u) => u['age'].greaterThan(21));
+///
+/// final adults = await q.fetch();
+/// ```
+class GraphQuery<N extends GraphNode<N>> {
+  GraphQuery({required this.pattern, this.executor});
+
+  final GraphPattern<N> pattern;
+
+  /// The store-supplied executor that runs this query. `null` for
+  /// detached queries — calling [fetch] then throws
+  /// [GraphInvalidQuery]. Backends and tests can wire in their own
+  /// executor when constructing a [GraphQuery] directly.
+  final GraphQueryExecutor? executor;
+
+  GraphFilterExpression? _filter;
+  int? _limit;
+  int? _offset;
+  final List<GraphOrderBy> _orderBy = [];
+
+  /// The compiled where-clause, or `null` if none has been set.
+  GraphFilterExpression? get filter => _filter;
+
+  int? get limit => _limit;
+  int? get offset => _offset;
+  List<GraphOrderBy> get orderBy => List.unmodifiable(_orderBy);
+
+  /// Apply [predicate] as the where-clause.
+  ///
+  /// The closure receives a [GraphWhereProxy]; properties are accessed
+  /// by name and comparison operators record [GraphFilterExpression]
+  /// nodes instead of evaluating against runtime values:
+  ///
+  /// ```dart
+  /// q.where((u) => u['age'].greaterThan(21).and(u['name'].equalTo('alice')));
+  /// ```
+  ///
+  /// Calling `where` twice ANDs the new predicate onto the existing
+  /// one — convenient for composable builders.
+  GraphQuery<N> where(
+    GraphFilterExpression Function(GraphWhereProxy proxy) predicate,
+  ) {
+    final next = predicate(GraphWhereProxy());
+    _filter = _filter == null ? next : _filter!.and(next);
+    return this;
+  }
+
+  /// Cap the result set at [count] rows. Throws [GraphInvalidQuery] if
+  /// [count] is negative.
+  GraphQuery<N> limitTo(int count) {
+    if (count < 0) {
+      throw GraphInvalidQuery('limit must be non-negative, got $count');
+    }
+    _limit = count;
+    return this;
+  }
+
+  /// Skip [count] rows. Throws [GraphInvalidQuery] if [count] is
+  /// negative.
+  GraphQuery<N> offsetBy(int count) {
+    if (count < 0) {
+      throw GraphInvalidQuery('offset must be non-negative, got $count');
+    }
+    _offset = count;
+    return this;
+  }
+
+  /// Append an ordering term.
+  GraphQuery<N> orderByProperty(
+    String property, {
+    GraphSortDirection direction = GraphSortDirection.ascending,
+  }) {
+    _orderBy.add(GraphOrderBy(property, direction));
+    return this;
+  }
+
+  /// Execute the query and return all matching nodes.
+  Future<List<N>> fetch() {
+    final exec = executor;
+    if (exec == null) {
+      throw GraphInvalidQuery(
+        'GraphQuery is detached — no executor was provided. '
+        'Build it through GraphContext.graph.match() to get a runnable query.',
+      );
+    }
+    return exec<N>(this);
+  }
+
+  /// Execute the query and return the first match, or `null` if there
+  /// were none.
+  Future<N?> fetchOne() async {
+    final capped = limit ?? 1;
+    final rows = await (this..limitTo(capped < 1 ? 1 : capped)).fetch();
+    return rows.isEmpty ? null : rows.first;
+  }
+}

--- a/packages/graph/lib/src/store/graph_persistent_store.dart
+++ b/packages/graph/lib/src/store/graph_persistent_store.dart
@@ -1,0 +1,75 @@
+import '../query/graph_pattern.dart';
+import '../query/graph_query.dart';
+import '../types/graph_edge.dart';
+import '../types/graph_node.dart';
+import '../types/graph_relationship_direction.dart';
+
+/// Backend-agnostic persistence contract for graph data.
+///
+/// **Not** a subclass of conduit core's `PersistentStore` — this is a
+/// parallel hierarchy. The SQL `PersistentStore` is bound to columns,
+/// foreign keys, and `QueryPredicate.format` strings; none of that
+/// vocabulary fits a graph backend cleanly. Forcing inheritance would
+/// produce a graph adapter that pretends to be SQL.
+///
+/// In v0 the only backing implementation in the wild is the upcoming
+/// Neo4j backend (see Phase 6b). The Cypher escape hatch ([cypher])
+/// is intentionally surfaced here from day one so users are never
+/// boxed in by the closure DSL.
+abstract class GraphPersistentStore {
+  /// Pattern-based read.
+  ///
+  /// Implementations should accept a [GraphPattern] built via the
+  /// `GraphContext.graph.match()` helpers.
+  Future<List<N>> match<N extends GraphNode<N>>(GraphPattern<N> pattern);
+
+  /// Execute a fully-built [GraphQuery] (pattern + where/limit/order).
+  ///
+  /// `GraphQuery.fetch()` delegates here.
+  Future<List<N>> executeQuery<N extends GraphNode<N>>(GraphQuery<N> query);
+
+  /// Persist a node. The store is responsible for assigning [GraphNode.id].
+  Future<N> create<N extends GraphNode<N>>(N node);
+
+  /// Persist an edge. The store is responsible for assigning
+  /// [GraphEdge.id]. Both endpoints must already exist in the store
+  /// (their `id` fields must be set) — implementations should throw
+  /// `GraphNotFoundError` otherwise.
+  ///
+  /// `E` is left as a single generic that defaults to the runtime
+  /// type of [edge]; the concrete `From` / `To` of the edge are
+  /// available via `edge.from` and `edge.to` if the backend needs
+  /// them. We deliberately do **not** declare a three-parameter
+  /// `<E extends GraphEdge<From, To>, From, To>` signature here
+  /// because Dart cannot infer all three from a single argument
+  /// without an explicit type list at every call site.
+  Future<E> createEdge<E extends GraphEdge<dynamic, dynamic>>(E edge);
+
+  /// Walk outgoing/incoming edges of a particular kind from [from]
+  /// and return the nodes on the far side.
+  Future<List<N>> traverse<N extends GraphNode<N>>(
+    GraphNode<dynamic> from,
+    Type edgeKind, {
+    GraphRelationshipDirection direction =
+        GraphRelationshipDirection.outgoing,
+  });
+
+  /// **Always-on raw-Cypher escape hatch.**
+  ///
+  /// The closure DSL won't cover everything (recursive paths,
+  /// procedure calls, vendor extensions). Surfacing this from day one
+  /// keeps users from hitting a wall — they can drop into raw query
+  /// code without forking the framework.
+  ///
+  /// [params] are passed through as named bind parameters. Returned
+  /// rows are unbound `Map<String, Object?>` records; mapping back
+  /// into typed nodes is the caller's responsibility.
+  Future<List<Map<String, Object?>>> cypher(
+    String rawQuery, {
+    Map<String, Object?> params = const {},
+  });
+
+  /// Close the underlying connection / driver. Must be safe to call
+  /// more than once.
+  Future<void> close();
+}

--- a/packages/graph/lib/src/types/graph_backing.dart
+++ b/packages/graph/lib/src/types/graph_backing.dart
@@ -1,0 +1,60 @@
+/// Pluggable storage for the property bag carried by [GraphNode] and
+/// [GraphEdge].
+///
+/// Mirrors the role conduit core's `ManagedBacking` plays for
+/// `ManagedObject`: the property reads and writes go through a backing
+/// rather than directly into the node/edge subclass, so a backend can
+/// swap in a different implementation (lazy, partial-projection,
+/// dirty-tracking, …) without changing user code.
+///
+/// In v0 we ship one implementation — [GraphMapBacking], a plain
+/// in-memory map. Backends are free to provide their own.
+abstract class GraphBacking {
+  /// The current property bag.
+  ///
+  /// Backends may treat this as a live view or as a snapshot — callers
+  /// must not assume mutating the returned map mutates the backing.
+  Map<String, Object?> get contents;
+
+  /// Reads a property by name.
+  Object? valueForProperty(String name);
+
+  /// Writes a property by name.
+  void setValueForProperty(String name, Object? value);
+
+  /// Removes a property by name. Returns the previous value, if any.
+  Object? removeProperty(String name);
+
+  /// True iff [name] is present in the property bag.
+  bool hasProperty(String name);
+}
+
+/// Plain in-memory [GraphBacking].
+///
+/// Default backing for newly constructed nodes and edges. Stores
+/// properties in a `LinkedHashMap` so iteration order is stable
+/// (insertion order) — matters for renderers that emit deterministic
+/// query strings.
+class GraphMapBacking implements GraphBacking {
+  GraphMapBacking([Map<String, Object?>? initial])
+      : _contents = <String, Object?>{...?initial};
+
+  final Map<String, Object?> _contents;
+
+  @override
+  Map<String, Object?> get contents => _contents;
+
+  @override
+  Object? valueForProperty(String name) => _contents[name];
+
+  @override
+  void setValueForProperty(String name, Object? value) {
+    _contents[name] = value;
+  }
+
+  @override
+  Object? removeProperty(String name) => _contents.remove(name);
+
+  @override
+  bool hasProperty(String name) => _contents.containsKey(name);
+}

--- a/packages/graph/lib/src/types/graph_edge.dart
+++ b/packages/graph/lib/src/types/graph_edge.dart
@@ -1,0 +1,90 @@
+import 'graph_backing.dart';
+import 'graph_label.dart';
+import 'graph_node.dart';
+
+/// A typed graph edge — first-class value with its own property bag.
+///
+/// **Edge-properties are the reason this is a separate type system.**
+/// Foreign-key rows in a SQL ORM cannot represent properties on the
+/// relationship itself; graph databases can, and applications routinely
+/// rely on it (e.g. `(:User)-[:Friend {since: 2024-01-15}]->(:User)`).
+///
+/// Generic parameters are the **node types**, not labels — so the
+/// compiler enforces that you wire endpoints of the right shape:
+///
+/// ```dart
+/// class Friend extends GraphEdge<User, User> {
+///   Friend({required User from, required User to})
+///       : super(label: GraphLabel('Friend'), from: from, to: to);
+///
+///   DateTime get since => this['since'] as DateTime;
+///   set since(DateTime v) => this['since'] = v;
+/// }
+///
+/// // Compile-time error: Group is not a User.
+/// // Friend(from: someGroup, to: someUser);
+/// ```
+///
+/// An edge carries a single label (graph DBs typically don't allow
+/// multi-label edges, in contrast to nodes) and a [GraphBacking] for
+/// its properties.
+abstract class GraphEdge<From extends GraphNode<From>,
+    To extends GraphNode<To>> {
+  GraphEdge({
+    required this.label,
+    required this.from,
+    required this.to,
+    GraphBacking? backing,
+    this.id,
+  }) : backing = backing ?? GraphMapBacking();
+
+  /// The edge label / relationship type.
+  final GraphLabel label;
+
+  /// The source node.
+  final From from;
+
+  /// The target node.
+  final To to;
+
+  /// The property backing — read/write goes through this.
+  final GraphBacking backing;
+
+  /// The store-assigned id of this edge, or `null` if it has not been
+  /// persisted. Backends are responsible for setting this on
+  /// `createEdge`.
+  Object? id;
+
+  /// Convenience accessor — same as `backing.valueForProperty(name)`.
+  Object? operator [](String name) => backing.valueForProperty(name);
+
+  /// Convenience setter — same as `backing.setValueForProperty(name,
+  /// value)`.
+  void operator []=(String name, Object? value) =>
+      backing.setValueForProperty(name, value);
+
+  /// True iff [name] is present in the property bag.
+  bool hasProperty(String name) => backing.hasProperty(name);
+
+  /// Removes [name] from the property bag. Returns the prior value, if any.
+  Object? removeProperty(String name) => backing.removeProperty(name);
+
+  /// A read-only view of all properties.
+  Map<String, Object?> get properties =>
+      Map.unmodifiable(backing.contents);
+
+  /// Snapshot of this edge as a plain map: `{ id, label, from, to,
+  /// properties }`. Convenience for serialization / debugging.
+  Map<String, Object?> asMap() => <String, Object?>{
+        if (id != null) 'id': id,
+        'label': label.name,
+        'from': from.id,
+        'to': to.id,
+        'properties': Map<String, Object?>.from(backing.contents),
+      };
+
+  @override
+  String toString() => '$runtimeType(${from.runtimeType}'
+      '-[:${label.name}]->${to.runtimeType}, id=$id, '
+      'properties=${backing.contents})';
+}

--- a/packages/graph/lib/src/types/graph_label.dart
+++ b/packages/graph/lib/src/types/graph_label.dart
@@ -1,0 +1,37 @@
+/// A graph label.
+///
+/// Wraps a [String] so labels are not naked strings at API boundaries.
+/// Multi-label nodes are first-class in graph databases like Neo4j; a
+/// node carries a [List] of these.
+///
+/// Labels are case-sensitive and must be non-empty. By convention they
+/// match the corresponding Dart type name (e.g. `User`, `Friend`), but
+/// nothing in this package enforces that — the convention exists so a
+/// renderer can derive a default label from a [Type].
+final class GraphLabel {
+  /// Creates a label. Throws [ArgumentError] if [name] is empty.
+  GraphLabel(this.name) {
+    if (name.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'graph label must be non-empty');
+    }
+  }
+
+  /// `const`-friendly alternate constructor — skips the non-empty
+  /// check. Use only when the literal `name` is known to be valid at
+  /// authoring time (e.g. for default labels in subclass
+  /// constructors).
+  const GraphLabel.unchecked(this.name);
+
+  /// The label string as it appears in the underlying graph store.
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      other is GraphLabel && other.name == name;
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  String toString() => 'GraphLabel($name)';
+}

--- a/packages/graph/lib/src/types/graph_node.dart
+++ b/packages/graph/lib/src/types/graph_node.dart
@@ -1,0 +1,102 @@
+import 'graph_backing.dart';
+import 'graph_label.dart';
+
+/// A graph node — analogue of conduit core's `ManagedObject<T>`.
+///
+/// **Properties only, no foreign keys.** Edges are first-class values
+/// (see `GraphEdge`); a node never embeds a reference to another node.
+/// This is the load-bearing distinction from the SQL ORM and the
+/// reason conduit_graph is a parallel hierarchy rather than an adapter
+/// over `ManagedObject`.
+///
+/// Each node carries:
+///
+/// - a [labels] list — multi-label nodes are first-class in Neo4j
+/// - a [backing] — pluggable property storage (see [GraphBacking]);
+///   the default is an in-memory [GraphMapBacking]
+///
+/// User code subclasses this for each node type:
+///
+/// ```dart
+/// class User extends GraphNode<User> {
+///   User() : super(labels: [GraphLabel('User')]);
+///
+///   String get name => this['name'] as String;
+///   set name(String v) => this['name'] = v;
+///
+///   int get age => this['age'] as int;
+///   set age(int v) => this['age'] = v;
+/// }
+/// ```
+///
+/// The generic `T` lets the query DSL (`GraphQuery<T>`) carry the
+/// concrete node type through builder calls, the same way
+/// `ManagedObject<T>` flows through `Query<T>`.
+abstract class GraphNode<T extends GraphNode<T>> {
+  GraphNode({
+    required List<GraphLabel> labels,
+    GraphBacking? backing,
+    this.id,
+  })  : labels = List.unmodifiable(labels),
+        backing = backing ?? GraphMapBacking() {
+    if (labels.isEmpty) {
+      throw ArgumentError.value(
+        labels,
+        'labels',
+        'a graph node must declare at least one label',
+      );
+    }
+  }
+
+  /// The labels attached to this node, in declaration order.
+  final List<GraphLabel> labels;
+
+  /// The property backing — read/write goes through this.
+  final GraphBacking backing;
+
+  /// The store-assigned id of this node, or `null` if it has not been
+  /// persisted. Backends are responsible for setting this on `create`.
+  Object? id;
+
+  /// Convenience accessor — same as `backing.valueForProperty(name)`.
+  Object? operator [](String name) => backing.valueForProperty(name);
+
+  /// Convenience setter — same as `backing.setValueForProperty(name,
+  /// value)`.
+  void operator []=(String name, Object? value) =>
+      backing.setValueForProperty(name, value);
+
+  /// True iff [name] is present in the property bag.
+  bool hasProperty(String name) => backing.hasProperty(name);
+
+  /// Removes [name] from the property bag. Returns the prior value, if any.
+  Object? removeProperty(String name) => backing.removeProperty(name);
+
+  /// A read-only view of all properties.
+  Map<String, Object?> get properties =>
+      Map.unmodifiable(backing.contents);
+
+  /// Replaces all properties with [values]. Existing keys not present
+  /// in [values] are removed.
+  void readFromMap(Map<String, Object?> values) {
+    final keys = backing.contents.keys.toList();
+    for (final k in keys) {
+      backing.removeProperty(k);
+    }
+    values.forEach(backing.setValueForProperty);
+  }
+
+  /// Snapshot of this node as a plain map: `{ id, labels, properties
+  /// }`. Convenience for serialization / debugging.
+  Map<String, Object?> asMap() => <String, Object?>{
+        if (id != null) 'id': id,
+        'labels': labels.map((l) => l.name).toList(growable: false),
+        'properties': Map<String, Object?>.from(backing.contents),
+      };
+
+  @override
+  String toString() {
+    final lbls = labels.map((l) => l.name).join(':');
+    return '$runtimeType($lbls, id=$id, properties=${backing.contents})';
+  }
+}

--- a/packages/graph/lib/src/types/graph_property_type.dart
+++ b/packages/graph/lib/src/types/graph_property_type.dart
@@ -1,0 +1,49 @@
+/// Storage classes for graph properties.
+///
+/// Analogue of conduit core's `ManagedPropertyType` — but **labeling
+/// only**, not schema enforcement. Graph databases are flexible by
+/// nature; this enum exists so a backend can serialize Dart values
+/// faithfully (e.g. emit ISO-8601 for [datetime], JSON for [map]) and
+/// so a node/edge type can self-describe its properties for codegen
+/// and tooling. There is no `nullable` / `unique` / `indexed` flag set
+/// — those concepts belong to a schema layer that we deliberately do
+/// not ship in v0.
+enum GraphPropertyType {
+  /// A UTF-8 string.
+  string,
+
+  /// A 64-bit signed integer.
+  integer,
+
+  /// A 64-bit IEEE-754 double.
+  double,
+
+  /// A boolean.
+  bool,
+
+  /// A timestamp. Backends typically serialize to ISO-8601 / epoch ms.
+  datetime,
+
+  /// A homogeneous list of any of the scalar storage classes above.
+  list,
+
+  /// A string-keyed map. Backends typically serialize to JSON.
+  map,
+}
+
+/// Best-effort inference of a [GraphPropertyType] from a runtime value.
+///
+/// Returns `null` if [value] is `null` or its runtime type is not one
+/// of the supported storage classes — callers should treat that as
+/// "leave the property type unspecified" rather than as a failure.
+GraphPropertyType? inferGraphPropertyType(Object? value) {
+  if (value == null) return null;
+  if (value is String) return GraphPropertyType.string;
+  if (value is bool) return GraphPropertyType.bool;
+  if (value is int) return GraphPropertyType.integer;
+  if (value is double) return GraphPropertyType.double;
+  if (value is DateTime) return GraphPropertyType.datetime;
+  if (value is List) return GraphPropertyType.list;
+  if (value is Map) return GraphPropertyType.map;
+  return null;
+}

--- a/packages/graph/lib/src/types/graph_relationship_direction.dart
+++ b/packages/graph/lib/src/types/graph_relationship_direction.dart
@@ -1,0 +1,8 @@
+/// Direction of a graph relationship in pattern queries and traversals.
+///
+/// Cypher equivalents:
+///
+/// - [outgoing]   — `(a)-[:REL]->(b)`
+/// - [incoming]   — `(a)<-[:REL]-(b)`
+/// - [undirected] — `(a)-[:REL]-(b)`
+enum GraphRelationshipDirection { outgoing, incoming, undirected }

--- a/packages/graph/pubspec.yaml
+++ b/packages/graph/pubspec.yaml
@@ -1,0 +1,18 @@
+name: conduit_graph
+description: Type-system foundation for an Object-Graph Mapper (OGM) on top of conduit. Parallel to the SQL ORM — nodes, typed edges with edge-properties, and pattern queries — backend-agnostic.
+version: 6.0.0
+home: https://www.theconduit.dev
+repository: https://github.com/conduit-dart/conduit
+issue_tracker: https://github.com/conduit-dart/conduit/issues
+
+environment:
+  sdk: ">=3.12.0-0 <4.0.0"
+resolution: workspace
+
+dependencies:
+  collection: ^1.18.0
+  meta: ^1.12.0
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.25.2

--- a/packages/graph/test/conduit_graph_test.dart
+++ b/packages/graph/test/conduit_graph_test.dart
@@ -1,0 +1,437 @@
+import 'package:conduit_graph/conduit_graph.dart';
+import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// Test fixtures: tiny social graph (User)-[:Friend]->(User), (User)-[:Authored]->(Post).
+// ---------------------------------------------------------------------------
+
+class User extends GraphNode<User> {
+  User({String? name, int? age})
+      : super(labels: [GraphLabel('User')]) {
+    if (name != null) this['name'] = name;
+    if (age != null) this['age'] = age;
+  }
+
+  String? get name => this['name'] as String?;
+  set name(String? v) => this['name'] = v;
+
+  int? get age => this['age'] as int?;
+  set age(int? v) => this['age'] = v;
+}
+
+class Post extends GraphNode<Post> {
+  Post({String? title}) : super(labels: [GraphLabel('Post')]) {
+    if (title != null) this['title'] = title;
+  }
+
+  String? get title => this['title'] as String?;
+  set title(String? v) => this['title'] = v;
+}
+
+class Friend extends GraphEdge<User, User> {
+  Friend({required super.from, required super.to, DateTime? since})
+      : super(label: const GraphLabel.unchecked('Friend')) {
+    if (since != null) this['since'] = since;
+  }
+
+  DateTime? get since => this['since'] as DateTime?;
+  set since(DateTime? v) => this['since'] = v;
+}
+
+class Authored extends GraphEdge<User, Post> {
+  Authored({required super.from, required super.to})
+      : super(label: const GraphLabel.unchecked('Authored'));
+}
+
+// ---------------------------------------------------------------------------
+// Fake backend — records calls so tests can assert intent without a DB.
+// ---------------------------------------------------------------------------
+
+class _FakeGraphPersistentStore implements GraphPersistentStore {
+  final List<GraphPattern<dynamic>> matchCalls = [];
+  final List<GraphQuery<dynamic>> executeCalls = [];
+  final List<GraphNode<dynamic>> createCalls = [];
+  final List<GraphEdge<dynamic, dynamic>> createEdgeCalls = [];
+  final List<({String query, Map<String, Object?> params})> cypherCalls = [];
+  final List<({GraphNode<dynamic> from, Type kind, GraphRelationshipDirection dir})>
+      traverseCalls = [];
+
+  // Programmable return values.
+  List<GraphNode<dynamic>> matchReturn = [];
+  List<GraphNode<dynamic>> executeReturn = [];
+  List<GraphNode<dynamic>> traverseReturn = [];
+  List<Map<String, Object?>> cypherReturn = [];
+
+  int _nextNodeId = 1;
+  int _nextEdgeId = 1;
+  bool closed = false;
+
+  @override
+  Future<List<N>> match<N extends GraphNode<N>>(GraphPattern<N> pattern) async {
+    matchCalls.add(pattern);
+    return matchReturn.cast<N>();
+  }
+
+  @override
+  Future<List<N>> executeQuery<N extends GraphNode<N>>(GraphQuery<N> query) async {
+    executeCalls.add(query);
+    return executeReturn.cast<N>();
+  }
+
+  @override
+  Future<N> create<N extends GraphNode<N>>(N node) async {
+    node.id = _nextNodeId++;
+    createCalls.add(node);
+    return node;
+  }
+
+  @override
+  Future<E> createEdge<E extends GraphEdge<dynamic, dynamic>>(E edge) async {
+    edge.id = _nextEdgeId++;
+    createEdgeCalls.add(edge);
+    return edge;
+  }
+
+  @override
+  Future<List<N>> traverse<N extends GraphNode<N>>(
+    GraphNode<dynamic> from,
+    Type edgeKind, {
+    GraphRelationshipDirection direction = GraphRelationshipDirection.outgoing,
+  }) async {
+    traverseCalls.add((from: from, kind: edgeKind, dir: direction));
+    return traverseReturn.cast<N>();
+  }
+
+  @override
+  Future<List<Map<String, Object?>>> cypher(
+    String rawQuery, {
+    Map<String, Object?> params = const {},
+  }) async {
+    cypherCalls.add((query: rawQuery, params: params));
+    return cypherReturn;
+  }
+
+  @override
+  Future<void> close() async {
+    closed = true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('GraphLabel', () {
+    test('rejects empty names', () {
+      expect(() => GraphLabel(''), throwsArgumentError);
+    });
+
+    test('equality is by name', () {
+      expect(GraphLabel('User'), equals(GraphLabel('User')));
+      expect(GraphLabel('User'), isNot(equals(GraphLabel('user'))));
+    });
+  });
+
+  group('GraphNode', () {
+    test('instantiation requires at least one label', () {
+      expect(
+        () => _NoLabelNode(),
+        throwsArgumentError,
+      );
+    });
+
+    test('property get / set go through the backing', () {
+      final u = User(name: 'alice', age: 30);
+      expect(u.name, 'alice');
+      expect(u.age, 30);
+      expect(u['name'], 'alice');
+
+      u['email'] = 'a@example.com';
+      expect(u.hasProperty('email'), isTrue);
+      expect(u.removeProperty('email'), 'a@example.com');
+      expect(u.hasProperty('email'), isFalse);
+    });
+
+    test('properties view is unmodifiable', () {
+      final u = User(name: 'alice');
+      expect(() => u.properties['name'] = 'bob', throwsUnsupportedError);
+    });
+
+    test('readFromMap replaces the entire property bag', () {
+      final u = User(name: 'alice', age: 30);
+      u.readFromMap({'name': 'bob'});
+      expect(u.name, 'bob');
+      expect(u.hasProperty('age'), isFalse);
+    });
+
+    test('asMap snapshot includes labels and properties', () {
+      final u = User(name: 'alice');
+      u.id = 42;
+      final snap = u.asMap();
+      expect(snap['id'], 42);
+      expect(snap['labels'], ['User']);
+      expect((snap['properties'] as Map)['name'], 'alice');
+    });
+  });
+
+  group('GraphEdge', () {
+    test('carries from / to / properties', () {
+      final a = User(name: 'alice')..id = 1;
+      final b = User(name: 'bob')..id = 2;
+      final f = Friend(from: a, to: b, since: DateTime.utc(2024, 1, 15));
+
+      expect(f.from, same(a));
+      expect(f.to, same(b));
+      expect(f.label, equals(GraphLabel('Friend')));
+      expect(f.since, DateTime.utc(2024, 1, 15));
+      expect(f['since'], isA<DateTime>());
+    });
+
+    test('endpoints are compile-time-typed by generics', () {
+      // This test exists mostly as documentation; the real
+      // enforcement is the fact that the next line would not compile:
+      //   Friend(from: Post(), to: User());
+      final a = User(name: 'a');
+      final p = Post(title: 't');
+      final authored = Authored(from: a, to: p);
+      expect(authored.from, same(a));
+      expect(authored.to, same(p));
+    });
+  });
+
+  group('GraphPattern', () {
+    test('builds an anchor with no relationships by default', () {
+      final p = GraphPattern<User>.build((u) {}, variable: 'u');
+      expect(p.root.variable, 'u');
+      expect(p.root.label.name, 'User');
+      expect(p.root.relationships, isEmpty);
+    });
+
+    test('connectedTo records direction and edge label', () {
+      final p = GraphPattern<User>.build(
+        (u) => u.connectedTo<Friend>(
+          direction: GraphRelationshipDirection.outgoing,
+        ),
+      );
+      expect(p.root.relationships, hasLength(1));
+      final r = p.root.relationships.first;
+      expect(r.edgeLabel.name, 'Friend');
+      expect(r.edgeType, Friend);
+      expect(r.direction, GraphRelationshipDirection.outgoing);
+    });
+
+    test('connectedTo can pin terminal label/type/variable', () {
+      final p = GraphPattern<User>.build(
+        (u) => u.connectedTo<Authored>(
+          toLabel: GraphLabel('Post'),
+          toType: Post,
+          toVariable: 'p',
+        ),
+      );
+      final r = p.root.relationships.first;
+      expect(r.toLabel?.name, 'Post');
+      expect(r.toType, Post);
+      expect(r.toVariable, 'p');
+    });
+  });
+
+  group('GraphQuery filter AST', () {
+    test('where compiles a closure to a structured filter', () {
+      final q = GraphQuery<User>(
+        pattern: GraphPattern<User>.build((_) {}),
+      ).where((u) => u['age'].greaterThan(21));
+
+      final f = q.filter;
+      expect(f, isA<GraphPropertyFilter>());
+      final pf = f! as GraphPropertyFilter;
+      expect(pf.property, 'age');
+      expect(pf.operator, GraphFilterOperator.greaterThan);
+      expect(pf.value, 21);
+    });
+
+    test('chained where ANDs predicates together', () {
+      final q = GraphQuery<User>(pattern: GraphPattern<User>.build((_) {}))
+          .where((u) => u['age'].greaterThan(21))
+          .where((u) => u['name'].equalTo('alice'));
+
+      final f = q.filter;
+      expect(f, isA<GraphCompoundFilter>());
+      final cf = f! as GraphCompoundFilter;
+      expect(cf.combinator, GraphFilterCombinator.and);
+      expect(cf.children, hasLength(2));
+    });
+
+    test('compound expressions support OR via the filter API', () {
+      final q = GraphQuery<User>(pattern: GraphPattern<User>.build((_) {}))
+          .where(
+        (u) => u['age'].lessThan(18).or(u['age'].greaterThan(65)),
+      );
+
+      final f = q.filter;
+      expect(f, isA<GraphCompoundFilter>());
+      final cf = f! as GraphCompoundFilter;
+      expect(cf.combinator, GraphFilterCombinator.or);
+    });
+
+    test('limitTo / offsetBy reject negatives', () {
+      final q = GraphQuery<User>(pattern: GraphPattern<User>.build((_) {}));
+      expect(() => q.limitTo(-1), throwsA(isA<GraphInvalidQuery>()));
+      expect(() => q.offsetBy(-1), throwsA(isA<GraphInvalidQuery>()));
+    });
+
+    test('orderByProperty appends terms in order', () {
+      final q = GraphQuery<User>(pattern: GraphPattern<User>.build((_) {}))
+          .orderByProperty('name')
+          .orderByProperty('age', direction: GraphSortDirection.descending);
+      expect(q.orderBy.map((o) => o.property), ['name', 'age']);
+      expect(q.orderBy.last.direction, GraphSortDirection.descending);
+    });
+
+    test('detached fetch (no executor) throws', () {
+      final q = GraphQuery<User>(pattern: GraphPattern<User>.build((_) {}));
+      expect(q.fetch, throwsA(isA<GraphInvalidQuery>()));
+    });
+  });
+
+  group('GraphContext + GraphDataModel', () {
+    test('registers node and edge types', () {
+      final ctx = GraphContext.withTypes(
+        persistentStore: _FakeGraphPersistentStore(),
+        registerNodes: (m) {
+          m.registerNode<User>();
+          m.registerNode<Post>();
+        },
+        registerEdges: (m) {
+          m.registerEdge<Friend, User, User>();
+          m.registerEdge<Authored, User, Post>();
+        },
+      );
+
+      expect(ctx.dataModel.isRegistered(User), isTrue);
+      expect(ctx.dataModel.isRegistered(Friend), isTrue);
+      expect(ctx.dataModel.nodeEntityFor(User).label.name, 'User');
+      expect(ctx.dataModel.edgeEntityFor(Authored).fromType, User);
+      expect(ctx.dataModel.edgeEntityFor(Authored).toType, Post);
+    });
+
+    test('looking up an unregistered type throws GraphInvalidQuery', () {
+      final ctx = GraphContext.withTypes(
+        persistentStore: _FakeGraphPersistentStore(),
+      );
+      expect(
+        () => ctx.dataModel.nodeEntityFor(User),
+        throwsA(isA<GraphInvalidQuery>()),
+      );
+    });
+
+    test('match builds a runnable query bound to the store', () async {
+      final fake = _FakeGraphPersistentStore();
+      final ctx = GraphContext.withTypes(
+        persistentStore: fake,
+        registerNodes: (m) => m.registerNode<User>(),
+      );
+
+      fake.executeReturn = [User(name: 'alice')];
+
+      final results = await ctx.graph
+          .match<User>((u) => u.connectedTo<Friend>())
+          .where((u) => u['age'].greaterThan(21))
+          .fetch();
+
+      expect(fake.executeCalls, hasLength(1));
+      final q = fake.executeCalls.single as GraphQuery<User>;
+      expect(q.pattern.root.label.name, 'User');
+      expect(q.pattern.root.relationships.single.edgeLabel.name, 'Friend');
+      expect(q.filter, isA<GraphPropertyFilter>());
+      expect(results.single.name, 'alice');
+    });
+
+    test('insertNode + insertEdge round-trip through the store', () async {
+      final fake = _FakeGraphPersistentStore();
+      final ctx = GraphContext(GraphDataModel(), fake);
+
+      final alice = await ctx.insertNode(User(name: 'alice'));
+      final bob = await ctx.insertNode(User(name: 'bob'));
+      final f = await ctx.insertEdge(Friend(from: alice, to: bob));
+
+      expect(alice.id, 1);
+      expect(bob.id, 2);
+      expect(f.id, 1);
+      expect(fake.createCalls, hasLength(2));
+      expect(fake.createEdgeCalls.single, same(f));
+    });
+
+    test('cypher escape hatch is surfaced on context and store', () async {
+      final fake = _FakeGraphPersistentStore()
+        ..cypherReturn = [
+          {'n.name': 'alice'}
+        ];
+      final ctx = GraphContext(GraphDataModel(), fake);
+
+      final rows = await ctx.cypher(
+        'MATCH (n:User) WHERE n.age > \$min RETURN n.name',
+        params: {'min': 21},
+      );
+
+      expect(fake.cypherCalls.single.query, contains('MATCH (n:User)'));
+      expect(fake.cypherCalls.single.params, {'min': 21});
+      expect(rows.single['n.name'], 'alice');
+    });
+
+    test('traverse delegates direction + edge kind to the store', () async {
+      final fake = _FakeGraphPersistentStore();
+      final ctx = GraphContext(GraphDataModel(), fake);
+      final alice = User(name: 'alice')..id = 1;
+
+      await ctx.traverse<User>(alice, Friend,
+          direction: GraphRelationshipDirection.incoming);
+
+      expect(fake.traverseCalls.single.kind, Friend);
+      expect(
+        fake.traverseCalls.single.dir,
+        GraphRelationshipDirection.incoming,
+      );
+    });
+
+    test('close is delegated to the underlying store', () async {
+      final fake = _FakeGraphPersistentStore();
+      final ctx = GraphContext(GraphDataModel(), fake);
+      await ctx.close();
+      expect(fake.closed, isTrue);
+    });
+  });
+
+  group('GraphPropertyType inference', () {
+    test('maps common Dart values to storage classes', () {
+      expect(inferGraphPropertyType('hi'), GraphPropertyType.string);
+      expect(inferGraphPropertyType(true), GraphPropertyType.bool);
+      expect(inferGraphPropertyType(42), GraphPropertyType.integer);
+      expect(inferGraphPropertyType(3.14), GraphPropertyType.double);
+      expect(inferGraphPropertyType(DateTime.now()), GraphPropertyType.datetime);
+      expect(inferGraphPropertyType([1, 2]), GraphPropertyType.list);
+      expect(inferGraphPropertyType({'a': 1}), GraphPropertyType.map);
+      expect(inferGraphPropertyType(null), isNull);
+    });
+  });
+
+  group('Errors', () {
+    test('exception types are distinct GraphException subclasses', () {
+      expect(GraphConnectionError('x'), isA<GraphException>());
+      expect(GraphConstraintViolation('x'), isA<GraphException>());
+      expect(GraphNotFoundError('x'), isA<GraphException>());
+      expect(GraphInvalidQuery('x'), isA<GraphException>());
+    });
+
+    test('toString includes message and cause when present', () {
+      final e = GraphConnectionError('boom', cause: 'inner');
+      expect(e.toString(), contains('boom'));
+      expect(e.toString(), contains('inner'));
+    });
+  });
+}
+
+// Helper for the "no labels" test — bypasses `User` constructor's defaulting.
+class _NoLabelNode extends GraphNode<_NoLabelNode> {
+  _NoLabelNode() : super(labels: const []);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ workspace:
   - packages/common
   - packages/config
   - packages/core
+  - packages/graph
   - packages/isolate_exec
   - packages/open_api
   - packages/password_hash
@@ -80,6 +81,7 @@ melos:
                             -V conduit_common:$v \
                             -V conduit_config:$v \
                             -V conduit_core:$v \
+                            -V conduit_graph:$v \
                             -V conduit_isolate_exec:$v \
                             -V conduit_open_api:$v \
                             -V conduit_password_hash:$v \


### PR DESCRIPTION
## Summary

Phase 6a of the Conduit ORM strategy: a focused, design-only PR that lays the type-system foundation for an Object-Graph Mapper. The Neo4j backend that consumes this is the follow-up phase (P6b) and is **not** part of this PR.

### Why a parallel hierarchy, not a generalization of `ManagedObject`

Conduit's `ManagedObject<T>`, `ManagedRelationshipType` (`hasOne` / `hasMany` / `belongsTo`), `Schema*`, and `QueryPredicate.format` are SQL-bound. Forcing graph concepts onto them creates a graph adapter that pretends to be SQL — wrong abstraction. Graph backends need first-class typed edges *with their own properties* (which SQL FKs cannot represent — this is the load-bearing distinction), multi-label nodes, pattern-based queries, and a schemaless property bag. So `conduit_graph` is a **parallel** hierarchy: `GraphNode<T>` rhymes with `ManagedObject<T>` but does not inherit from it; `GraphPersistentStore` rhymes with `PersistentStore` but does not inherit from it. Apps that need both can hold a `ManagedContext` and a `GraphContext` side by side on `ApplicationChannel`.

### Public surfaces

- **Types** — `GraphNode<T>`, `GraphEdge<From, To>`, `GraphLabel`, `GraphPropertyType`, `GraphRelationshipDirection`, pluggable `GraphBacking` (default `GraphMapBacking`)
- **Errors** — sealed `GraphException` + `GraphConnectionError`, `GraphConstraintViolation`, `GraphNotFoundError`, `GraphInvalidQuery` (deliberately not subclassing `QueryException`)
- **Store** — `GraphPersistentStore` abstract contract: `match`, `executeQuery`, `create`, `createEdge`, `traverse`, `cypher`, `close`
- **Context** — `GraphContext` + `GraphContext.withTypes(...)` factory; entry point `ctx.graph.match<User>((u) => u.connectedTo<Friend>()).where(...).fetch()`
- **Data model** — `GraphDataModel` registry of node and edge type entities
- **Query DSL** — closure-built `GraphPattern` + chainable `GraphQuery<N>`. The `where` closure compiles to a structured `GraphFilterExpression` AST (with `GraphPropertyFilter`, `GraphCompoundFilter`, `GraphNotFilter`) — **not** to a `QueryPredicate.format` string. Backends render the AST in their native dialect (Cypher in P6b).

### `cypher()` escape hatch (deliberate design choice)

Every `GraphPersistentStore` exposes `cypher(rawQuery, params: ...)` from day one. The closure DSL won't cover everything (recursive paths, vendor procedures, custom projections); surfacing the escape hatch immediately keeps users from hitting a wall the first time they need something the DSL can't express. Documented prominently in the README.

### What we deliberately don't ship in v0

- No migration system (graph migrations are out of scope; raw Cypher scripts for now)
- No `Schema*` enforcement (`GraphPropertyType` labels properties for serialization only)
- No backend (this PR is the abstraction; P6b ships `conduit_neo4j`)
- Not added as a dependency of any other package — graph is opt-in

### Verification

- `dart analyze .` in `packages/graph` — **no issues found**
- `melos run analyze` across the workspace — **clean** for `conduit_graph` and no regressions in other packages (the few `info`-level lints elsewhere are pre-existing)
- `dart test` in `packages/graph` — **28 tests pass**
- Workspace registration via `pubspec.yaml`; `melos exec --scope conduit_graph -- "dart test"` succeeds

### Follow-up

P6b — `conduit_neo4j`, a `GraphPersistentStore` backed by the Bolt protocol that consumes the AST emitted by `GraphQuery.fetch()` and round-trips results into typed `GraphNode<T>` subclasses.

Generated with [Claude Code](https://claude.com/claude-code)