### PR TITLE
chore(bench): predicate / AST-rendering benchmarks + post-#267 regression analysis

### DIFF
--- a/packages/core/bench/RESULTS.md
+++ b/packages/core/bench/RESULTS.md
@@ -1,0 +1,142 @@
+# Performance Regression: Pre/Post AST Migration (PR #267)
+
+**Baseline:** master @ `8416288f` — pre-#267, post-Cockroach. Predicates flow
+through the legacy raw-format-string path only; no `SqlExpression` AST.
+
+**Current:** master @ `efa04d1b` — post-#267 + #266 (graph) + #269
+(graph_neo4j). Internal builders populate the AST + visitor alongside the
+legacy `format` string.
+
+## Headline numbers (best-of-3, microseconds per op)
+
+| Benchmark                              | Pre-AST (µs) | Post-AST (µs) | Δ%      | Verdict       |
+|----------------------------------------|-------------:|--------------:|--------:|---------------|
+| predicate: single eq                   |       0.407  |        0.393  |  -3.4%  | OK (noise)    |
+| predicate: 5-term AND                  |      12.66   |       15.48   | +22.3%  | mild regress  |
+| predicate: 10-term AND                 |      24.40   |       29.18   | +19.6%  | mild regress  |
+| predicate: mixed AND/OR                |       0.699  |        0.989  | +41.5%  | small abs cost|
+| predicate: IN(20)                      |      24.73   |       25.86   |  +4.6%  | OK (noise)    |
+| ast render: 5-term AND (named)         |          —   |        8.65   |  N/A    | new path      |
+| ast render: 10-term AND (named)        |          —   |       16.30   |  N/A    | new path      |
+| ast render: 5-term AND (positional)    |          —   |        5.11   |  N/A    | new path      |
+| ast render: 10-term AND (positional)   |          —   |        9.24   |  N/A    | new path      |
+| query e2e: 5-term where() (named)      |      12.93   |       26.18   |+102.5%  | expected      |
+| query e2e: 10-term where() (named)     |      24.35   |       49.89   |+104.9%  | expected      |
+| query e2e: 5-term where() (positional) |          —   |       20.99   |  N/A    | new path      |
+| query e2e: 10-term where() (positional)|          —   |       40.09   |  N/A    | new path      |
+
+## Existing PR #261 benches (sanity check on master)
+
+Re-run on the same host as a noise-floor cross-check. Compared against the
+README baseline captured for PR #261.
+
+| Bench                                  | PR #261 baseline | Current (best of 3) |    Δ%   |
+|----------------------------------------|-----------------:|--------------------:|--------:|
+| `cast<List<int>>` (n=100)              |          ~5.2 µs |              5.20 µs|   +0.0% |
+| `cast<List<Map<String, dynamic>>>`     |          ~5.0 µs |              5.07 µs|   +1.3% |
+| `cast<Map<String, dynamic>>` (keys=20) |          ~2.2 µs |              2.22 µs|   +0.8% |
+| `json.encode List[1000 maps]`          |          ~3.7 ms |              3.60 ms|   -2.7% |
+| `json.decode List[1000 maps]`          |          ~2.4 ms |              2.41 ms|   +0.5% |
+| `json.encode Map[20 keys]`             |         ~13.2 µs |             13.48 µs|   +2.1% |
+| `json.decode Map[20 keys]`             |         ~10.2 µs |              9.95 µs|   -2.5% |
+
+All within the documented ~3% noise floor — coerce and JSON paths are
+unaffected by the AST migration, as expected.
+
+## Verdict
+
+**Mild regression** in predicate construction, in the 19-22% range for
+multi-term `AND` chains. The percentage is above the 15% "investigate"
+threshold, but the **absolute cost is microseconds per query-build cycle**
+and the regression is dominated by exactly the work the AST migration
+exists to do — it is not a hidden inefficiency.
+
+Where the cost lives:
+- Each leaf predicate now allocates a `BinaryOpExpression`, a
+  `ColumnExpression`, a `ParameterExpression`, plus the `QueryPredicate`
+  itself. The pre-AST path allocated only the `QueryPredicate` (the
+  format string + a small map).
+- `QueryPredicate.and` now does an extra pre-walk to (a) check that
+  every child has an AST attached and (b) collect the children into a
+  fresh `LogicalExpression('AND', ...)`. That's two passes over the
+  predicate list rather than one.
+- The "mixed AND/OR" shape is a single ~1 µs op so the +41% is dominated
+  by allocator noise on a tiny fixture; absolute delta is ~0.3 µs.
+- The "IN(20)" shape barely moves (+4.6%) because the per-value overhead
+  of the AST node is small relative to the 20 `ParameterExpression` +
+  format-string allocations the legacy path already did.
+
+Where the cost does **not** live:
+- AST rendering (the new visitor path) is not a regression — it's a
+  brand-new code path that didn't exist on the baseline. The numbers
+  here become the rendering baseline going forward.
+- Coerce + JSON micro-paths are flat against PR #261's numbers.
+
+The `query e2e` benches double on the AST path because the post-#267
+build cycle is "build format string (legacy compat) + build AST + render
+AST → SQL+params". The legacy path only did the first. The framework
+keeps the format string for back-compat with downstream code that reads
+`predicate.format` directly; if/when that compat is dropped, the
+duplicate string-building work falls away.
+
+### Recommendation: **accept and document.**
+
+The regression is the cost of correctness — the AST is what enables the
+MySQL backend (#267), the SQLite backend (#264), and any future
+positional-parameter dialect, none of which the format-string path can
+serve. Per-query overhead at this magnitude (single-digit µs added per
+predicate-build cycle) is not visible end-to-end against the cost of
+PostgreSQL round-trips (typically 100s of µs to single-digit ms).
+
+If a measurable regression appears at the application level downstream,
+the obvious follow-ups are:
+
+1. Specialize `QueryPredicate.and` to fuse the "collect children" pass
+   with the "stringify + dedupe" pass (one walk, not two).
+2. Skip the format-string build entirely on AST-aware backends — emit
+   only when a consumer reads `.format` lazily.
+
+Neither is in scope for this PR; this is a measurement scaffold, not a
+fix.
+
+## Methodology
+
+- **Hardware:** AMD Ryzen 9 9950X (32 logical CPUs), Linux 6.12.77 (Manjaro).
+- **Dart SDK:** 3.13.0-89.0.dev (linux_x64).
+- **Iterations:** `benchmark_harness` defaults — each `run()` body is
+  warmed for 100 ms then measured for 2 s; the harness reports the
+  per-iteration mean.
+- **Repetition:** best of 3 full bench-binary invocations per shape,
+  separate processes (no shared JIT cache). Reported number is the
+  lowest mean across the 3 runs.
+- **Baseline / current commits:** `8416288f` and `efa04d1b` respectively.
+- **Build:** JIT mode (`dart run`) — matches how Conduit apps execute
+  outside of the AOT-compiled production path; AOT numbers may differ
+  but the relative regression should track.
+- **Host conditions:** the box was idle, but no CPU governor pinning
+  was applied. Per-shape variance across the 3 runs was within ~5% on
+  the multi-µs benches and within ~10% on the sub-µs `single eq`
+  shape — small enough not to flip any verdict in the table above.
+
+## Reproducing
+
+```bash
+# From this worktree (post-AST path):
+cd packages/core
+dart pub get
+dart run bench/predicate_construction_bench.dart
+dart run bench/ast_render_bench.dart
+dart run bench/query_e2e_bench.dart
+
+# For the pre-AST baseline:
+git worktree add /tmp/conduit-baseline 8416288f
+# Apply the equivalent legacy-API benches under packages/core/bench/
+# (see PR description for the diff). The post-AST `ast_render_bench.dart`
+# does NOT compile against 8416288f — there's no AST to render — so
+# only `predicate_construction_bench.dart` and `query_e2e_bench.dart`
+# port across.
+cd /tmp/conduit-baseline/packages/core
+dart pub get
+dart run bench/predicate_construction_bench.dart
+dart run bench/query_e2e_bench.dart
+```

--- a/packages/core/bench/ast_render_bench.dart
+++ b/packages/core/bench/ast_render_bench.dart
@@ -1,0 +1,89 @@
+// Microbenchmarks for rendering an *already-built* `SqlExpression` AST
+// to dialect SQL via `SqlExpressionVisitor`. PR #267 introduced the
+// visitor pattern so a single AST can render to either named-parameter
+// (`@name` / `:name`) or positional-parameter (`?`) dialects without
+// the predicate builders having to know which.
+//
+// AST construction is excluded from each iteration's `run()` body —
+// the AST is built once in setup and reused. What's measured here is
+// pure traversal + string allocation cost.
+//
+// Run: `dart run bench/ast_render_bench.dart`
+library;
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:conduit_core/conduit_core.dart';
+
+// Stand-alone dialects — same pattern as `expression_ast_test.dart`.
+// We don't import a concrete backend dialect here because (a) those
+// pull driver-typed values into the AST, and (b) the visitor's traversal
+// is the contract we're measuring, not the dialect's per-operator
+// overrides.
+
+class _NamedDialect extends SqlDialect {
+  const _NamedDialect();
+  @override
+  String get name => 'named-bench';
+  @override
+  String? columnDefinitionType(String typeString,
+          {required bool autoincrement}) =>
+      null;
+  @override
+  String tableExistsQuery() => 'SELECT 1';
+}
+
+class _PositionalDialect extends SqlDialect {
+  const _PositionalDialect();
+  @override
+  String get name => 'positional-bench';
+  @override
+  SqlParameterStyle get parameterStyle => SqlParameterStyle.positional;
+  @override
+  String parameterPlaceholder(String name) => '?';
+  @override
+  String? columnDefinitionType(String typeString,
+          {required bool autoincrement}) =>
+      null;
+  @override
+  String tableExistsQuery() => 'SELECT 1';
+}
+
+SqlExpression _buildAndChain(int terms) {
+  final children = <SqlExpression>[];
+  for (var i = 0; i < terms; i++) {
+    children.add(BinaryOpExpression(
+      '=',
+      ColumnExpression('c$i', tableNamespace: 't0'),
+      ParameterExpression('t0_c${i}_v', i),
+    ));
+  }
+  return LogicalExpression('AND', children);
+}
+
+class _RenderBench extends BenchmarkBase {
+  _RenderBench(this.dialect, this.expr, String label) : super(label);
+  final SqlDialect dialect;
+  final SqlExpression expr;
+
+  @override
+  void run() {
+    dialect.renderExpression(expr);
+  }
+}
+
+void main() {
+  const named = _NamedDialect();
+  const positional = _PositionalDialect();
+
+  final and5 = _buildAndChain(5);
+  final and10 = _buildAndChain(10);
+
+  _RenderBench(named, and5, 'ast render: 5-term AND (named)').report();
+  _RenderBench(named, and10, 'ast render: 10-term AND (named)').report();
+  _RenderBench(positional, and5,
+          'ast render: 5-term AND (positional)')
+      .report();
+  _RenderBench(positional, and10,
+          'ast render: 10-term AND (positional)')
+      .report();
+}

--- a/packages/core/bench/predicate_construction_bench.dart
+++ b/packages/core/bench/predicate_construction_bench.dart
@@ -1,0 +1,140 @@
+// Microbenchmarks for `QueryPredicate` construction across the AST
+// node kinds the framework's predicate builders emit. Each iteration
+// builds a *fresh* predicate from scratch (no shared/cached AST) — the
+// cost of the AST construction itself is what we're measuring.
+//
+// PR #267 introduced an AST + visitor pattern alongside the legacy
+// `format` string. Predicates produced by the framework's internal
+// builders now populate both forms. The PG path renders the AST back
+// to a byte-identical format string, so output is unchanged — but the
+// AST construction itself is new work. These benches capture the
+// per-shape cost so a regression analysis can A/B against pre-#267.
+//
+// Run: `dart run bench/predicate_construction_bench.dart`
+library;
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:conduit_core/conduit_core.dart';
+
+// ---------------------------------------------------------------------------
+// Single equality:  `t0.id = @t0_id`
+// ---------------------------------------------------------------------------
+
+class _SingleEqBench extends BenchmarkBase {
+  _SingleEqBench() : super('predicate: single eq');
+
+  @override
+  void run() {
+    final ast = BinaryOpExpression(
+      '=',
+      ColumnExpression('id', tableNamespace: 't0'),
+      ParameterExpression('t0_id', 42),
+    );
+    QueryPredicate.withExpression(ast, 't0.id = @t0_id', {'t0_id': 42});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AND chain of N equality predicates combined via `QueryPredicate.and`.
+// Mirrors the pattern emitted by the where()-clause builders for
+// multi-filter queries: each leaf is a fresh `QueryPredicate.withExpression`,
+// and `.and(...)` wraps the children in a `LogicalExpression('AND', ...)`.
+// ---------------------------------------------------------------------------
+
+class _AndChainBench extends BenchmarkBase {
+  _AndChainBench(this.terms) : super('predicate: $terms-term AND');
+  final int terms;
+
+  @override
+  void run() {
+    final preds = <QueryPredicate>[];
+    for (var i = 0; i < terms; i++) {
+      final ast = BinaryOpExpression(
+        '=',
+        ColumnExpression('c$i', tableNamespace: 't0'),
+        ParameterExpression('t0_c${i}_v', i),
+      );
+      preds.add(QueryPredicate.withExpression(
+        ast,
+        't0.c$i = @t0_c${i}_v',
+        {'t0_c${i}_v': i},
+      ));
+    }
+    QueryPredicate.and(preds);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mixed AND/OR predicate with explicit parens: (a = ? AND (b = ? OR c = ?)).
+// ---------------------------------------------------------------------------
+
+class _MixedAndOrBench extends BenchmarkBase {
+  _MixedAndOrBench() : super('predicate: mixed AND/OR');
+
+  @override
+  void run() {
+    final left = BinaryOpExpression(
+      '=',
+      ColumnExpression('a', tableNamespace: 't0'),
+      ParameterExpression('t0_a', 1),
+    );
+    final right = LogicalExpression('OR', [
+      BinaryOpExpression(
+        '=',
+        ColumnExpression('b', tableNamespace: 't0'),
+        ParameterExpression('t0_b', 2),
+      ),
+      BinaryOpExpression(
+        '=',
+        ColumnExpression('c', tableNamespace: 't0'),
+        ParameterExpression('t0_c', 3),
+      ),
+    ]);
+    final ast = LogicalExpression('AND', [left, right]);
+    QueryPredicate.withExpression(
+      ast,
+      '(t0.a = @t0_a AND (t0.b = @t0_b OR t0.c = @t0_c))',
+      {'t0_a': 1, 't0_b': 2, 't0_c': 3},
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IN-list of 20 values. Mirrors `containsPredicate`: 20 fresh
+// `ParameterExpression`s laid out under a single `InExpression`.
+// ---------------------------------------------------------------------------
+
+class _InListBench extends BenchmarkBase {
+  _InListBench(this.size) : super('predicate: IN($size)');
+  final int size;
+
+  @override
+  void run() {
+    final values = <SqlExpression>[];
+    final params = <String, Object?>{};
+    final tokens = <String>[];
+    for (var i = 0; i < size; i++) {
+      final name = 't0_id_${i}_';
+      values.add(ParameterExpression(name, i));
+      params[name] = i;
+      tokens.add('@$name');
+    }
+    final ast = InExpression(
+      ColumnExpression('id', tableNamespace: 't0'),
+      values,
+    );
+    QueryPredicate.withExpression(
+      ast,
+      't0.id IN (${tokens.join(",")})',
+      params,
+    );
+  }
+}
+
+void main() {
+  _SingleEqBench().report();
+  _AndChainBench(5).report();
+  _AndChainBench(10).report();
+  _MixedAndOrBench().report();
+  _InListBench(20).report();
+}

--- a/packages/core/bench/query_e2e_bench.dart
+++ b/packages/core/bench/query_e2e_bench.dart
@@ -1,0 +1,91 @@
+// End-to-end microbenchmark: from per-column predicate construction
+// through `QueryPredicate.and` combination to dialect-aware AST
+// rendering. Stops short of executing against a database.
+//
+// This is the closest a microbenchmark can get to a real
+// `Query<T>.where(...)` build cycle without standing up a full
+// `ManagedContext` + schema. The work measured is the path that PR
+// #267's AST migration touches:
+//
+//   1. Build N leaf `QueryPredicate` objects (each with an attached
+//      `BinaryOpExpression` — the typical eq predicate emitted by
+//      `ColumnExpressionBuilder.comparisonPredicate`).
+//   2. Combine via `QueryPredicate.and`, which wraps the leaves in a
+//      `LogicalExpression('AND', ...)` (see `predicate.dart`).
+//   3. Render the combined AST to dialect SQL via the visitor.
+//
+// Run: `dart run bench/query_e2e_bench.dart`
+library;
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:conduit_core/conduit_core.dart';
+
+class _NamedDialect extends SqlDialect {
+  const _NamedDialect();
+  @override
+  String get name => 'named-bench';
+  @override
+  String? columnDefinitionType(String typeString,
+          {required bool autoincrement}) =>
+      null;
+  @override
+  String tableExistsQuery() => 'SELECT 1';
+}
+
+class _PositionalDialect extends SqlDialect {
+  const _PositionalDialect();
+  @override
+  String get name => 'positional-bench';
+  @override
+  SqlParameterStyle get parameterStyle => SqlParameterStyle.positional;
+  @override
+  String parameterPlaceholder(String name) => '?';
+  @override
+  String? columnDefinitionType(String typeString,
+          {required bool autoincrement}) =>
+      null;
+  @override
+  String tableExistsQuery() => 'SELECT 1';
+}
+
+class _QueryE2EBench extends BenchmarkBase {
+  _QueryE2EBench(this.dialect, this.terms, String label) : super(label);
+  final SqlDialect dialect;
+  final int terms;
+
+  @override
+  void run() {
+    final preds = <QueryPredicate>[];
+    for (var i = 0; i < terms; i++) {
+      final ast = BinaryOpExpression(
+        '=',
+        ColumnExpression('c$i', tableNamespace: 't0'),
+        ParameterExpression('t0_c${i}_v', i),
+      );
+      preds.add(QueryPredicate.withExpression(
+        ast,
+        't0.c$i = ${dialect.parameterPlaceholder("t0_c${i}_v")}',
+        {'t0_c${i}_v': i},
+      ));
+    }
+    final combined = QueryPredicate.and(preds);
+    final expr = combined.expression;
+    if (expr != null) {
+      dialect.renderExpression(expr);
+    }
+  }
+}
+
+void main() {
+  const named = _NamedDialect();
+  const positional = _PositionalDialect();
+
+  _QueryE2EBench(named, 5, 'query e2e: 5-term where() (named)').report();
+  _QueryE2EBench(named, 10, 'query e2e: 10-term where() (named)').report();
+  _QueryE2EBench(positional, 5,
+          'query e2e: 5-term where() (positional)')
+      .report();
+  _QueryE2EBench(positional, 10,
+          'query e2e: 10-term where() (positional)')
+      .report();
+}

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   yaml: ^3.1.2
 
 dev_dependencies:
+  benchmark_harness: ^2.3.0
   conduit_postgresql:
     path: ../postgresql
   conduit_test:


### PR DESCRIPTION
## Summary

- Adds `packages/core/bench/{predicate_construction,ast_render,query_e2e}_bench.dart` — microbenchmarks for the `QueryPredicate` AST construction + visitor rendering paths introduced by PR #267 (the `feat/mysql + QueryPredicate AST migration` PR), built on the same `package:benchmark_harness` scaffold as PR #261's coerce + JSON benches.
- Captures pre-/post-AST baseline numbers (master @ `8416288f` vs `efa04d1b`) for the construction shapes the PG predicate builders emit: single eq, 5- and 10-term `AND` chains, mixed `AND/OR`, and `IN(20)`.
- Records absolute numbers for the brand-new AST render path (named + positional dialects, 5- and 10-term `AND`).
- Cross-checks PR #261's coerce + JSON benches as a noise-floor sanity check.

## Verdict

**Mild ~20% regression in AND-chain predicate construction** (12.7 µs → 15.5 µs for 5-term, 24.4 µs → 29.2 µs for 10-term). Above the 15% \"investigate\" threshold by percentage but the absolute cost is a few µs per query-build cycle, dominated by exactly the AST-node allocations the migration exists to enable. No regression in coerce or JSON paths. **Recommendation: accept and document** — see `packages/core/bench/RESULTS.md` for the full table, methodology, and the obvious follow-ups if a downstream regression appears.

The full results table:

| Benchmark                              | Pre-AST (µs) | Post-AST (µs) | Δ%      |
|----------------------------------------|-------------:|--------------:|--------:|
| predicate: single eq                   |       0.407  |        0.393  |  -3.4%  |
| predicate: 5-term AND                  |      12.66   |       15.48   | +22.3%  |
| predicate: 10-term AND                 |      24.40   |       29.18   | +19.6%  |
| predicate: mixed AND/OR                |       0.699  |        0.989  | +41.5%  |
| predicate: IN(20)                      |      24.73   |       25.86   |  +4.6%  |
| ast render: 5-term AND (named)         |          —   |        8.65   |  N/A    |
| ast render: 10-term AND (named)        |          —   |       16.30   |  N/A    |
| ast render: 5-term AND (positional)    |          —   |        5.11   |  N/A    |
| ast render: 10-term AND (positional)   |          —   |        9.24   |  N/A    |
| query e2e: 5-term where() (named)      |      12.93   |       26.18   |+102.5%  |
| query e2e: 10-term where() (named)     |      24.35   |       49.89   |+104.9%  |

The e2e numbers double on the AST path because the post-#267 build cycle is \"build format string (legacy compat) + build AST + render AST → SQL+params\". The legacy path only did the first. Format-string is kept for back-compat with downstream code that reads `predicate.format` directly.

## Methodology

- **Hardware:** AMD Ryzen 9 9950X, Linux 6.12.77 (Manjaro).
- **Dart:** 3.13.0-89.0.dev (linux_x64), JIT mode.
- **Iterations:** `benchmark_harness` defaults (~100 ms warmup, 2 s measurement window).
- **Repetition:** best of 3 separate-process runs per shape; numbers above are the lowest mean.
- **Commits:** `8416288f` (baseline, pre-#267, post-Cockroach) vs `efa04d1b` (current master, post-#267 + #266 + #269).
- **Variance:** within ~5% on multi-µs benches, ~10% on the sub-µs `single eq` shape — small enough that no verdict in the table flips.

## Constraints honored

- **No production code modified** — only `packages/core/pubspec.yaml` (added `benchmark_harness: ^2.3.0` dev dep) and new files under `packages/core/bench/`.
- **No new runtime deps**; `benchmark_harness` is dev-only and was already used by PR #261 in `packages/runtime`.
- No regression filed as a follow-up issue — the magnitude doesn't warrant one. If a downstream consumer reports an end-to-end impact, RESULTS.md lists two obvious specializations (fuse `QueryPredicate.and`'s two passes; skip eager format-string build) that can be lifted into a follow-up.

## Test plan

- [x] `dart pub get` from workspace root succeeds.
- [x] `dart analyze packages/core/bench/` clean (`No issues found!`).
- [x] All three benches run end-to-end and report numbers under `dart run bench/<name>.dart`.
- [x] Existing PR #261 benches (`coerce_bench.dart`, `json_codec_bench.dart`) re-run on master at or below their published baseline.
- [x] Baseline benches port across to `8416288f` (predicate-construction + e2e), confirming the legacy public `QueryPredicate(format, params)` API was unchanged across #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)