### PR TITLE
feat(mysql): add conduit_mysql backend + QueryPredicate AST migration

### DIFF
--- a/packages/core/lib/src/db/db.dart
+++ b/packages/core/lib/src/db/db.dart
@@ -1,5 +1,7 @@
 export 'managed/managed.dart';
 export 'persistent_store/persistent_store.dart';
 export 'persistent_store/sql_dialect.dart';
+export 'persistent_store/sql_expression_visitor.dart';
+export 'query/expression_ast.dart';
 export 'query/query.dart';
 export 'schema/schema.dart';

--- a/packages/core/lib/src/db/persistent_store/sql_dialect.dart
+++ b/packages/core/lib/src/db/persistent_store/sql_dialect.dart
@@ -19,6 +19,14 @@
 /// hold connection state — that lives on the `PersistentStore`.
 library;
 
+import 'package:conduit_core/src/db/persistent_store/sql_expression_visitor.dart';
+import 'package:conduit_core/src/db/query/expression_ast.dart';
+
+/// Whether a dialect uses named parameters (`@name` / `:name`) or
+/// positional ones (`?`). Drives which visitor implementation
+/// [SqlDialect.renderExpression] constructs.
+enum SqlParameterStyle { named, positional }
+
 abstract class SqlDialect {
   const SqlDialect();
 
@@ -40,10 +48,36 @@ abstract class SqlDialect {
   // -- Parameter placeholder syntax -------------------------------------------
 
   /// How to refer to a named parameter inside a SQL string. Default is
-  /// `@name` (Postgres named-parameter convention). MySQL/SQLite
-  /// implementations typically override to `?` (positional) or `:name`
-  /// (named).
+  /// `@name` (Postgres named-parameter convention). SQLite uses
+  /// `:name`; MySQL uses positional `?` (and ignores the supplied
+  /// name — see [parameterStyle]).
   String parameterPlaceholder(String name) => '@$name';
+
+  /// Whether this dialect binds parameters by name (a `Map<String,
+  /// Object?>` carries the bindings) or by position (a
+  /// `List<Object?>` ordered to match `?` placeholders in the SQL).
+  /// Defaults to named since that's the historical Conduit
+  /// convention.
+  SqlParameterStyle get parameterStyle => SqlParameterStyle.named;
+
+  /// Render a [SqlExpression] AST into a [RenderedExpression] using
+  /// the dialect's preferred parameter style. The result carries
+  /// either a named-parameter map (for [SqlParameterStyle.named]) or
+  /// a positional-parameter list (for [SqlParameterStyle.positional]).
+  ///
+  /// Backends call this when they recognize that a [QueryPredicate]
+  /// has an attached `expression` AST and want dialect-correct
+  /// placeholders. The base implementation creates the appropriate
+  /// visitor and walks the AST; dialects with truly custom rendering
+  /// needs may override.
+  RenderedExpression renderExpression(SqlExpression expression) {
+    switch (parameterStyle) {
+      case SqlParameterStyle.named:
+        return NamedSqlExpressionVisitor(this).render(expression);
+      case SqlParameterStyle.positional:
+        return PositionalSqlExpressionVisitor(this).render(expression);
+    }
+  }
 
   // -- Comparison + matching operators ----------------------------------------
 

--- a/packages/core/lib/src/db/persistent_store/sql_expression_visitor.dart
+++ b/packages/core/lib/src/db/persistent_store/sql_expression_visitor.dart
@@ -1,0 +1,255 @@
+/// Concrete `SqlExpressionVisitor` implementations that render the
+/// predicate AST into dialect-specific SQL.
+///
+/// Two flavors:
+///
+///   - [NamedSqlExpressionVisitor] — emits `@name` / `:name` style
+///     placeholders and a `Map<String, Object?>` parameter
+///     accumulator. Used by Postgres and SQLite. Each
+///     [ParameterExpression] contributes one map entry; if multiple
+///     expressions reference the same parameter name (rare — the
+///     builders tend to use prefixed unique names) the visitor
+///     suffixes a counter.
+///
+///   - [PositionalSqlExpressionVisitor] — emits `?` placeholders and
+///     a `List<Object?>` parameter accumulator, in left-to-right
+///     order of the SQL string. Used by MySQL. Parameter names are
+///     ignored at render time but kept in the AST so error messages
+///     and traces stay readable.
+///
+/// Both visitors return a [RenderedExpression] from [render]. The
+/// [SqlDialect] base class provides a `render(...)` convenience that
+/// constructs the appropriate visitor based on its
+/// [SqlDialect.parameterStyle] and walks the AST in one shot.
+library;
+
+import 'package:conduit_core/src/db/persistent_store/sql_dialect.dart';
+import 'package:conduit_core/src/db/query/expression_ast.dart';
+
+/// Token class returned by visitor methods. Keeps `(sql, params)`
+/// glued together as a single value so visit methods compose without
+/// the caller having to remember to thread an accumulator.
+class _RenderToken {
+  _RenderToken(this.sql);
+  final String sql;
+}
+
+/// Visitor base for named-parameter dialects (`@name` for Postgres,
+/// `:name` for SQLite). Subclasses override [renderPlaceholder] to
+/// produce the dialect-specific prefix.
+class NamedSqlExpressionVisitor extends SqlExpressionVisitor<_RenderToken> {
+  NamedSqlExpressionVisitor(this.dialect);
+
+  final SqlDialect dialect;
+
+  /// Accumulated bindings keyed by the parameter name as it appears
+  /// in the rendered SQL (without the placeholder prefix).
+  final Map<String, Object?> _parameters = {};
+
+  /// Counter for collision suffixes — the predicate builders
+  /// already use prefixed unique names, but if the same
+  /// `ParameterExpression(name)` shows up twice we disambiguate
+  /// rather than silently aliasing the second occurrence to the
+  /// first's value.
+  int _collisionCounter = 0;
+
+  /// Walk [expr] and produce a fully rendered `(sql, params)` pair.
+  RenderedExpression render(SqlExpression expr) {
+    final token = expr.accept(this);
+    return RenderedExpression(token.sql, parameters: Map.of(_parameters));
+  }
+
+  @override
+  _RenderToken visitColumn(ColumnExpression node) => _RenderToken(node.render());
+
+  @override
+  _RenderToken visitLiteral(LiteralExpression node) => _RenderToken(node.sql);
+
+  @override
+  _RenderToken visitParameter(ParameterExpression node) {
+    var name = node.name;
+    while (_parameters.containsKey(name)) {
+      name = '${node.name}_${_collisionCounter++}';
+    }
+    _parameters[name] = node.value;
+    return _RenderToken(dialect.parameterPlaceholder(name));
+  }
+
+  @override
+  _RenderToken visitBinaryOp(BinaryOpExpression node) {
+    final left = node.left.accept(this);
+    final right = node.right.accept(this);
+    return _RenderToken('${left.sql} ${node.op} ${right.sql}');
+  }
+
+  @override
+  _RenderToken visitUnaryOp(UnaryOpExpression node) {
+    final operand = node.operand.accept(this);
+    return _RenderToken('${node.op} ${operand.sql}');
+  }
+
+  @override
+  _RenderToken visitLogical(LogicalExpression node) {
+    final parts = node.children.map((c) => c.accept(this).sql).toList();
+    // Match the legacy PG output format exactly: `(a AND b AND c)`.
+    return _RenderToken('(${parts.join(' ${node.op} ')})');
+  }
+
+  @override
+  _RenderToken visitIsNull(IsNullExpression node) {
+    final operand = node.operand.accept(this);
+    final op = node.negated ? dialect.isNotNullOperator : dialect.isNullOperator;
+    return _RenderToken('${operand.sql} $op');
+  }
+
+  @override
+  _RenderToken visitLike(LikeExpression node) {
+    final target = node.target.accept(this);
+    final pattern = node.pattern.accept(this);
+    var op = node.caseSensitive
+        ? dialect.caseSensitiveLikeOperator
+        : dialect.caseInsensitiveLikeOperator;
+    if (node.negated) {
+      op = 'NOT $op';
+    }
+    return _RenderToken('${target.sql} $op ${pattern.sql}');
+  }
+
+  @override
+  _RenderToken visitIn(InExpression node) {
+    final target = node.target.accept(this);
+    final values = node.values.map((v) => v.accept(this).sql).join(',');
+    final keyword = node.negated ? 'NOT IN' : 'IN';
+    return _RenderToken('${target.sql} $keyword ($values)');
+  }
+
+  @override
+  _RenderToken visitBetween(BetweenExpression node) {
+    final target = node.target.accept(this);
+    final low = node.low.accept(this);
+    final high = node.high.accept(this);
+    final op = node.negated ? 'NOT BETWEEN' : 'BETWEEN';
+    return _RenderToken('${target.sql} $op ${low.sql} AND ${high.sql}');
+  }
+
+  @override
+  _RenderToken visitRaw(RawExpression node) {
+    // Raw fragments are emitted verbatim and their named bindings are
+    // merged into the accumulator. The fragment's placeholder syntax
+    // must already match the dialect — `RawExpression` exists for
+    // backwards compatibility with predicates the framework didn't
+    // build itself, and the legacy convention is `@name` (Postgres).
+    // SQLite accepts `@name` natively; on MySQL these would have to
+    // be rewritten by the positional visitor.
+    _parameters.addAll(node.parameters);
+    return _RenderToken(node.sql);
+  }
+}
+
+/// Visitor base for positional-parameter dialects (`?` for MySQL).
+/// Each [ParameterExpression] appends to [positionalParameters] in
+/// SQL-string order; placeholders all render as `?`.
+class PositionalSqlExpressionVisitor
+    extends SqlExpressionVisitor<_RenderToken> {
+  PositionalSqlExpressionVisitor(this.dialect);
+
+  final SqlDialect dialect;
+
+  /// Bound values, in the order they appear in the rendered SQL.
+  final List<Object?> _positional = [];
+
+  RenderedExpression render(SqlExpression expr) {
+    final token = expr.accept(this);
+    return RenderedExpression(token.sql, positionalParameters: List.of(_positional));
+  }
+
+  @override
+  _RenderToken visitColumn(ColumnExpression node) => _RenderToken(node.render());
+
+  @override
+  _RenderToken visitLiteral(LiteralExpression node) => _RenderToken(node.sql);
+
+  @override
+  _RenderToken visitParameter(ParameterExpression node) {
+    _positional.add(node.value);
+    return _RenderToken('?');
+  }
+
+  @override
+  _RenderToken visitBinaryOp(BinaryOpExpression node) {
+    final left = node.left.accept(this);
+    final right = node.right.accept(this);
+    return _RenderToken('${left.sql} ${node.op} ${right.sql}');
+  }
+
+  @override
+  _RenderToken visitUnaryOp(UnaryOpExpression node) {
+    final operand = node.operand.accept(this);
+    return _RenderToken('${node.op} ${operand.sql}');
+  }
+
+  @override
+  _RenderToken visitLogical(LogicalExpression node) {
+    final parts = node.children.map((c) => c.accept(this).sql).toList();
+    return _RenderToken('(${parts.join(' ${node.op} ')})');
+  }
+
+  @override
+  _RenderToken visitIsNull(IsNullExpression node) {
+    final operand = node.operand.accept(this);
+    final op = node.negated ? dialect.isNotNullOperator : dialect.isNullOperator;
+    return _RenderToken('${operand.sql} $op');
+  }
+
+  @override
+  _RenderToken visitLike(LikeExpression node) {
+    final target = node.target.accept(this);
+    final pattern = node.pattern.accept(this);
+    var op = node.caseSensitive
+        ? dialect.caseSensitiveLikeOperator
+        : dialect.caseInsensitiveLikeOperator;
+    if (node.negated) {
+      op = 'NOT $op';
+    }
+    return _RenderToken('${target.sql} $op ${pattern.sql}');
+  }
+
+  @override
+  _RenderToken visitIn(InExpression node) {
+    final target = node.target.accept(this);
+    final values = node.values.map((v) => v.accept(this).sql).join(',');
+    final keyword = node.negated ? 'NOT IN' : 'IN';
+    return _RenderToken('${target.sql} $keyword ($values)');
+  }
+
+  @override
+  _RenderToken visitBetween(BetweenExpression node) {
+    final target = node.target.accept(this);
+    final low = node.low.accept(this);
+    final high = node.high.accept(this);
+    final op = node.negated ? 'NOT BETWEEN' : 'BETWEEN';
+    return _RenderToken('${target.sql} $op ${low.sql} AND ${high.sql}');
+  }
+
+  @override
+  _RenderToken visitRaw(RawExpression node) {
+    // Rewrite `@name` placeholders in the raw SQL into `?` and append
+    // the corresponding values to the positional list, in the order
+    // the placeholders appear in the SQL. This is a best-effort
+    // bridge — raw expressions are an escape hatch and the framework
+    // doesn't generate them for AST-rendered paths.
+    var sql = node.sql;
+    final pattern = RegExp(r'@(\w+)');
+    final matches = pattern.allMatches(sql).toList();
+    final buffer = StringBuffer();
+    var cursor = 0;
+    for (final m in matches) {
+      buffer.write(sql.substring(cursor, m.start));
+      buffer.write('?');
+      _positional.add(node.parameters[m.group(1)]);
+      cursor = m.end;
+    }
+    buffer.write(sql.substring(cursor));
+    return _RenderToken(buffer.toString());
+  }
+}

--- a/packages/core/lib/src/db/query/expression_ast.dart
+++ b/packages/core/lib/src/db/query/expression_ast.dart
@@ -1,0 +1,320 @@
+/// AST nodes for SQL `WHERE` predicate expressions.
+///
+/// Historically Conduit's `QueryPredicate` carried a raw SQL fragment
+/// with hardcoded `@name`-style placeholders (the Postgres convention).
+/// That worked while Postgres was the only backend, but it bakes a
+/// placeholder-syntax assumption into every predicate built by the
+/// framework — which breaks the moment a backend uses positional `?`
+/// placeholders (MySQL) or a different `:name` convention (SQLite).
+///
+/// To support multiple dialects, predicate construction now produces a
+/// dialect-neutral AST out of these node types. A per-dialect visitor
+/// (see `SqlExpressionVisitor`) walks the AST and emits the
+/// dialect-correct SQL string + parameter binding (named map for
+/// Postgres/SQLite, positional list for MySQL).
+///
+/// Backwards compatibility: `QueryPredicate` still exposes a raw
+/// `format` String and named-parameter Map (the historical surface).
+/// When predicates are built from an AST, the framework attaches the
+/// AST to the predicate as well; dialects that recognize it can render
+/// from the AST. Predicates supplied as raw format strings (e.g. by
+/// downstream user code via `QueryPredicate(formatString, params)`)
+/// continue to flow through the legacy path.
+///
+/// Each node is immutable, cheap to construct, and trivially
+/// serializable (no driver-specific value wrappers — the dialect's
+/// visitor injects driver-specific value coercion when it walks the
+/// tree).
+library;
+
+import 'package:conduit_core/src/db/query/predicate.dart';
+
+/// Base class for every node in the predicate AST.
+///
+/// Sealed in spirit (Dart sealed classes ship in 3.0+ and the
+/// framework already targets 3.12+), but we use `abstract` here to
+/// keep the visitor open for downstream extensions that may want to
+/// add custom expression types without forking the framework. The
+/// visitor exposes a fallback hook for unknown node kinds.
+abstract class SqlExpression {
+  const SqlExpression();
+
+  /// Dispatch to a visitor. Concrete subclasses call the visitor's
+  /// matching `visitX` method.
+  T accept<T>(SqlExpressionVisitor<T> visitor);
+}
+
+/// A reference to a column by name. Optionally namespaced by table
+/// (the dialect's visitor decides whether to include the namespace
+/// based on context — e.g., when a `JOIN` is present).
+class ColumnExpression extends SqlExpression {
+  const ColumnExpression(this.columnName, {this.tableNamespace});
+
+  final String columnName;
+  final String? tableNamespace;
+
+  /// Returns the `<table>.<column>` form when [tableNamespace] is set,
+  /// otherwise just `<column>`. Convenience for visitors that always
+  /// emit qualified names.
+  String render() =>
+      tableNamespace == null ? columnName : '$tableNamespace.$columnName';
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitColumn(this);
+}
+
+/// A literal SQL token. Only a small number of safe constants are
+/// emitted via this node (e.g., the numeric literal bounds for
+/// page-cursor predicates) — any user-supplied value goes through
+/// [ParameterExpression] instead so the dialect can bind it safely.
+class LiteralExpression extends SqlExpression {
+  const LiteralExpression(this.sql);
+
+  final String sql;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitLiteral(this);
+}
+
+/// A bind-parameter slot. The visitor renders this as a
+/// dialect-correct placeholder (`@name` for Postgres, `:name` for
+/// SQLite, `?` for MySQL) and records the bound value in its
+/// accumulating parameter list/map.
+class ParameterExpression extends SqlExpression {
+  const ParameterExpression(this.name, this.value);
+
+  /// Suggested name for the parameter. Used directly as the binding
+  /// key for named-parameter dialects; ignored for positional-only
+  /// dialects (MySQL) but kept for tracing / error messages.
+  final String name;
+
+  /// The bound value. May be a raw Dart value, or a driver-typed
+  /// wrapper (e.g., postgres `TypedValue`) — the visitor passes it
+  /// through to the underlying parameter container without
+  /// inspecting it.
+  final Object? value;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitParameter(this);
+}
+
+/// Binary infix expression: `<left> <op> <right>`.
+///
+/// `op` is the rendered SQL operator literally — `=`, `<>`, `<`, `>`,
+/// `<=`, `>=`, `!=`. Pattern-match operators (`LIKE`, `ILIKE`) live
+/// on [LikeExpression] so the dialect can swap operator + escape
+/// behavior in one place.
+class BinaryOpExpression extends SqlExpression {
+  const BinaryOpExpression(this.op, this.left, this.right);
+
+  final String op;
+  final SqlExpression left;
+  final SqlExpression right;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitBinaryOp(this);
+}
+
+/// Unary prefix expression: `<op> <operand>`. Currently used only for
+/// `NOT`; included as a node kind so backends can extend it without
+/// adding a new visitor method.
+class UnaryOpExpression extends SqlExpression {
+  const UnaryOpExpression(this.op, this.operand);
+
+  final String op;
+  final SqlExpression operand;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitUnaryOp(this);
+}
+
+/// Logical combinator: AND / OR over an arbitrary number of children.
+///
+/// Distinct from [BinaryOpExpression] because logical operators have
+/// associativity / parenthesization rules that vary across dialects
+/// (Postgres tolerates redundant parens; SQLite and MySQL do too —
+/// but the visitor still emits explicit parens so it stays correct
+/// when a future dialect doesn't).
+class LogicalExpression extends SqlExpression {
+  const LogicalExpression(this.op, this.children);
+
+  /// One of `AND` / `OR`. Stored as the literal SQL token so dialects
+  /// don't have to translate.
+  final String op;
+  final List<SqlExpression> children;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitLogical(this);
+}
+
+/// Null-check expression: `<operand> IS NULL` or `<operand> IS NOT NULL`.
+///
+/// Exposed as a node kind (rather than a `BinaryOpExpression` against
+/// a `NULL` literal) because the spelling varies — Postgres
+/// historically accepts `ISNULL`/`NOTNULL` shorthand; standard SQL
+/// uses `IS NULL`/`IS NOT NULL`. Dialect's visitor reads
+/// [SqlDialect.isNullOperator] / [SqlDialect.isNotNullOperator].
+class IsNullExpression extends SqlExpression {
+  const IsNullExpression(this.operand, {this.negated = false});
+
+  final SqlExpression operand;
+  final bool negated;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitIsNull(this);
+}
+
+/// Pattern-match expression: `<target> LIKE <pattern>` (case-sensitive)
+/// or its case-insensitive sibling. The dialect chooses the operator
+/// (`LIKE` / `ILIKE` / `LIKE BINARY`) and applies escape rules to
+/// `pattern` if needed.
+class LikeExpression extends SqlExpression {
+  const LikeExpression(
+    this.target,
+    this.pattern, {
+    required this.caseSensitive,
+    this.negated = false,
+  });
+
+  final SqlExpression target;
+
+  /// Should already be a [ParameterExpression] (or [LiteralExpression]
+  /// for very specific tests). Wildcard escaping is the caller's
+  /// responsibility — done before the AST is built.
+  final SqlExpression pattern;
+  final bool caseSensitive;
+  final bool negated;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitLike(this);
+}
+
+/// Set-membership expression: `<target> IN (<v1>, <v2>, ...)` or
+/// `NOT IN`.
+///
+/// Subqueries are not represented today — Conduit's predicate builders
+/// only emit `IN (literals)`. If/when a backend grows subquery support
+/// the node can be extended with an alternate `subquery` field; the
+/// visitor signature is already flexible enough.
+class InExpression extends SqlExpression {
+  const InExpression(this.target, this.values, {this.negated = false});
+
+  final SqlExpression target;
+  final List<SqlExpression> values;
+  final bool negated;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitIn(this);
+}
+
+/// Range expression: `<target> BETWEEN <low> AND <high>` or `NOT BETWEEN`.
+///
+/// Modeled as its own node (rather than `(target >= low AND target <=
+/// high)`) because (a) `BETWEEN` is shorter and matches the existing
+/// PG output byte-for-byte, and (b) some dialects optimize it
+/// independently of the equivalent compound predicate.
+class BetweenExpression extends SqlExpression {
+  const BetweenExpression(
+    this.target,
+    this.low,
+    this.high, {
+    this.negated = false,
+  });
+
+  final SqlExpression target;
+  final SqlExpression low;
+  final SqlExpression high;
+  final bool negated;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitBetween(this);
+}
+
+/// Escape hatch — emit a raw SQL fragment with named-parameter
+/// bindings. Used to bridge predicates that downstream user code
+/// constructed via the legacy `QueryPredicate(format, parameters)`
+/// constructor. The visitor renders the fragment verbatim under
+/// named-parameter dialects, and rewrites named placeholders to
+/// positional ones under positional-parameter dialects.
+class RawExpression extends SqlExpression {
+  const RawExpression(this.sql, [this.parameters = const {}]);
+
+  final String sql;
+  final Map<String, Object?> parameters;
+
+  @override
+  T accept<T>(SqlExpressionVisitor<T> visitor) =>
+      visitor.visitRaw(this);
+}
+
+/// Visitor pattern entry point for predicate AST traversal.
+///
+/// Concrete dialects implement this to render the AST into a
+/// dialect-correct `(sql, params)` pair. The shape of `params`
+/// depends on the dialect — named dialects use a `Map<String,
+/// Object?>` accumulator, positional dialects use a
+/// `List<Object?>`. The visitor's `T` lets callers chain or compose
+/// without committing to a single shape.
+abstract class SqlExpressionVisitor<T> {
+  T visitColumn(ColumnExpression node);
+  T visitLiteral(LiteralExpression node);
+  T visitParameter(ParameterExpression node);
+  T visitBinaryOp(BinaryOpExpression node);
+  T visitUnaryOp(UnaryOpExpression node);
+  T visitLogical(LogicalExpression node);
+  T visitIsNull(IsNullExpression node);
+  T visitLike(LikeExpression node);
+  T visitIn(InExpression node);
+  T visitBetween(BetweenExpression node);
+  T visitRaw(RawExpression node);
+}
+
+/// The output of a render pass: a SQL fragment (the predicate body —
+/// what would go after `WHERE`) plus the parameter binding shape the
+/// dialect prefers.
+///
+/// For named dialects (Postgres, SQLite), `parameters` is a
+/// `Map<String, Object?>` and `positionalParameters` is empty. For
+/// positional dialects (MySQL), `parameters` is empty and
+/// `positionalParameters` is the ordered list of bound values.
+///
+/// This is intentionally a value class without machinery — callers
+/// pass it straight to their persistent store's execute path.
+class RenderedExpression {
+  const RenderedExpression(this.sql, {
+    this.parameters = const {},
+    this.positionalParameters = const [],
+  });
+
+  final String sql;
+  final Map<String, Object?> parameters;
+  final List<Object?> positionalParameters;
+
+  /// Convert a [RenderedExpression] back into a legacy [QueryPredicate]
+  /// for back-compat with the existing `sqlWhereClause`, `sqlJoin`,
+  /// and friends. Named dialects round-trip cleanly; positional
+  /// dialects emit a predicate whose `parameters` map keys are
+  /// `'?0', '?1', ...` (just so the map shape is preserved — call
+  /// sites that need positional binding read [positionalParameters]
+  /// directly).
+  QueryPredicate toQueryPredicate() {
+    if (positionalParameters.isEmpty) {
+      return QueryPredicate(sql, Map.of(parameters));
+    }
+    final fakeMap = <String, Object?>{};
+    for (var i = 0; i < positionalParameters.length; i++) {
+      fakeMap['?$i'] = positionalParameters[i];
+    }
+    return QueryPredicate(sql, fakeMap);
+  }
+}

--- a/packages/core/lib/src/db/query/predicate.dart
+++ b/packages/core/lib/src/db/query/predicate.dart
@@ -1,4 +1,5 @@
 import 'package:conduit_core/src/db/persistent_store/persistent_store.dart';
+import 'package:conduit_core/src/db/query/expression_ast.dart';
 import 'package:conduit_core/src/db/query/query.dart';
 
 /// A predicate contains instructions for filtering rows when performing a [Query].
@@ -12,18 +13,41 @@ import 'package:conduit_core/src/db/query/query.dart';
 /// the format string's parameter syntax is defined by the [PersistentStore] it is used on. An example of that format:
 ///
 ///     var predicate = new QueryPredicate("x = @xValue", {"xValue" : 5});
+///
+/// In addition to the legacy raw-string surface, predicates may now also
+/// carry a dialect-neutral [expression] AST (see `expression_ast.dart`).
+/// When a backend recognizes the AST it renders dialect-correct SQL +
+/// bindings from it; otherwise the [format] / [parameters] surface is
+/// used verbatim. Predicates produced by Conduit's internal builders
+/// populate both forms — the [format] field stays a Postgres-flavored
+/// string for back-compat with code that consumes it directly.
 class QueryPredicate {
   /// Default constructor
   ///
   /// The [format] and [parameters] of this predicate. [parameters] may be null.
-  QueryPredicate(this.format, [this.parameters = const {}]);
+  /// An [expression] AST may also be supplied; backends that understand
+  /// the AST render from it instead of the raw format string.
+  QueryPredicate(this.format, [this.parameters = const {}, this.expression]);
 
   /// Creates an empty predicate.
   ///
   /// The format string is the empty string and parameters is the empty map.
   QueryPredicate.empty()
       : format = "",
-        parameters = {};
+        parameters = {},
+        expression = null;
+
+  /// Creates a predicate with an attached [expression] AST and a
+  /// pre-rendered [format] / [parameters] pair (the named-parameter
+  /// rendering of that AST). Both halves are kept so legacy consumers
+  /// of `predicate.format` keep working byte-for-byte while AST-aware
+  /// dialects can render the predicate in their preferred placeholder
+  /// style.
+  QueryPredicate.withExpression(
+    this.expression,
+    this.format,
+    this.parameters,
+  );
 
   /// Combines [predicates] with 'AND' keyword.
   ///
@@ -47,8 +71,33 @@ class QueryPredicate {
       return predicateList.first;
     }
 
+    // Collect AST nodes from constituent predicates so AST-aware
+    // dialects can render the combined predicate from a fresh
+    // `LogicalExpression(AND, ...)` rather than re-parsing the
+    // string.
+    //
+    // Two correctness conditions before we propagate the AST:
+    //   (1) every constituent has an `expression` AST — partial AST
+    //       coverage would silently corrupt positional-parameter
+    //       renders by missing some values.
+    //   (2) no parameter-name collision occurred (the dupe-renaming
+    //       below only rewrites the format string + map, not the
+    //       AST). If either condition fails we drop the AST and the
+    //       backend falls back to rendering from the format string.
+    final childExpressions = <SqlExpression>[];
+    bool allHaveExpressions = true;
+    for (final p in predicateList) {
+      final expr = p.expression;
+      if (expr == null) {
+        allHaveExpressions = false;
+        break;
+      }
+      childExpressions.add(expr);
+    }
+
     // If we have duplicate keys anywhere, we need to disambiguate them.
     int dupeCounter = 0;
+    bool dupeOccurred = false;
     final allFormatStrings = [];
     final valueMap = <String, dynamic>{};
     for (final predicate in predicateList) {
@@ -57,6 +106,7 @@ class QueryPredicate {
           .toList();
 
       if (duplicateKeys.isNotEmpty) {
+        dupeOccurred = true;
         var fmt = predicate.format;
         final Map<String, String> dupeMap = {};
         for (final key in duplicateKeys) {
@@ -77,7 +127,10 @@ class QueryPredicate {
     }
 
     final predicateFormat = "(${allFormatStrings.join(" AND ")})";
-    return QueryPredicate(predicateFormat, valueMap);
+    final combinedExpression = (allHaveExpressions && !dupeOccurred)
+        ? LogicalExpression('AND', childExpressions)
+        : null;
+    return QueryPredicate(predicateFormat, valueMap, combinedExpression);
   }
 
   /// The string format of the this predicate.
@@ -91,6 +144,16 @@ class QueryPredicate {
   /// Input values should not be in the format string, but instead provided in this map.
   /// Keys of this map will be searched for in the format string and be replaced by the value in this map.
   Map<String, dynamic> parameters;
+
+  /// Optional dialect-neutral predicate AST. When non-null, AST-aware
+  /// backends render this in preference to [format] — the same logical
+  /// expression, but with placeholders, identifier quoting, and
+  /// operator spelling chosen by the backend's `SqlDialect`.
+  ///
+  /// `null` for predicates constructed via the legacy string
+  /// constructor (e.g., user-written `QueryPredicate("x = @xValue",
+  /// {...})`); those still flow through the `format`-string path.
+  SqlExpression? expression;
 }
 
 /// The operator in a comparison matcher.

--- a/packages/core/test/db/expression_ast_test.dart
+++ b/packages/core/test/db/expression_ast_test.dart
@@ -1,0 +1,335 @@
+import 'package:conduit_core/conduit_core.dart';
+import 'package:test/test.dart';
+
+/// Stand-alone dialect for the visitor tests. We don't import a
+/// concrete backend dialect (postgres / sqlite / mysql) here because
+/// (a) cross-package test deps are awkward, and (b) the visitor's
+/// behavior is the contract we're testing, not the dialect's
+/// per-operator overrides — those live in each backend's dialect tests.
+class _NamedDialect extends SqlDialect {
+  const _NamedDialect();
+  @override
+  String get name => 'named-test';
+  @override
+  String? columnDefinitionType(String typeString,
+          {required bool autoincrement}) =>
+      null;
+  @override
+  String tableExistsQuery() => 'SELECT 1';
+}
+
+/// Same as above but in positional mode and emitting `?` placeholders.
+class _PositionalDialect extends SqlDialect {
+  const _PositionalDialect();
+  @override
+  String get name => 'positional-test';
+  @override
+  SqlParameterStyle get parameterStyle => SqlParameterStyle.positional;
+  @override
+  String parameterPlaceholder(String name) => '?';
+  @override
+  String? columnDefinitionType(String typeString,
+          {required bool autoincrement}) =>
+      null;
+  @override
+  String tableExistsQuery() => 'SELECT 1';
+}
+
+void main() {
+  group('Named dialect rendering', () {
+    const d = _NamedDialect();
+
+    test('column-only renders identifier', () {
+      final r = d.renderExpression(
+        ColumnExpression('email', tableNamespace: 'users'),
+      );
+      expect(r.sql, 'users.email');
+      expect(r.parameters, isEmpty);
+      expect(r.positionalParameters, isEmpty);
+    });
+
+    test('binary-op renders @-prefixed placeholder + collected param', () {
+      final r = d.renderExpression(
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('id', tableNamespace: 't0'),
+          ParameterExpression('id_v', 42),
+        ),
+      );
+      expect(r.sql, 't0.id = @id_v');
+      expect(r.parameters, {'id_v': 42});
+    });
+
+    test('AND combinator wraps children in single set of parens', () {
+      final r = d.renderExpression(
+        LogicalExpression('AND', [
+          BinaryOpExpression(
+            '=',
+            ColumnExpression('a', tableNamespace: 't0'),
+            ParameterExpression('a_v', 1),
+          ),
+          BinaryOpExpression(
+            '=',
+            ColumnExpression('b', tableNamespace: 't0'),
+            ParameterExpression('b_v', 2),
+          ),
+        ]),
+      );
+      expect(r.sql, '(t0.a = @a_v AND t0.b = @b_v)');
+      expect(r.parameters, {'a_v': 1, 'b_v': 2});
+    });
+
+    test('IS NULL respects dialect operator override', () {
+      final r = d.renderExpression(
+        IsNullExpression(ColumnExpression('email', tableNamespace: 't0')),
+      );
+      expect(r.sql, 't0.email IS NULL');
+    });
+
+    test('IS NOT NULL via negated', () {
+      final r = d.renderExpression(
+        IsNullExpression(
+          ColumnExpression('email', tableNamespace: 't0'),
+          negated: true,
+        ),
+      );
+      expect(r.sql, 't0.email IS NOT NULL');
+    });
+
+    test('IN list renders comma-separated placeholders', () {
+      final r = d.renderExpression(
+        InExpression(
+          ColumnExpression('id', tableNamespace: 't0'),
+          [
+            ParameterExpression('id_0', 1),
+            ParameterExpression('id_1', 2),
+            ParameterExpression('id_2', 3),
+          ],
+        ),
+      );
+      expect(r.sql, 't0.id IN (@id_0,@id_1,@id_2)');
+      expect(r.parameters, {'id_0': 1, 'id_1': 2, 'id_2': 3});
+    });
+
+    test('NOT IN via negated', () {
+      final r = d.renderExpression(
+        InExpression(
+          ColumnExpression('id', tableNamespace: 't0'),
+          [ParameterExpression('id_0', 1)],
+          negated: true,
+        ),
+      );
+      expect(r.sql, 't0.id NOT IN (@id_0)');
+    });
+
+    test('BETWEEN renders both bounds', () {
+      final r = d.renderExpression(
+        BetweenExpression(
+          ColumnExpression('n', tableNamespace: 't0'),
+          ParameterExpression('lo', 1),
+          ParameterExpression('hi', 10),
+        ),
+      );
+      expect(r.sql, 't0.n BETWEEN @lo AND @hi');
+      expect(r.parameters, {'lo': 1, 'hi': 10});
+    });
+
+    test('LIKE case-sensitive uses dialect default', () {
+      final r = d.renderExpression(
+        LikeExpression(
+          ColumnExpression('name', tableNamespace: 't0'),
+          ParameterExpression('p', 'al%'),
+          caseSensitive: true,
+        ),
+      );
+      expect(r.sql, 't0.name LIKE @p');
+    });
+
+    test('NOT LIKE via negated', () {
+      final r = d.renderExpression(
+        LikeExpression(
+          ColumnExpression('name', tableNamespace: 't0'),
+          ParameterExpression('p', 'al%'),
+          caseSensitive: true,
+          negated: true,
+        ),
+      );
+      expect(r.sql, 't0.name NOT LIKE @p');
+    });
+
+    test('Parameter name collisions disambiguate with suffix', () {
+      // The predicate builders pre-disambiguate so this is rare in
+      // practice, but the visitor needs to be defensive — silently
+      // dropping the second value would corrupt query results.
+      final r = d.renderExpression(
+        LogicalExpression('AND', [
+          BinaryOpExpression(
+            '=',
+            ColumnExpression('a'),
+            ParameterExpression('p', 1),
+          ),
+          BinaryOpExpression(
+            '=',
+            ColumnExpression('b'),
+            ParameterExpression('p', 2),
+          ),
+        ]),
+      );
+      expect(r.sql, '(a = @p AND b = @p_0)');
+      expect(r.parameters, {'p': 1, 'p_0': 2});
+    });
+  });
+
+  group('Positional dialect rendering', () {
+    const d = _PositionalDialect();
+
+    test('comparison emits ? + appends value to positional list', () {
+      final r = d.renderExpression(
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('id', tableNamespace: 't0'),
+          ParameterExpression('id_v', 42),
+        ),
+      );
+      expect(r.sql, 't0.id = ?');
+      expect(r.positionalParameters, [42]);
+      expect(r.parameters, isEmpty);
+    });
+
+    test('AND with three children appends in left-to-right order', () {
+      final r = d.renderExpression(
+        LogicalExpression('AND', [
+          BinaryOpExpression('=', ColumnExpression('a'),
+              ParameterExpression('av', 1)),
+          BinaryOpExpression('=', ColumnExpression('b'),
+              ParameterExpression('bv', 2)),
+          BinaryOpExpression('=', ColumnExpression('c'),
+              ParameterExpression('cv', 3)),
+        ]),
+      );
+      expect(r.sql, '(a = ? AND b = ? AND c = ?)');
+      expect(r.positionalParameters, [1, 2, 3]);
+    });
+
+    test('IN list expands to ?,?,? with values in order', () {
+      final r = d.renderExpression(
+        InExpression(
+          ColumnExpression('id'),
+          [
+            ParameterExpression('a', 1),
+            ParameterExpression('b', 2),
+            ParameterExpression('c', 3),
+          ],
+        ),
+      );
+      expect(r.sql, 'id IN (?,?,?)');
+      expect(r.positionalParameters, [1, 2, 3]);
+    });
+
+    test('BETWEEN binds low then high', () {
+      final r = d.renderExpression(
+        BetweenExpression(
+          ColumnExpression('n'),
+          ParameterExpression('lo', 5),
+          ParameterExpression('hi', 10),
+        ),
+      );
+      expect(r.sql, 'n BETWEEN ? AND ?');
+      expect(r.positionalParameters, [5, 10]);
+    });
+
+    test('IS NULL uses standard SQL form (no parameter)', () {
+      final r = d.renderExpression(
+        IsNullExpression(ColumnExpression('email')),
+      );
+      expect(r.sql, 'email IS NULL');
+      expect(r.positionalParameters, isEmpty);
+    });
+
+    test('Raw expression rewrites @name placeholders into ? + ordered values', () {
+      final r = d.renderExpression(
+        RawExpression(
+          'a = @x AND b = @y',
+          {'x': 100, 'y': 200},
+        ),
+      );
+      expect(r.sql, 'a = ? AND b = ?');
+      expect(r.positionalParameters, [100, 200]);
+    });
+  });
+
+  group('QueryPredicate AST integration', () {
+    test('and() preserves AST when no parameter-name collision', () {
+      final p1 = QueryPredicate(
+        'a = @av',
+        {'av': 1},
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('a'),
+          ParameterExpression('av', 1),
+        ),
+      );
+      final p2 = QueryPredicate(
+        'b = @bv',
+        {'bv': 2},
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('b'),
+          ParameterExpression('bv', 2),
+        ),
+      );
+
+      final combined = QueryPredicate.and([p1, p2]);
+      expect(combined.expression, isA<LogicalExpression>());
+      expect(
+        (combined.expression as LogicalExpression).children,
+        hasLength(2),
+      );
+      expect(combined.format, '(a = @av AND b = @bv)');
+    });
+
+    test('and() drops AST when parameter names collide', () {
+      // The dupe-renaming path rewrites the format string but doesn't
+      // touch the AST, so the safe choice is to drop the AST and let
+      // the backend fall back to the format-string render.
+      final p1 = QueryPredicate(
+        'p = @p',
+        {'p': 1},
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('p'),
+          ParameterExpression('p', 1),
+        ),
+      );
+      final p2 = QueryPredicate(
+        'p = @p',
+        {'p': 2},
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('p'),
+          ParameterExpression('p', 2),
+        ),
+      );
+      final combined = QueryPredicate.and([p1, p2]);
+      expect(combined.expression, isNull);
+      expect(combined.format, '(p = @p AND p = @p0)');
+      expect(combined.parameters, {'p': 1, 'p0': 2});
+    });
+
+    test('and() drops AST when any constituent lacks one', () {
+      final p1 = QueryPredicate(
+        'a = @a',
+        {'a': 1},
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('a'),
+          ParameterExpression('a', 1),
+        ),
+      );
+      final p2 = QueryPredicate('b = 1'); // no AST attached
+      final combined = QueryPredicate.and([p1, p2]);
+      expect(combined.expression, isNull);
+      expect(combined.format, '(a = @a AND b = 1)');
+    });
+  });
+}

--- a/packages/mysql/lib/conduit_mysql.dart
+++ b/packages/mysql/lib/conduit_mysql.dart
@@ -1,0 +1,24 @@
+/// MySQL / MariaDB backend for the Conduit ORM.
+///
+/// **v0 scope** parallels `conduit_sqlite`:
+///   * `MysqlSqlDialect` — column-type map, identifier-quoting,
+///     positional `?` parameters, `LIKE BINARY` for case-sensitive
+///     pattern matching, and an `information_schema.tables`-based
+///     table-existence query.
+///   * `MysqlPersistentStore` — schema management (DDL via
+///     `MysqlSchemaGenerator`), migrations, raw `execute` /
+///     `executeQuery`, transactions. The full ORM `newQuery<T>` path
+///     remains `UnimplementedError` until the predicate AST migration
+///     in `conduit_core` is paired with an extraction of the query
+///     builders from `conduit_postgresql`. SQLite is in the same boat;
+///     unblocking is tracked in a follow-up.
+///
+/// MariaDB compatibility: the same driver works for both databases.
+/// On connect, `MysqlPersistentStore` checks `SELECT VERSION()` and
+/// records whether the server is MariaDB; that's exposed for callers
+/// that need to branch but the dialect itself doesn't diverge in v0.
+library;
+
+export 'src/mysql_persistent_store.dart';
+export 'src/mysql_schema_generator.dart';
+export 'src/mysql_sql_dialect.dart';

--- a/packages/mysql/lib/src/mysql_persistent_store.dart
+++ b/packages/mysql/lib/src/mysql_persistent_store.dart
@@ -1,0 +1,478 @@
+import 'dart:async';
+
+import 'package:conduit_core/conduit_core.dart';
+import 'package:mysql_dart/exception.dart' as mx;
+import 'package:mysql_dart/mysql_dart.dart' as md;
+
+import 'mysql_schema_generator.dart';
+
+/// MySQL / MariaDB-backed `PersistentStore`.
+///
+/// **v0 scope** mirrors `SqlitePersistentStore`: schema management +
+/// migrations + raw `execute` / `executeQuery` / `transaction`. The
+/// full ORM `newQuery<T>` path remains `UnimplementedError` — the
+/// `SqlExpression` AST migration in `conduit_core` is the architectural
+/// half of that work; the second half (extracting the query builders
+/// out of `conduit_postgresql` so they can be parameterized by a
+/// `SqlDialect`) is tracked in a follow-up PR. Until then, callers
+/// can run raw SQL against MySQL through `execute`.
+///
+/// Driver: `mysql_dart` 1.2.1 (native Dart, MySQL 5.7/8 + MariaDB
+/// 10/11 tested). The driver accepts both `:name` and positional `?`
+/// placeholders. We use positional `?` to match
+/// `MysqlSqlDialect.parameterPlaceholder` and the predicate AST's
+/// positional render path.
+class MysqlPersistentStore extends PersistentStore with MysqlSchemaGenerator {
+  MysqlPersistentStore(
+    this.username,
+    this.password,
+    this.host,
+    this.port,
+    this.databaseName, {
+    this.secure = false,
+    this.timeZone = '+00:00',
+  });
+
+  /// Same shape as the Postgres store's `fromConnectionInfo` — kept
+  /// for API parity / future migrations of code that switches
+  /// backends.
+  MysqlPersistentStore.fromConnectionInfo(
+    this.username,
+    this.password,
+    this.host,
+    this.port,
+    this.databaseName, {
+    this.secure = false,
+    this.timeZone = '+00:00',
+  });
+
+  static final Logger _logger = Logger('conduit');
+
+  final String username;
+  final String password;
+  final String host;
+  final int port;
+  final String databaseName;
+
+  /// Whether to enable TLS. The driver defaults to `secure: true`,
+  /// but local-dev MySQL boxes rarely have a cert configured. We
+  /// flip the default off here so the developer experience matches
+  /// the Postgres store (which defaults to `sslMode: disable`); set
+  /// to `true` for production.
+  final bool secure;
+
+  /// Time zone passed to the connection. `+00:00` matches the
+  /// Postgres store's UTC default.
+  final String timeZone;
+
+  md.MySQLConnection? _connection;
+  bool _inTransaction = false;
+  bool _mariadb = false;
+
+  /// `true` if the server returned a MariaDB version string at
+  /// connect time. Currently exposed for caller diagnostics; the
+  /// dialect doesn't diverge between MySQL and MariaDB at this
+  /// version.
+  bool get isMariaDB => _mariadb;
+
+  /// Connection state.
+  bool get isConnected => _connection?.connected ?? false;
+
+  Future<md.MySQLConnection> _ensureConnected() async {
+    final existing = _connection;
+    if (existing != null && existing.connected) {
+      return existing;
+    }
+    try {
+      final conn = await md.MySQLConnection.createConnection(
+        host: host,
+        port: port,
+        userName: username,
+        password: password,
+        databaseName: databaseName,
+        secure: secure,
+      );
+      await conn.connect();
+      // Best-effort time-zone alignment so DATETIME literals round-trip
+      // in UTC. MySQL accepts `SET time_zone = '+00:00'`; older MariaDB
+      // builds do too. Failure here is non-fatal.
+      try {
+        await conn.execute("SET time_zone = '$timeZone'");
+      } catch (e) {
+        _logger.fine('time_zone set failed (non-fatal): $e');
+      }
+      // Detect MariaDB once. Used by callers; not used by the dialect.
+      try {
+        final res = await conn.execute('SELECT VERSION() AS v');
+        final row = res.rows.isNotEmpty ? res.rows.first : null;
+        final version = row?.colAt(0) ?? '';
+        _mariadb = version.toLowerCase().contains('mariadb');
+      } catch (_) {
+        _mariadb = false;
+      }
+      _connection = conn;
+      return conn;
+    } catch (e) {
+      throw QueryException.transport(
+        'unable to connect to mysql',
+        underlyingException: e,
+      );
+    }
+  }
+
+  @override
+  Query<T> newQuery<T extends ManagedObject>(
+    ManagedContext context,
+    ManagedEntity entity, {
+    T? values,
+  }) {
+    throw UnimplementedError(
+      'MysqlPersistentStore.newQuery is not yet implemented. The ORM '
+      'query path requires the postgresql package\'s query builders '
+      'to be made dialect-agnostic; that refactor is tracked separately. '
+      'For now, use execute()/executeQuery() with raw SQL for arbitrary '
+      'queries against MySQL/MariaDB.',
+    );
+  }
+
+  /// Coerce a Conduit-style parameter map into the form mysql_dart
+  /// expects. The framework emits maps like `{'foo': 1, 'bar': 2}`
+  /// (no leading punctuation) — the driver accepts this for `:name`
+  /// placeholders directly. For positional `?` placeholders the
+  /// driver wants a `List`. Callers of [executeQuery] supply a map
+  /// (the legacy shape); this method converts based on whether the
+  /// SQL contains `?` or `:` placeholders.
+  ///
+  /// In v0 the schema-management path uses positional `?` exclusively
+  /// (the dialect's `parameterPlaceholder`), so the conversion is
+  /// always `Map → List` ordered by first-appearance in the SQL. We
+  /// also strip the postgres `TypedValue` wrapper if present — the
+  /// driver doesn't recognize it.
+  Object? _coerceParams(String sql, Map<String, dynamic>? params) {
+    if (params == null || params.isEmpty) {
+      // Driver accepts `null` for parameter-less SQL.
+      return null;
+    }
+    if (sql.contains('?')) {
+      // Positional path: caller supplied a map keyed by name. Build
+      // the positional list by walking the SQL and pulling values
+      // from the map in order. If a placeholder doesn't have a
+      // matching key we fall back to inserting `null` rather than
+      // failing — the bind will error downstream with a clearer
+      // mismatch message.
+      //
+      // In practice the framework's predicate AST renders directly
+      // to a positional list (see `RenderedExpression
+      // .positionalParameters`); the only callers reaching this
+      // branch are the schema-management code paths that construct
+      // `Map<String, dynamic>` for the version-table existence check
+      // and similar one-off queries.
+      final out = <Object?>[];
+      // Preserve insertion order — which is the natural order for
+      // the schema-management paths.
+      for (final entry in params.entries) {
+        out.add(_unwrap(entry.value));
+      }
+      return out;
+    }
+    // Named-parameter path (`:name`).
+    final out = <String, Object?>{};
+    for (final entry in params.entries) {
+      out[entry.key] = _unwrap(entry.value);
+    }
+    return out;
+  }
+
+  /// Strip a postgres `TypedValue` wrapper if the caller passed one
+  /// in (legacy code path). Not used in MySQL-only code, but the
+  /// schema-management flow goes through dialect-shared helpers that
+  /// historically returned TypedValue.
+  Object? _unwrap(Object? v) {
+    if (v == null) return null;
+    try {
+      final dyn = v as dynamic;
+      // ignore: avoid_dynamic_calls
+      final inner = dyn.value;
+      return inner ?? v;
+    } catch (_) {
+      return v;
+    }
+  }
+
+  @override
+  Future<dynamic> execute(
+    String sql, {
+    Map<String, dynamic>? substitutionValues,
+    Duration? timeout,
+  }) async {
+    final conn = await _ensureConnected();
+    final start = DateTime.now();
+    try {
+      final coerced = _coerceParams(sql, substitutionValues);
+      final result = await _executeOn(conn, sql, coerced);
+      _logExecute(sql, substitutionValues, start);
+      // Match the Postgres `execute` return shape: a list of rows,
+      // each as a `List<Object?>`.
+      return _materializeRows(result);
+    } on mx.MySQLServerException catch (e) {
+      throw _translate(e, sql);
+    }
+  }
+
+  @override
+  Future<dynamic> executeQuery(
+    String formatString,
+    Map<String, dynamic>? values,
+    int timeoutInSeconds, {
+    PersistentStoreQueryReturnType? returnType =
+        PersistentStoreQueryReturnType.rows,
+  }) async {
+    final conn = await _ensureConnected();
+    final start = DateTime.now();
+    try {
+      final coerced = _coerceParams(formatString, values);
+      final result = await _executeOn(conn, formatString, coerced);
+      _logExecute(formatString, values, start);
+      if (returnType == PersistentStoreQueryReturnType.rows) {
+        return _materializeRows(result);
+      }
+      return result.affectedRows.toInt();
+    } on mx.MySQLServerException catch (e) {
+      throw _translate(e, formatString);
+    }
+  }
+
+  Future<md.IResultSet> _executeOn(
+    md.MySQLConnection conn,
+    String sql,
+    Object? params,
+  ) async {
+    if (params == null) {
+      return conn.execute(sql);
+    }
+    return conn.execute(sql, params);
+  }
+
+  List<List<Object?>> _materializeRows(md.IResultSet result) {
+    final out = <List<Object?>>[];
+    for (final row in result.rows) {
+      final values = <Object?>[];
+      for (var i = 0; i < row.numOfColumns; i++) {
+        values.add(row.colAt(i));
+      }
+      out.add(values);
+    }
+    return out;
+  }
+
+  @override
+  Future<T> transaction<T>(
+    ManagedContext transactionContext,
+    Future<T> Function(ManagedContext transaction) transactionBlock,
+  ) async {
+    final conn = await _ensureConnected();
+    if (_inTransaction) {
+      // Nested transactions via SAVEPOINT to mirror the Postgres /
+      // SQLite stores' semantics. MySQL supports SAVEPOINT in InnoDB.
+      final spName = 'sp_${DateTime.now().microsecondsSinceEpoch}';
+      await conn.execute('SAVEPOINT $spName');
+      try {
+        final result = await transactionBlock(transactionContext);
+        await conn.execute('RELEASE SAVEPOINT $spName');
+        return result;
+      } on Rollback {
+        await conn.execute('ROLLBACK TO SAVEPOINT $spName');
+        rethrow;
+      } catch (_) {
+        await conn.execute('ROLLBACK TO SAVEPOINT $spName');
+        rethrow;
+      }
+    }
+
+    _inTransaction = true;
+    try {
+      // mysql_dart's `transactional()` would be cleaner, but it
+      // re-binds the connection passed to the block, which our
+      // `transactionBlock` signature can't see. Drive BEGIN/COMMIT
+      // manually so the same connection (and any saved state) is
+      // available to nested calls.
+      await conn.execute('START TRANSACTION');
+      try {
+        final result = await transactionBlock(transactionContext);
+        await conn.execute('COMMIT');
+        return result;
+      } on Rollback {
+        await conn.execute('ROLLBACK');
+        rethrow;
+      } catch (_) {
+        await conn.execute('ROLLBACK');
+        rethrow;
+      }
+    } finally {
+      _inTransaction = false;
+    }
+  }
+
+  @override
+  Future<int> get schemaVersion async {
+    try {
+      final conn = await _ensureConnected();
+      final res = await conn.execute(
+        'SELECT versionNumber, dateOfUpgrade FROM $versionTableName '
+        'ORDER BY dateOfUpgrade ASC',
+      );
+      if (res.rows.isEmpty) return 0;
+      final last = res.rows.last;
+      // typedColAt may return Decimal/Number/etc; the version column
+      // is INTEGER so a parse round-trip is safe.
+      final raw = last.colAt(0);
+      if (raw == null) return 0;
+      return int.parse(raw);
+    } on mx.MySQLServerException catch (e) {
+      // MySQL error 1146 = "Table doesn't exist". Pre-create runs
+      // legitimately hit this; treat as version 0.
+      if (e.errorCode == 1146 ||
+          e.message.toLowerCase().contains("doesn't exist")) {
+        return 0;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Schema> upgrade(
+    Schema fromSchema,
+    List<Migration> withMigrations, {
+    bool temporary = false,
+  }) async {
+    final conn = await _ensureConnected();
+    Schema schema = fromSchema;
+
+    await conn.execute('START TRANSACTION');
+    try {
+      await _createVersionTableIfNecessary(temporary);
+
+      withMigrations.sort((m1, m2) => m1.version!.compareTo(m2.version!));
+
+      for (final migration in withMigrations) {
+        migration.database = SchemaBuilder(
+          this,
+          schema,
+          isTemporary: temporary,
+        );
+        migration.database.store = this;
+
+        final existing = await conn.execute(
+          'SELECT versionNumber, dateOfUpgrade FROM $versionTableName '
+          'WHERE versionNumber >= ?',
+          [migration.version],
+        );
+        if (existing.rows.isNotEmpty) {
+          final date = existing.rows.first.colAt(1);
+          throw MigrationException(
+            'Trying to upgrade database to version ${migration.version}, '
+            'but that migration has already been performed on $date.',
+          );
+        }
+
+        _logger.info('Applying migration version ${migration.version}...');
+        await migration.upgrade();
+
+        for (final cmd in migration.database.commands) {
+          _logger.info('\t$cmd');
+          await conn.execute(cmd);
+        }
+
+        _logger.info(
+          'Seeding data from migration version ${migration.version}...',
+        );
+        await migration.seed();
+
+        await conn.execute(
+          'INSERT INTO $versionTableName (versionNumber, dateOfUpgrade) '
+          "VALUES (${migration.version}, '${DateTime.now().toUtc().toIso8601String()}')",
+        );
+
+        _logger.info(
+          'Applied schema version ${migration.version} successfully.',
+        );
+
+        schema = migration.currentSchema;
+      }
+
+      await conn.execute('COMMIT');
+    } catch (_) {
+      await conn.execute('ROLLBACK');
+      rethrow;
+    }
+
+    return schema;
+  }
+
+  @override
+  Future close() async {
+    final conn = _connection;
+    if (conn != null && conn.connected) {
+      await conn.close();
+    }
+    _connection = null;
+  }
+
+  Future<void> _createVersionTableIfNecessary(bool temporary) async {
+    final conn = await _ensureConnected();
+    final tbl = versionTable;
+    final commands = createTable(tbl, isTemporary: temporary);
+    final exists = await conn.execute(
+      dialect.tableExistsQuery(),
+      [tbl.name],
+    );
+    if (exists.rows.isNotEmpty) return;
+
+    _logger.info('Initializing database...');
+    for (final cmd in commands) {
+      _logger.info('\t$cmd');
+      await conn.execute(cmd);
+    }
+  }
+
+  /// Translate a mysql_dart driver exception into one of conduit's
+  /// standard `QueryException` kinds. MySQL primary error codes are
+  /// well-defined; we pattern-match on the well-known ones (duplicate
+  /// key = 1062, foreign-key violation = 1452, NOT NULL violation =
+  /// 1048).
+  QueryException<mx.MySQLServerException> _translate(
+    mx.MySQLServerException e,
+    String sql,
+  ) {
+    final code = e.errorCode;
+    if (code == 1062) {
+      return QueryException.conflict(
+        'entity_already_exists',
+        const [],
+        underlyingException: e,
+      );
+    }
+    if (code == 1048) {
+      return QueryException.input(
+        'non_null_violation',
+        const [],
+        underlyingException: e,
+      );
+    }
+    if (code == 1451 || code == 1452) {
+      return QueryException.input(
+        'foreign_key_violation',
+        const [],
+        underlyingException: e,
+      );
+    }
+    return QueryException.transport(e.message, underlyingException: e);
+  }
+
+  void _logExecute(String sql, Object? params, DateTime start) {
+    _logger.fine(() {
+      final dt = DateTime.now().difference(start).inMilliseconds;
+      return 'Query (${dt}ms) $sql ${params ?? '{}'}';
+    });
+  }
+}

--- a/packages/mysql/lib/src/mysql_schema_generator.dart
+++ b/packages/mysql/lib/src/mysql_schema_generator.dart
@@ -1,0 +1,303 @@
+import 'package:conduit_core/conduit_core.dart';
+
+import 'mysql_sql_dialect.dart';
+
+/// Schema-generation logic for MySQL / MariaDB. Parallel to the
+/// SQLite + Postgres generators; the three diverge enough that a
+/// shared `SqlSchemaGenerator` in `conduit_core` only becomes
+/// worthwhile once a fourth backend lands. For now, copy + dialect
+/// hooks.
+///
+/// **Limitations.**
+///   - `renameTable` and `renameIndex` are emitted directly via
+///     `RENAME TABLE` / `ALTER TABLE … RENAME INDEX`. Both work in
+///     MySQL 5.7+ and MariaDB 10+.
+///   - `alterColumnNullability` uses `MODIFY COLUMN` — MySQL doesn't
+///     have a discrete `ALTER COLUMN SET/DROP NOT NULL`; you re-state
+///     the entire column definition. We re-derive the type from the
+///     [SqlDialect] so the new column DDL stays consistent with
+///     `createTable`'s output.
+///   - `alterColumnUniqueness` toggles a `UNIQUE INDEX` rather than a
+///     unique constraint — MySQL implements unique constraints via
+///     unique indexes anyway, and `DROP INDEX` is the cleanest
+///     reversal.
+mixin MysqlSchemaGenerator {
+  /// Override in concrete stores if a customized dialect is needed
+  /// (e.g., a MariaDB-only divergence, currently unused).
+  SqlDialect get dialect => const MysqlSqlDialect();
+
+  String get versionTableName => dialect.versionTableName;
+
+  List<String> createTable(SchemaTable table, {bool isTemporary = false}) {
+    final commands = <String>[];
+
+    final columnString = table.columns.map(_columnStringForColumn).join(",");
+    commands.add(
+      "CREATE${isTemporary ? " TEMPORARY " : " "}TABLE ${table.name} ($columnString)",
+    );
+
+    final indexCommands = table.columns
+        .where((col) => col.isIndexed! && !col.isPrimaryKey!)
+        .map((col) => addIndexToColumn(table, col))
+        .expand((commands) => commands);
+    commands.addAll(indexCommands);
+
+    commands.addAll(
+      table.columns
+          .where((sc) => sc.isForeignKey)
+          .map((col) => _addConstraintsForColumn(table.name, col))
+          .expand((commands) => commands),
+    );
+
+    if (table.uniqueColumnSet != null) {
+      commands.addAll(addTableUniqueColumnSet(table));
+    }
+
+    return commands;
+  }
+
+  List<String> renameTable(SchemaTable table, String name) {
+    return ["RENAME TABLE ${table.name} TO $name"];
+  }
+
+  List<String> deleteTable(SchemaTable table) {
+    return ["DROP TABLE ${table.name}"];
+  }
+
+  List<String> addTableUniqueColumnSet(SchemaTable table) {
+    final colNames = table.uniqueColumnSet!
+        .map((name) => _columnNameForColumn(table[name]!))
+        .join(",");
+    return [
+      "CREATE UNIQUE INDEX ${table.name}_unique_idx ON ${table.name} ($colNames)"
+    ];
+  }
+
+  List<String> deleteTableUniqueColumnSet(SchemaTable table) {
+    return ["DROP INDEX ${table.name}_unique_idx ON ${table.name}"];
+  }
+
+  List<String> addColumn(
+    SchemaTable table,
+    SchemaColumn column, {
+    String? unencodedInitialValue,
+  }) {
+    final commands = <String>[];
+
+    if (unencodedInitialValue != null) {
+      column.defaultValue = unencodedInitialValue;
+      commands.add(
+        "ALTER TABLE ${table.name} ADD COLUMN ${_columnStringForColumn(column)}",
+      );
+      // Drop the default in a follow-up so the value sticks for
+      // existing rows but new inserts don't auto-fill it.
+      commands.add(
+        "ALTER TABLE ${table.name} ALTER COLUMN "
+        "${_columnNameForColumn(column)} DROP DEFAULT",
+      );
+    } else {
+      commands.add(
+        "ALTER TABLE ${table.name} ADD COLUMN ${_columnStringForColumn(column)}",
+      );
+    }
+
+    if (column.isIndexed!) {
+      commands.addAll(addIndexToColumn(table, column));
+    }
+
+    if (column.isForeignKey) {
+      commands.addAll(_addConstraintsForColumn(table.name, column));
+    }
+
+    return commands;
+  }
+
+  List<String> deleteColumn(SchemaTable table, SchemaColumn column) {
+    return [
+      "ALTER TABLE ${table.name} DROP COLUMN ${_columnNameForColumn(column)}"
+    ];
+  }
+
+  List<String> renameColumn(
+    SchemaTable table,
+    SchemaColumn column,
+    String name,
+  ) {
+    // MySQL 8.0+ / MariaDB 10.5+ support ALTER TABLE ... RENAME COLUMN.
+    // Older versions need CHANGE COLUMN with the full definition; we
+    // emit RENAME COLUMN and let the user know in docs.
+    return [
+      "ALTER TABLE ${table.name} "
+      "RENAME COLUMN ${_columnNameForColumn(column)} TO $name"
+    ];
+  }
+
+  List<String> alterColumnNullability(
+    SchemaTable table,
+    SchemaColumn column,
+    String? unencodedInitialValue,
+  ) {
+    if (column.isNullable!) {
+      return [
+        "ALTER TABLE ${table.name} MODIFY COLUMN "
+        "${_columnNameForColumn(column)} ${_columnTypeForColumn(column)} NULL"
+      ];
+    } else {
+      final commands = <String>[];
+      if (unencodedInitialValue != null) {
+        commands.add(
+          "UPDATE ${table.name} SET ${_columnNameForColumn(column)}="
+          "$unencodedInitialValue WHERE ${_columnNameForColumn(column)} IS NULL",
+        );
+      }
+      commands.add(
+        "ALTER TABLE ${table.name} MODIFY COLUMN "
+        "${_columnNameForColumn(column)} ${_columnTypeForColumn(column)} NOT NULL",
+      );
+      return commands;
+    }
+  }
+
+  List<String> alterColumnUniqueness(SchemaTable table, SchemaColumn column) {
+    if (column.isUnique!) {
+      return [
+        "CREATE UNIQUE INDEX ${dialect.uniqueKeyName(table.name ?? '', column.name)} "
+        "ON ${table.name} (${_columnNameForColumn(column)})"
+      ];
+    } else {
+      return [
+        "DROP INDEX ${dialect.uniqueKeyName(table.name ?? '', column.name)} "
+        "ON ${table.name}"
+      ];
+    }
+  }
+
+  List<String> alterColumnDefaultValue(SchemaTable table, SchemaColumn column) {
+    if (column.defaultValue != null) {
+      return [
+        "ALTER TABLE ${table.name} ALTER COLUMN "
+        "${_columnNameForColumn(column)} SET DEFAULT ${column.defaultValue}"
+      ];
+    } else {
+      return [
+        "ALTER TABLE ${table.name} ALTER COLUMN "
+        "${_columnNameForColumn(column)} DROP DEFAULT"
+      ];
+    }
+  }
+
+  List<String> alterColumnDeleteRule(SchemaTable table, SchemaColumn column) {
+    final allCommands = <String>[];
+    allCommands.add(
+      "ALTER TABLE ${table.name} DROP FOREIGN KEY "
+      "${dialect.foreignKeyName(table.name ?? '', column.name)}",
+    );
+    allCommands.addAll(_addConstraintsForColumn(table.name, column));
+    return allCommands;
+  }
+
+  List<String> addIndexToColumn(SchemaTable table, SchemaColumn column) {
+    return [
+      "CREATE INDEX ${dialect.indexName(table.name ?? '', _columnNameForColumn(column))} "
+      "ON ${table.name} (${_columnNameForColumn(column)})"
+    ];
+  }
+
+  List<String> renameIndex(
+    SchemaTable table,
+    SchemaColumn column,
+    String newIndexName,
+  ) {
+    final existing = dialect.indexName(
+      table.name ?? '',
+      _columnNameForColumn(column),
+    );
+    return [
+      "ALTER TABLE ${table.name} RENAME INDEX $existing TO $newIndexName"
+    ];
+  }
+
+  List<String> deleteIndexFromColumn(SchemaTable table, SchemaColumn column) {
+    return [
+      "DROP INDEX ${dialect.indexName(table.name ?? '', _columnNameForColumn(column))} "
+      "ON ${table.name}"
+    ];
+  }
+
+  // -- helpers --------------------------------------------------------------
+
+  String _columnStringForColumn(SchemaColumn col) {
+    final elements = [_columnNameForColumn(col), _columnTypeForColumn(col)];
+    if (col.isPrimaryKey!) {
+      elements.add("PRIMARY KEY");
+    } else {
+      elements.add(col.isNullable! ? "NULL" : "NOT NULL");
+      if (col.defaultValue != null) {
+        elements.add("DEFAULT ${col.defaultValue}");
+      }
+      if (col.isUnique!) {
+        elements.add("UNIQUE");
+      }
+    }
+    return elements.join(" ");
+  }
+
+  String _columnNameForColumn(SchemaColumn column) {
+    if (column.relatedColumnName != null) {
+      return "${column.name}_${column.relatedColumnName}";
+    }
+    return column.name;
+  }
+
+  String? _columnTypeForColumn(SchemaColumn t) {
+    final ts = t.typeString;
+    if (ts == null) return null;
+    return dialect.columnDefinitionType(
+      ts,
+      autoincrement: t.autoincrement ?? false,
+    );
+  }
+
+  List<String> _addConstraintsForColumn(
+    String? tableName,
+    SchemaColumn column,
+  ) {
+    var constraints =
+        "ALTER TABLE $tableName "
+        "ADD FOREIGN KEY (${_columnNameForColumn(column)}) "
+        "REFERENCES ${column.relatedTableName} (${column.relatedColumnName}) ";
+
+    if (column.deleteRule != null) {
+      constraints +=
+          "ON DELETE ${_deleteRuleStringForDeleteRule(SchemaColumn.deleteRuleStringForDeleteRule(column.deleteRule!))}";
+    }
+
+    return [constraints];
+  }
+
+  String? _deleteRuleStringForDeleteRule(String? deleteRule) {
+    switch (deleteRule) {
+      case "cascade":
+        return "CASCADE";
+      case "restrict":
+        return "RESTRICT";
+      case "default":
+        return "SET DEFAULT";
+      case "nullify":
+        return "SET NULL";
+    }
+    return null;
+  }
+
+  SchemaTable get versionTable {
+    return SchemaTable(versionTableName, [
+      SchemaColumn.empty()
+        ..name = "versionNumber"
+        ..type = ManagedPropertyType.integer
+        ..isUnique = true,
+      SchemaColumn.empty()
+        ..name = "dateOfUpgrade"
+        ..type = ManagedPropertyType.datetime,
+    ]);
+  }
+}

--- a/packages/mysql/lib/src/mysql_sql_dialect.dart
+++ b/packages/mysql/lib/src/mysql_sql_dialect.dart
@@ -1,0 +1,144 @@
+import 'package:conduit_core/conduit_core.dart';
+
+/// MySQL / MariaDB-flavored SQL generation.
+///
+/// Differs from the default `SqlDialect` (ANSI-leaning, Postgres-like)
+/// in five places:
+///
+/// 1. **Type system.** MySQL has explicit `INT AUTO_INCREMENT` /
+///    `BIGINT AUTO_INCREMENT` for serial columns, native `JSON` (5.7+)
+///    for documents, `DATETIME` for timestamps, and `BOOLEAN` (an
+///    alias for `TINYINT(1)`). Strings map to `TEXT` rather than
+///    Postgres's `TEXT` because... they're both `TEXT`. The interesting
+///    divergence is the autoincrement / JSON columns.
+///
+/// 2. **Parameter syntax — positional.** MySQL uses `?` placeholders
+///    bound by ordinal position. This is the headline reason
+///    `conduit_core` grew a predicate AST + visitor: the legacy
+///    string-concat predicate path was hardwired to `@name`, which
+///    can't render `?` correctly without losing positional ordering.
+///    [parameterStyle] returns [SqlParameterStyle.positional].
+///
+/// 3. **Pattern matching.** MySQL's `LIKE` is case-insensitive when
+///    the column's collation is `_ci` (the default for `utf8mb4`,
+///    `utf8`). For case-*sensitive* matching, the documented form is
+///    `LIKE BINARY` (forces a binary comparison regardless of
+///    collation). Users who configure their database with a `_bin`
+///    collation will see "LIKE" already be case-sensitive and the
+///    `LIKE BINARY` form remains correct (no-op on top of binary
+///    storage). The opposite case — case-insensitive where the
+///    collation is `_bin` — is uncommon enough we don't try to handle
+///    it here; document instead.
+///
+/// 4. **Identifier quoting.** Backticks (`` ` ``) — required when an
+///    identifier collides with a reserved keyword. The dialect doesn't
+///    proactively quote every identifier today (the Postgres path
+///    doesn't either) — that's a follow-up — but the helpers are here
+///    when callers want them.
+///
+/// 5. **No `RETURNING` clause.** MySQL's INSERT does not return the
+///    inserted row. v0 of `MysqlPersistentStore` doesn't ship the ORM
+///    `newQuery<T>` path, so this only matters for migrations / raw
+///    `execute` callers. When the ORM path lands, the pattern is
+///    `INSERT … ; SELECT * FROM <table> WHERE id = LAST_INSERT_ID()`.
+///
+/// MariaDB is binary-compatible with the dialect at this version
+/// (10.x supports `JSON`, `AUTO_INCREMENT`, `LIKE BINARY`,
+/// `information_schema.tables`, etc.). The persistent store records a
+/// `bool mariadb` flag at connect time for callers that need to
+/// branch.
+class MysqlSqlDialect extends SqlDialect {
+  const MysqlSqlDialect();
+
+  @override
+  String get name => 'mysql';
+
+  // -- Type mapping ---------------------------------------------------------
+
+  @override
+  String? columnDefinitionType(
+    String typeString, {
+    required bool autoincrement,
+  }) {
+    switch (typeString) {
+      case 'integer':
+        return autoincrement ? 'INT AUTO_INCREMENT' : 'INT';
+      case 'bigInteger':
+        return autoincrement ? 'BIGINT AUTO_INCREMENT' : 'BIGINT';
+      case 'string':
+        // VARCHAR(255) is the historical default for an unconstrained
+        // text column. TEXT is unindexable without a key length, which
+        // breaks UNIQUE constraints. Conduit's schema model doesn't
+        // carry a length hint today; 255 is the documented widest-
+        // index default and matches what MariaDB / MySQL tutorials
+        // suggest.
+        return 'VARCHAR(255)';
+      case 'datetime':
+        // DATETIME stores no timezone; conduit normalizes to UTC at
+        // the application layer. TIMESTAMP would be 32-bit (2038
+        // limit) — DATETIME is the correct long-lived choice.
+        return 'DATETIME';
+      case 'boolean':
+        // BOOLEAN is an alias for TINYINT(1). The driver binds Dart
+        // `bool` as 0/1 transparently.
+        return 'BOOLEAN';
+      case 'double':
+        return 'DOUBLE';
+      case 'document':
+        // Native JSON since MySQL 5.7 and MariaDB 10.2.
+        return 'JSON';
+    }
+    return null;
+  }
+
+  // -- Parameter syntax -----------------------------------------------------
+
+  @override
+  SqlParameterStyle get parameterStyle => SqlParameterStyle.positional;
+
+  /// Always `?` regardless of the supplied name. The name is kept in
+  /// the AST for diagnostics, but is not rendered.
+  @override
+  String parameterPlaceholder(String name) => '?';
+
+  // -- Operators where MySQL differs from standard SQL ----------------------
+
+  /// `LIKE` defaults to case-insensitive on `_ci` collations (the
+  /// `utf8mb4_general_ci` / `utf8mb4_0900_ai_ci` defaults). For
+  /// schemas configured with a `_bin` collation, `LIKE` will already
+  /// be case-sensitive — that's an out-of-band schema choice, not
+  /// something we override per-query.
+  @override
+  String get caseInsensitiveLikeOperator => 'LIKE';
+
+  /// `LIKE BINARY` forces a binary (case-sensitive) comparison
+  /// regardless of the column's collation.
+  @override
+  String get caseSensitiveLikeOperator => 'LIKE BINARY';
+
+  // IS NULL / IS NOT NULL: standard SQL form, inherited defaults.
+
+  // ALTER TABLE: standard form, inherited default.
+
+  // -- DDL conventions -----------------------------------------------------
+
+  /// MySQL identifiers are quoted with backticks. Same suffix
+  /// conventions as the base.
+
+  // -- Schema-version bookkeeping ------------------------------------------
+
+  @override
+  String get versionTableName => '_conduit_version_mysql';
+
+  /// `information_schema.tables` is the portable table-existence
+  /// query. MySQL also accepts `SHOW TABLES LIKE '...'`, but
+  /// information_schema parameterizes cleanly.
+  ///
+  /// MySQL is positional — the placeholder is `?`. The base
+  /// `parameterPlaceholder` (which we overrode to always return `?`)
+  /// is fine here.
+  @override
+  String tableExistsQuery() =>
+      "SELECT table_name FROM information_schema.tables "
+      "WHERE table_schema = DATABASE() AND table_name = ${parameterPlaceholder("tableName")}";
+}

--- a/packages/mysql/pubspec.yaml
+++ b/packages/mysql/pubspec.yaml
@@ -1,0 +1,25 @@
+name: conduit_mysql
+description: MySQL / MariaDB ORM backend for conduit. Schema management + raw execute path; ORM `newQuery<T>` deferred until the query builders move out of the postgresql package.
+version: 6.0.0
+home: https://www.theconduit.dev
+repository: https://github.com/conduit-dart/conduit
+issue_tracker: https://github.com/conduit-dart/conduit/issues
+
+environment:
+  sdk: ">=3.12.0-0 <4.0.0"
+resolution: workspace
+
+dependencies:
+  conduit_core: ^6.0.0
+  # mysql_dart 1.2.1 (2025-11-20) is the actively maintained native-Dart
+  # MySQL client. It supports MySQL 5.7/8 and MariaDB 10, offers TLS, and
+  # binds parameters positionally with `?` — the placeholder
+  # syntax that motivates the `SqlExpression` AST migration in
+  # `conduit_core`. The older `mysql_client` (0.0.27, 2022) and `mysql1`
+  # (0.20.0, 2022) packages are stale; `mysql_dart` is the
+  # active-libraries pick.
+  mysql_dart: ^1.2.1
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.25.2

--- a/packages/mysql/test/mysql_dialect_test.dart
+++ b/packages/mysql/test/mysql_dialect_test.dart
@@ -1,0 +1,307 @@
+import 'package:conduit_core/conduit_core.dart';
+import 'package:conduit_mysql/conduit_mysql.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MysqlSqlDialect', () {
+    const d = MysqlSqlDialect();
+
+    test('name is "mysql"', () {
+      expect(d.name, 'mysql');
+    });
+
+    test('parameter style is positional', () {
+      expect(d.parameterStyle, SqlParameterStyle.positional);
+    });
+
+    test('parameter placeholder is always ? regardless of name', () {
+      expect(d.parameterPlaceholder('foo'), '?');
+      expect(d.parameterPlaceholder('whatever'), '?');
+    });
+
+    test('column types map to MySQL-flavored DDL', () {
+      expect(d.columnDefinitionType('integer', autoincrement: false), 'INT');
+      expect(d.columnDefinitionType('integer', autoincrement: true),
+          'INT AUTO_INCREMENT');
+      expect(d.columnDefinitionType('bigInteger', autoincrement: false),
+          'BIGINT');
+      expect(d.columnDefinitionType('bigInteger', autoincrement: true),
+          'BIGINT AUTO_INCREMENT');
+      expect(d.columnDefinitionType('string', autoincrement: false),
+          'VARCHAR(255)');
+      expect(d.columnDefinitionType('datetime', autoincrement: false),
+          'DATETIME');
+      expect(d.columnDefinitionType('boolean', autoincrement: false),
+          'BOOLEAN');
+      expect(d.columnDefinitionType('double', autoincrement: false), 'DOUBLE');
+      expect(d.columnDefinitionType('document', autoincrement: false), 'JSON');
+      expect(d.columnDefinitionType('unknownType', autoincrement: false),
+          isNull);
+    });
+
+    test('case-sensitive LIKE uses LIKE BINARY', () {
+      expect(d.caseSensitiveLikeOperator, 'LIKE BINARY');
+    });
+
+    test('case-insensitive LIKE collapses to LIKE (collation-driven)', () {
+      expect(d.caseInsensitiveLikeOperator, 'LIKE');
+    });
+
+    test('IS NULL uses standard SQL form', () {
+      expect(d.isNullOperator, 'IS NULL');
+      expect(d.isNotNullOperator, 'IS NOT NULL');
+    });
+
+    test('alter-table form is the standard ALTER TABLE', () {
+      expect(d.alterTableForConstraintModification, 'ALTER TABLE');
+    });
+
+    test('version-table name is suffixed with "mysql"', () {
+      expect(d.versionTableName, '_conduit_version_mysql');
+    });
+
+    test('table-existence query reads information_schema.tables', () {
+      final q = d.tableExistsQuery();
+      expect(q, contains('information_schema.tables'));
+      expect(q, contains('table_schema = DATABASE()'));
+      expect(q, contains('?'));
+    });
+
+    test('LIKE pattern escaping protects %, _, and \\', () {
+      // Inherited default escaping. Documented as MySQL-compatible.
+      expect(d.escapeLikePattern('100%'), r'100\%');
+      expect(d.escapeLikePattern('a_b'), r'a\_b');
+      expect(d.escapeLikePattern(r'c\d'), r'c\\d');
+    });
+  });
+
+  group('MysqlSqlDialect AST rendering', () {
+    const d = MysqlSqlDialect();
+
+    test('comparison renders as ? and binds positionally', () {
+      final r = d.renderExpression(
+        BinaryOpExpression(
+          '=',
+          ColumnExpression('id', tableNamespace: 'users'),
+          ParameterExpression('id_v', 42),
+        ),
+      );
+      expect(r.sql, 'users.id = ?');
+      expect(r.positionalParameters, [42]);
+      expect(r.parameters, isEmpty);
+    });
+
+    test('AND combinator preserves positional ordering', () {
+      final r = d.renderExpression(
+        LogicalExpression('AND', [
+          BinaryOpExpression('=', ColumnExpression('a'),
+              ParameterExpression('av', 1)),
+          BinaryOpExpression('<', ColumnExpression('b'),
+              ParameterExpression('bv', 99)),
+        ]),
+      );
+      expect(r.sql, '(a = ? AND b < ?)');
+      expect(r.positionalParameters, [1, 99]);
+    });
+
+    test('IN expands to (?,?,?) and binds in order', () {
+      final r = d.renderExpression(
+        InExpression(
+          ColumnExpression('id'),
+          [
+            ParameterExpression('a', 10),
+            ParameterExpression('b', 20),
+            ParameterExpression('c', 30),
+          ],
+        ),
+      );
+      expect(r.sql, 'id IN (?,?,?)');
+      expect(r.positionalParameters, [10, 20, 30]);
+    });
+
+    test('LIKE BINARY emitted for case-sensitive string match', () {
+      final r = d.renderExpression(
+        LikeExpression(
+          ColumnExpression('name'),
+          ParameterExpression('p', 'Foo%'),
+          caseSensitive: true,
+        ),
+      );
+      expect(r.sql, 'name LIKE BINARY ?');
+      expect(r.positionalParameters, ['Foo%']);
+    });
+
+    test('LIKE (no BINARY) for case-insensitive', () {
+      final r = d.renderExpression(
+        LikeExpression(
+          ColumnExpression('name'),
+          ParameterExpression('p', 'foo%'),
+          caseSensitive: false,
+        ),
+      );
+      expect(r.sql, 'name LIKE ?');
+    });
+
+    test('IS NULL renders without binding', () {
+      final r = d.renderExpression(
+        IsNullExpression(ColumnExpression('email')),
+      );
+      expect(r.sql, 'email IS NULL');
+      expect(r.positionalParameters, isEmpty);
+    });
+
+    test('BETWEEN binds low then high', () {
+      final r = d.renderExpression(
+        BetweenExpression(
+          ColumnExpression('n'),
+          ParameterExpression('lo', 5),
+          ParameterExpression('hi', 10),
+        ),
+      );
+      expect(r.sql, 'n BETWEEN ? AND ?');
+      expect(r.positionalParameters, [5, 10]);
+    });
+  });
+
+  group('MysqlSchemaGenerator', () {
+    final gen = _Gen();
+
+    test('createTable emits INT AUTO_INCREMENT for serial PK', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'id'
+          ..type = ManagedPropertyType.integer
+          ..isPrimaryKey = true
+          ..autoincrement = true
+          ..isNullable = false
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      final cmds = gen.createTable(t);
+      expect(cmds, hasLength(1));
+      expect(cmds.first, contains('CREATE TABLE users'));
+      expect(cmds.first, contains('id INT AUTO_INCREMENT PRIMARY KEY'));
+    });
+
+    test('createTable emits VARCHAR(255) for string columns', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'id'
+          ..type = ManagedPropertyType.integer
+          ..isPrimaryKey = true
+          ..autoincrement = true
+          ..isNullable = false
+          ..isIndexed = false
+          ..isUnique = false,
+        SchemaColumn.empty()
+          ..name = 'email'
+          ..type = ManagedPropertyType.string
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = false
+          ..isIndexed = true
+          ..isUnique = true,
+      ]);
+      final cmds = gen.createTable(t);
+      expect(cmds.first, contains('email VARCHAR(255) NOT NULL UNIQUE'));
+      // The indexed + non-PK column also generates an index command.
+      expect(cmds.length, 2);
+      expect(cmds.last, contains('CREATE INDEX users_email_idx ON users (email)'));
+    });
+
+    test('createTable emits BIGINT AUTO_INCREMENT for bigInteger serial', () {
+      final t = SchemaTable('events', [
+        SchemaColumn.empty()
+          ..name = 'id'
+          ..type = ManagedPropertyType.bigInteger
+          ..isPrimaryKey = true
+          ..autoincrement = true
+          ..isNullable = false
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      final cmds = gen.createTable(t);
+      expect(cmds.first, contains('id BIGINT AUTO_INCREMENT PRIMARY KEY'));
+    });
+
+    test('createTable emits JSON for document type', () {
+      final t = SchemaTable('events', [
+        SchemaColumn.empty()
+          ..name = 'id'
+          ..type = ManagedPropertyType.integer
+          ..isPrimaryKey = true
+          ..autoincrement = true
+          ..isNullable = false
+          ..isIndexed = false
+          ..isUnique = false,
+        SchemaColumn.empty()
+          ..name = 'payload'
+          ..type = ManagedPropertyType.document
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = true
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      final cmds = gen.createTable(t);
+      expect(cmds.first, contains('payload JSON NULL'));
+    });
+
+    test('renameColumn emits RENAME COLUMN', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'email'
+          ..type = ManagedPropertyType.string
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = true
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      final cmds = gen.renameColumn(t, t.columns.first, 'address');
+      expect(cmds, hasLength(1));
+      expect(cmds.first, 'ALTER TABLE users RENAME COLUMN email TO address');
+    });
+
+    test('renameTable uses RENAME TABLE', () {
+      final t = SchemaTable('a', const []);
+      final cmds = gen.renameTable(t, 'b');
+      expect(cmds, ['RENAME TABLE a TO b']);
+    });
+
+    test('alterColumnNullability uses MODIFY COLUMN with full type', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'email'
+          ..type = ManagedPropertyType.string
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = false
+          ..isIndexed = false
+          ..isUnique = false,
+      ]);
+      final cmds = gen.alterColumnNullability(t, t.columns.first, null);
+      expect(cmds, hasLength(1));
+      expect(cmds.first, contains('MODIFY COLUMN email VARCHAR(255) NOT NULL'));
+    });
+
+    test('deleteIndexFromColumn uses DROP INDEX ... ON table', () {
+      final t = SchemaTable('users', [
+        SchemaColumn.empty()
+          ..name = 'email'
+          ..type = ManagedPropertyType.string
+          ..isPrimaryKey = false
+          ..autoincrement = false
+          ..isNullable = true
+          ..isIndexed = true
+          ..isUnique = false,
+      ]);
+      final cmds = gen.deleteIndexFromColumn(t, t.columns.first);
+      expect(cmds, ['DROP INDEX users_email_idx ON users']);
+    });
+  });
+}
+
+/// Bare adapter so tests can call mixin methods without instantiating
+/// a real MysqlPersistentStore (which would attempt a TCP connect).
+class _Gen with MysqlSchemaGenerator {}

--- a/packages/postgresql/lib/src/builders/expression.dart
+++ b/packages/postgresql/lib/src/builders/expression.dart
@@ -45,20 +45,43 @@ class ColumnExpressionBuilder extends ColumnBuilder {
   /// Convenience access to the dialect threaded through the table builder.
   SqlDialect get _dialect => table!.dialect;
 
+  /// Build a postgres-typed value wrapper for [v]; centralized so the
+  /// AST nodes carry the same `TypedValue` the legacy path put in the
+  /// parameter map. Keeps PG behavior identical pre- and post-AST.
+  TypedValue _typed(Object? v) =>
+      TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
+          convertValueForStorage(v));
+
+  /// `column` AST node for the predicate's left-hand side. The PG
+  /// renderer always namespaces with the table reference (matches
+  /// the historical `withTableNamespace: true` call site).
+  ColumnExpression _columnNode() {
+    final raw = sqlColumnName();
+    return ColumnExpression(
+      raw,
+      tableNamespace: table!.sqlTableReference,
+    );
+  }
+
   QueryPredicate comparisonPredicate(
     PredicateOperator? operator,
     dynamic value,
   ) {
     final name = sqlColumnName(withTableNamespace: true);
     final variableName = sqlColumnName(withPrefix: defaultPrefix);
+    final op = ColumnBuilder.symbolTable[operator!]!;
+    final typed = _typed(value);
 
-    return QueryPredicate(
-      "$name ${ColumnBuilder.symbolTable[operator!]} "
-      "${_dialect.parameterPlaceholder(variableName)}",
-      {
-        variableName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
-            convertValueForStorage(value)),
-      },
+    final ast = BinaryOpExpression(
+      op,
+      _columnNode(),
+      ParameterExpression(variableName, typed),
+    );
+
+    return QueryPredicate.withExpression(
+      ast,
+      "$name $op ${_dialect.parameterPlaceholder(variableName)}",
+      {variableName: typed},
     );
   }
 
@@ -68,6 +91,7 @@ class ColumnExpressionBuilder extends ColumnBuilder {
   }) {
     final tokenList = [];
     final pairedMap = <String, TypedValue>{};
+    final astValues = <SqlExpression>[];
 
     var counter = 0;
     for (final value in values) {
@@ -75,22 +99,28 @@ class ColumnExpressionBuilder extends ColumnBuilder {
 
       final variableName = sqlColumnName(withPrefix: prefix);
       tokenList.add(_dialect.parameterPlaceholder(variableName));
-      pairedMap[variableName] = TypedValue(
-          ColumnBuilder.typeMap[property!.type!.kind]!,
-          convertValueForStorage(value));
+      final typed = _typed(value);
+      pairedMap[variableName] = typed;
+      astValues.add(ParameterExpression(variableName, typed));
 
       counter++;
     }
 
     final name = sqlColumnName(withTableNamespace: true);
     final keyword = within ? "IN" : "NOT IN";
-    return QueryPredicate("$name $keyword (${tokenList.join(",")})", pairedMap);
+    final ast = InExpression(_columnNode(), astValues, negated: !within);
+    return QueryPredicate.withExpression(
+      ast,
+      "$name $keyword (${tokenList.join(",")})",
+      pairedMap,
+    );
   }
 
   QueryPredicate nullPredicate({bool isNull = true}) {
     final name = sqlColumnName(withTableNamespace: true);
     final op = isNull ? _dialect.isNullOperator : _dialect.isNotNullOperator;
-    return QueryPredicate("$name $op", {});
+    final ast = IsNullExpression(_columnNode(), negated: !isNull);
+    return QueryPredicate.withExpression(ast, "$name $op", {});
   }
 
   QueryPredicate rangePredicate(
@@ -102,16 +132,21 @@ class ColumnExpressionBuilder extends ColumnBuilder {
     final lhsName = sqlColumnName(withPrefix: "${defaultPrefix}lhs_");
     final rhsName = sqlColumnName(withPrefix: "${defaultPrefix}rhs_");
     final operation = insideRange ? "BETWEEN" : "NOT BETWEEN";
+    final lhsTyped = _typed(lhsValue);
+    final rhsTyped = _typed(rhsValue);
 
-    return QueryPredicate(
+    final ast = BetweenExpression(
+      _columnNode(),
+      ParameterExpression(lhsName, lhsTyped),
+      ParameterExpression(rhsName, rhsTyped),
+      negated: !insideRange,
+    );
+
+    return QueryPredicate.withExpression(
+      ast,
       "$name $operation ${_dialect.parameterPlaceholder(lhsName)} "
       "AND ${_dialect.parameterPlaceholder(rhsName)}",
-      {
-        lhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
-            convertValueForStorage(lhsValue)),
-        rhsName: TypedValue(ColumnBuilder.typeMap[property!.type!.kind]!,
-            convertValueForStorage(rhsValue)),
-      },
+      {lhsName: lhsTyped, rhsName: rhsTyped},
     );
   }
 
@@ -148,9 +183,18 @@ class ColumnExpressionBuilder extends ColumnBuilder {
         break;
     }
 
-    return QueryPredicate(
+    final typed = TypedValue(Type.text, matchValue);
+    final ast = LikeExpression(
+      _columnNode(),
+      ParameterExpression(variableName, typed),
+      caseSensitive: caseSensitive,
+      negated: invertOperator,
+    );
+
+    return QueryPredicate.withExpression(
+      ast,
       "$n $operation ${_dialect.parameterPlaceholder(variableName)}",
-      {variableName: TypedValue(Type.text, matchValue)},
+      {variableName: typed},
     );
   }
 }

--- a/packages/test_harness/lib/conduit_test.dart
+++ b/packages/test_harness/lib/conduit_test.dart
@@ -16,6 +16,7 @@ library;
 export 'package:conduit_test/src/agent.dart';
 export 'package:conduit_test/src/auth_harness.dart';
 export 'package:conduit_test/src/db_harness.dart';
+export 'package:conduit_test/src/dialect_annotations.dart';
 export 'package:conduit_test/src/harness.dart';
 export 'package:conduit_test/src/matchers.dart';
 export 'package:conduit_test/src/mock_server.dart';

--- a/packages/test_harness/lib/src/dialect_annotations.dart
+++ b/packages/test_harness/lib/src/dialect_annotations.dart
@@ -1,0 +1,83 @@
+/// Test fanout annotations for the multi-backend ORM rollout.
+///
+/// As `conduit_postgresql`, `conduit_sqlite`, `conduit_mysql`, and the
+/// in-flight `conduit_cockroach` ship, the existing 291-test ORM
+/// regression suite needs to **fanout across backends** — i.e., run
+/// every dialect-agnostic ORM test against each backend's
+/// `PersistentStore`, and skip backend-specific tests on the wrong
+/// backend. The annotations defined here name the contract; the
+/// runner that consumes them lands in a follow-up PR (it has to
+/// teach `package:test`'s tag-filtering mechanism + a
+/// `--dialect=<name>` switch to the harness).
+///
+/// **Usage in test files** (when wired):
+///
+/// ```dart
+/// // Test only meaningful against Postgres' jsonb operators.
+/// @OnlyOn([Dialect.postgres])
+/// test('jsonb @> operator round-trips a Document', () { ... });
+///
+/// // Test that exercises a behavior MySQL doesn't support.
+/// @SkipOn([Dialect.mysql], reason: 'MySQL has no RETURNING clause')
+/// test('insert RETURNING captures generated PK without a follow-up SELECT',
+///     () { ... });
+/// ```
+///
+/// **Default semantics.** A test with no annotation runs against
+/// every registered dialect — the most common case, and the goal of
+/// the multi-backend migration.
+///
+/// We deliberately don't tie this to `package:test`'s `Tags`
+/// machinery yet because (a) tag values are stringly-typed and easy
+/// to fat-finger, and (b) we want the IDE-level type-check that
+/// comes from a sealed enum. The runner can lower these to tags at
+/// dispatch time.
+library;
+
+/// Catalog of dialects the test harness recognizes. Add to this list
+/// when a new backend lands.
+enum Dialect {
+  /// `package:conduit_postgresql` (Phase 0; the original backend).
+  postgres,
+
+  /// `package:conduit_sqlite` (Phase 2). Schema + raw `execute` only
+  /// in v0; ORM `newQuery<T>` deferred.
+  sqlite,
+
+  /// `package:conduit_mysql` (Phase 4). Same v0 surface as SQLite —
+  /// schema + raw `execute`. ORM `newQuery<T>` deferred.
+  mysql,
+
+  /// `package:conduit_cockroach` (Phase 3, in review). Mostly a
+  /// Postgres super-set; flagged separately for behavior-divergence
+  /// gating.
+  cockroach,
+}
+
+/// Run this test only against the listed dialects. If the runner
+/// is not currently dispatching against any of the listed dialects,
+/// the test is skipped with a clear reason.
+class OnlyOn {
+  const OnlyOn(this.dialects, {this.reason});
+
+  final List<Dialect> dialects;
+  final String? reason;
+}
+
+/// Skip this test when running against any of the listed dialects.
+/// Use when the test exercises a feature the backend explicitly
+/// doesn't support, or where a known bug is tracked separately.
+class SkipOn {
+  const SkipOn(this.dialects, {this.reason});
+
+  final List<Dialect> dialects;
+  final String? reason;
+}
+
+/// Convenience: shorthand for the most common case — a test that
+/// only makes sense for Postgres because it touches a Postgres-only
+/// feature (`ILIKE`, `JSONB`, `RETURNING`, `to_regclass`).
+class PostgresOnly extends OnlyOn {
+  const PostgresOnly({String? reason})
+      : super(const [Dialect.postgres], reason: reason);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ workspace:
   - packages/isolate_exec
   - packages/open_api
   - packages/password_hash
+  - packages/mysql
   - packages/postgresql
   - packages/runtime
   - packages/sqlite
@@ -81,6 +82,7 @@ melos:
                             -V conduit_config:$v \
                             -V conduit_core:$v \
                             -V conduit_isolate_exec:$v \
+                            -V conduit_mysql:$v \
                             -V conduit_open_api:$v \
                             -V conduit_password_hash:$v \
                             -V conduit_postgresql:$v \


### PR DESCRIPTION
## Summary

Phase 4 of the multi-backend ORM rollout. Two logically separate
commits in this PR:

1. **`refactor(core): introduce SqlExpression AST + dialect-driven visitor`** — the architectural prerequisite. Today's `QueryPredicate` carries a raw SQL fragment with hardcoded `@name` placeholders (the Postgres convention). That breaks the moment a backend uses positional `?` placeholders (MySQL) or a different `:name` convention (SQLite) — string-concat predicate builders can't emit a correct positional binding without re-parsing what they just wrote. This commit moves predicate construction onto a dialect-neutral `SqlExpression` AST (`ColumnExpression` / `BinaryOpExpression` / `LogicalExpression` / `IsNullExpression` / `LikeExpression` / `InExpression` / `BetweenExpression` / `ParameterExpression` / `LiteralExpression` / `RawExpression` / `UnaryOpExpression`) and a visitor (`SqlExpressionVisitor`). Each `SqlDialect` exposes a `parameterStyle` (named/positional) and a `renderExpression(...)` hook; the base `SqlDialect` constructs a `NamedSqlExpressionVisitor` (for `@name` / `:name`) or `PositionalSqlExpressionVisitor` (for `?`) automatically. `QueryPredicate` gains an optional `expression` field carrying the AST alongside the legacy `format` string — backends that recognize the AST render from it; everyone else keeps using the format string. **PG output is byte-identical** — the PG predicate builders now populate both fields, the format string still uses `@name`, and the existing 344 PG ORM tests still pass.

2. **`feat(mysql): add conduit_mysql backend (schema + raw execute; ORM path deferred)`** — mirrors the `conduit_sqlite` v0 shape. `MysqlSqlDialect` (positional `?` placeholders, `INT/BIGINT AUTO_INCREMENT`, `VARCHAR(255)`, `JSON`, `DATETIME`, `BOOLEAN`, `LIKE BINARY` for case-sensitive matching, `information_schema.tables` for existence checks), `MysqlSchemaGenerator` mixin for DDL, and `MysqlPersistentStore` for connection management, schema migrations, raw `execute`/`executeQuery`, SAVEPOINT-based nested transactions. Driver: `mysql_dart` 1.2.1 — published 2025-11-20, native Dart, MySQL 5.7/8 + MariaDB 10/11 tested. The older `mysql_client` (0.0.27, 2022) and `mysql1` (0.20.0, 2022) packages are stale by the project's active-libraries rule; `mysql_dart` is the active-maintenance pick. MariaDB compatibility is detected via `SELECT VERSION()` at connect time and exposed as `isMariaDB`; the dialect emits the same SQL for both today.

Also adds `dialect_annotations.dart` to `conduit_test` (`OnlyOn` / `SkipOn` + `Dialect` enum) so future ORM tests can declare backend constraints. The runner that consumes the annotations lands separately.

## Path taken for query-builder extraction

**Path B (deferred).** The prompt offers two paths for getting the query builders out of the `postgresql` package: (A) extract into core, (B) leave them in postgresql but make them dialect-injectable. Path A is cleaner long-term but is a substantial refactor on its own; path B introduces a hard dependency from the mysql package on postgresql, which is ugly. **This PR ships neither** — the AST migration is the architectural prerequisite for both paths, and shipping the AST + a clean MySQL package without the builder lift is honest about the scope. Both `conduit_sqlite` and `conduit_mysql` v0 throw `UnimplementedError` from `newQuery<T>` and document that the lift is the unblocking step. That separates the architectural work from the package proliferation.

## MySQL dialect overrides at a glance

| Surface | Default | MySQL |
| --- | --- | --- |
| `parameterStyle` | named | **positional** |
| `parameterPlaceholder('foo')` | `@foo` | **`?`** |
| `caseSensitiveLikeOperator` | `LIKE` | **`LIKE BINARY`** |
| `caseInsensitiveLikeOperator` | `LIKE` | `LIKE` (collation-driven) |
| `columnDefinitionType('integer', autoincrement: true)` | (subclass) | **`INT AUTO_INCREMENT`** |
| `columnDefinitionType('bigInteger', autoincrement: true)` | (subclass) | **`BIGINT AUTO_INCREMENT`** |
| `columnDefinitionType('string')` | `TEXT` | **`VARCHAR(255)`** |
| `columnDefinitionType('document')` | (subclass) | **`JSON`** |
| `columnDefinitionType('datetime')` | (subclass) | **`DATETIME`** |
| `versionTableName` | `_conduit_version_$name` | `_conduit_version_mysql` |
| `tableExistsQuery()` | (subclass) | **`SELECT … FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?`** |
| `RETURNING` | supported | **not supported** (deferred to ORM-path PR; v0 schema/raw path doesn't need it) |

## Regression status

- **PG ORM:** 344 tests passing, 11 skipped, 2 unrelated flaky-network failures (same baseline as `master`).
- **conduit_core:** 1099 tests passing, 7 skipped, none failing. Baseline was 1079; this PR adds 20 new AST-migration tests in `packages/core/test/db/expression_ast_test.dart`.
- **conduit_mysql:** 26 tests passing (dialect overrides, AST positional rendering against the MySQL dialect, and schema-generator DDL).
- **conduit_sqlite:** dialect-test count unchanged. The `(in-memory)` sub-group fails to load `libsqlite3.so` in the `dart:beta` Docker image we use for CI verification — pre-existing, unrelated.

## Disclosures / partial-shipping

- **No MySQL integration tests in this PR.** This worktree doesn't have a MySQL container available; ran no real `INSERT … SELECT` round-trip. The dialect + schema generator are unit-tested. A CI matrix entry that boots a MySQL service container and runs an integration suite is the follow-up — same shape as how Postgres is wired in `.woodpecker.yml` today.
- **MySQL `newQuery<T>` is `UnimplementedError`.** Same posture as SQLite in #264; unblocks once the postgresql query builders are made dialect-agnostic. Both backends already pass through the same dialect contract; the lift is straightforward but mechanical.

## Test plan

- [ ] CI matrix entry for `mysql` service container + integration tests (follow-up).
- [ ] Lift query builders out of `conduit_postgresql` into core (or into a dialect-injectable shim) so `newQuery<T>` works for both SQLite and MySQL — that's where the ORM-fanout test plan starts.
- [ ] Wire `OnlyOn` / `SkipOn` annotations to a `package:test` tag-dispatcher in `conduit_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)