### PR TITLE
test(core): defeat isolate test flake by retrying bind on EADDRINUSE

### DIFF
--- a/packages/core/test/_helpers/free_port.dart
+++ b/packages/core/test/_helpers/free_port.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:conduit_core/conduit_core.dart';
+import 'package:test_core/src/util/io.dart' show getUnsafeUnusedPort;
+
+/// Builds an [Application], assigns it an OS-picked free port, and starts
+/// it — retrying on EADDRINUSE.
+///
+/// `getUnusedPort` from `package:test_core` has a built-in race window: it
+/// binds a probe socket on port 0 to discover an unused port, closes the
+/// socket, and returns the port number. Between the close and the actual
+/// downstream `HttpServer.bind`, another process can grab the port. The
+/// usual mitigation is to perform the real bind *inside* the `tryPort`
+/// callback so a null return triggers a fresh port — but
+/// `Application.start` rolls in isolate spawning + supervisor wiring,
+/// which the simple null-retry contract doesn't model cleanly.
+///
+/// This helper handles the retry explicitly: each attempt builds a fresh
+/// [Application] via [build], assigns a probed port, and calls `start`. If
+/// `start` throws a [SocketException] with EADDRINUSE (errno 48 on macOS
+/// or 98 on Linux), the failed app is stopped and the loop retries with a
+/// new port. Other failures propagate.
+Future<({Application<T> app, int port})> startWithFreePort<T extends ApplicationChannel>(
+  Application<T> Function() build, {
+  int numberOfInstances = 1,
+  int maxAttempts = 10,
+}) async {
+  Object? lastError;
+  StackTrace? lastStack;
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    final candidate = await getUnsafeUnusedPort();
+    final app = build();
+    app.options.port = candidate;
+    try {
+      await app.start(numberOfInstances: numberOfInstances);
+      return (app: app, port: candidate);
+    } on SocketException catch (e, st) {
+      if (_isAddrInUse(e)) {
+        await _safeStop(app);
+        lastError = e;
+        lastStack = st;
+        continue;
+      }
+      await _safeStop(app);
+      rethrow;
+    } on ApplicationStartupException catch (e, st) {
+      // Application.start wraps the underlying SocketException as
+      // ApplicationStartupException for the multi-isolate path; sniff
+      // the message to decide whether this is the same race.
+      if (e.toString().contains('Failed to create server socket') &&
+          e.toString().contains('Address already in use')) {
+        await _safeStop(app);
+        lastError = e;
+        lastStack = st;
+        continue;
+      }
+      await _safeStop(app);
+      rethrow;
+    }
+  }
+  throw StateError(
+    'startWithFreePort: could not bind a free port after $maxAttempts '
+    'attempts. Last error: $lastError\n$lastStack',
+  );
+}
+
+bool _isAddrInUse(SocketException e) {
+  final code = e.osError?.errorCode;
+  return code == 48 || code == 98; // macOS / Linux
+}
+
+Future<void> _safeStop(Application<dynamic> app) async {
+  try {
+    await app.stop();
+  } catch (_) {
+    // Stop can fail if start did not get far enough to register
+    // supervisors; ignore — the retry will build a fresh app.
+  }
+}

--- a/packages/core/test/http/isolate/isolate_application_test.dart
+++ b/packages/core/test/http/isolate/isolate_application_test.dart
@@ -8,13 +8,20 @@ import 'package:conduit_core/conduit_core.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
+import '../../_helpers/free_port.dart';
+
 void main() {
   group("Lifecycle", () {
     late Application<TestChannel> app;
+    late int port;
 
     setUp(() async {
-      app = Application<TestChannel>();
-      await app.start(numberOfInstances: 2, consoleLogging: true);
+      final started = await startWithFreePort(
+        () => Application<TestChannel>(),
+        numberOfInstances: 2,
+      );
+      app = started.app;
+      port = started.port;
       print("started");
     });
 
@@ -29,13 +36,13 @@ void main() {
     });
 
     test("Application responds to request", () async {
-      final response = await http.get(Uri.parse("http://localhost:8888/t"));
+      final response = await http.get(Uri.parse("http://localhost:$port/t"));
       expect(response.statusCode, 200);
     });
 
     test("Application properly routes request", () async {
-      final tRequest = http.get(Uri.parse("http://localhost:8888/t"));
-      final rRequest = http.get(Uri.parse("http://localhost:8888/r"));
+      final tRequest = http.get(Uri.parse("http://localhost:$port/t"));
+      final rRequest = http.get(Uri.parse("http://localhost:$port/r"));
 
       final tResponse = await tRequest;
       final rResponse = await rRequest;
@@ -48,7 +55,7 @@ void main() {
       final reqs = <Future>[];
       final responses = <http.Response>[];
       for (int i = 0; i < 500; i++) {
-        final req = http.get(Uri.parse("http://localhost:8888/t"));
+        final req = http.get(Uri.parse("http://localhost:$port/t"));
         req.then(responses.add);
         reqs.add(req);
       }
@@ -73,13 +80,13 @@ void main() {
       await app.stop();
 
       try {
-        await http.get(Uri.parse("http://localhost:8888/t"));
+        await http.get(Uri.parse("http://localhost:$port/t"));
         // ignore: empty_catches
       } on SocketException {}
 
       await app.start(numberOfInstances: 2, consoleLogging: true);
 
-      final resp = await http.get(Uri.parse("http://localhost:8888/t"));
+      final resp = await http.get(Uri.parse("http://localhost:$port/t"));
       expect(resp.statusCode, 200);
     });
 
@@ -89,7 +96,7 @@ void main() {
       var sum = 0;
       for (var i = 0; i < 10; i++) {
         final result =
-            await http.get(Uri.parse("http://localhost:8888/startup"));
+            await http.get(Uri.parse("http://localhost:$port/startup"));
         sum += int.parse(json.decode(result.body) as String);
       }
       expect(sum, 10);

--- a/packages/core/test/http/isolate/message_hub_test.dart
+++ b/packages/core/test/http/isolate/message_hub_test.dart
@@ -7,7 +7,8 @@ import 'package:collection/collection.dart' show IterableExtension;
 import 'package:conduit_core/conduit_core.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
-import 'package:test_core/src/util/io.dart' show getUnusedPort;
+
+import '../../_helpers/free_port.dart';
 
 void main() {
   group("Happy path", () {
@@ -21,9 +22,12 @@ void main() {
     test(
         "A message sent to the hub is received by other channels, but not by sender",
         () async {
-      port = await getUnusedPort((p) => p);
-      app = Application<HubChannel>()..options.port = port;
-      await app.start(numberOfInstances: 3);
+      final started = await startWithFreePort(
+        () => Application<HubChannel>(),
+        numberOfInstances: 3,
+      );
+      app = started.app;
+      port = started.port;
 
       final resp = await postMessage(port, "msg1");
       final postingIsolateID = isolateIdentifierFromResponse(resp);
@@ -54,11 +58,13 @@ void main() {
 
     test("A message sent in prepare is received by all channels eventually",
         () async {
-      port = await getUnusedPort((p) => p);
-      app = Application<HubChannel>()
-        ..options.port = port
-        ..options.context["sendIn"] = "prepare";
-      await app.start(numberOfInstances: 3);
+      final started = await startWithFreePort(
+        () => Application<HubChannel>()
+          ..options.context["sendIn"] = "prepare",
+        numberOfInstances: 3,
+      );
+      app = started.app;
+      port = started.port;
 
       expect(
         waitForMessages(port, {
@@ -89,11 +95,13 @@ void main() {
     });
 
     test("Message hub stream can have multiple listeners", () async {
-      port = await getUnusedPort((p) => p);
-      app = Application<HubChannel>()
-        ..options.port = port
-        ..options.context["multipleListeners"] = true;
-      await app.start(numberOfInstances: 3);
+      final started = await startWithFreePort(
+        () => Application<HubChannel>()
+          ..options.context["multipleListeners"] = true,
+        numberOfInstances: 3,
+      );
+      app = started.app;
+      port = started.port;
 
       final resp = await postMessage(port, "msg1");
       final postingIsolateID = isolateIdentifierFromResponse(resp);
@@ -135,9 +143,12 @@ void main() {
     });
 
     test("Send invalid x-isolate data returns error in error stream", () async {
-      port = await getUnusedPort((p) => p);
-      app = Application<HubChannel>()..options.port = port;
-      await app.start(numberOfInstances: 3);
+      final started = await startWithFreePort(
+        () => Application<HubChannel>(),
+        numberOfInstances: 3,
+      );
+      app = started.app;
+      port = started.port;
 
       var resp = await postMessage(port, "garbage");
       final errors = await getErrorsFromIsolates(port);


### PR DESCRIPTION
## Summary

The isolate tests under `packages/core/test/http/isolate/` flake on the macOS arm64 hosted runner with `SocketException: Failed to create server socket (OS Error: Address already in use, errno = 48)`. PR #271 hit this on `unit (beta)` ([failed run](https://github.com/conduit-dart/conduit/actions/runs/25441128195)) — the rerun was clean, confirming intermittent.

### Root cause

The tests use `getUnusedPort` from `package:test_core`:

\`\`\`dart
port = await getUnusedPort((p) => p);            // probe socket closes here
app = Application<HubChannel>()..options.port = port;
await app.start(numberOfInstances: 3);            // ← real bind happens here
\`\`\`

`getUnusedPort` works by binding a probe socket on port 0, reading the OS-assigned port, **closing the probe socket**, and returning the port. Between the close and `app.start`'s real bind, another process can grab the same ephemeral port. On macOS arm64 hosted runners with high concurrency this races often enough to flake CI roughly 1 run in 5–10.

`getUnusedPort` is designed to retry on null return from `tryPort`, but the existing call sites pass `(p) => p` and perform the bind outside the callback, so the retry path never fires.

### Fix

Add `startWithFreePort` under `packages/core/test/_helpers/free_port.dart` — builds a fresh `Application` per attempt, assigns a probed port, calls `start`, and on `SocketException` with `EADDRINUSE` (errno 48 on macOS / 98 on Linux) stops the failed app and loops with a new probed port. Other failures propagate. Default 10 attempts.

Wraps both the raw `SocketException` path and the `ApplicationStartupException` (multi-isolate) wrapper, since `numberOfInstances > 1` re-throws the bind error wrapped.

### Migrations

- `message_hub_test.dart` — 4 call sites (Happy path × 2, Multiple listeners × 1, Failure cases × 1)
- `isolate_application_test.dart` — `Lifecycle` group setUp + 7 hardcoded `localhost:8888` URLs reflowed to use the captured port
- `isolate_failure_test.dart` — **left alone**: its `port = 8888` is deliberate, the test provokes a port conflict to verify graceful failure

### Verification

- `dart analyze test/http/isolate/ test/_helpers/` — clean (one info-level `depend_on_referenced_packages` finding on `test_core`, pre-existing on master, just relocated to the helper)
- `dart test test/http/isolate/message_hub_test.dart` — 4/4 pass, 10x consecutive runs all green
- `dart test test/http/isolate/isolate_application_test.dart` — 7/7 pass

### What this does NOT do

- Does not change `Application.start` to expose the actual bound port — the helper-based test pattern keeps production code untouched.
- Does not migrate non-isolate tests (`cors_test`, `controller_test`, `default_resource_controller_test`) that hardcode 8000/8888 — they don't run multi-isolate, collision risk is materially lower, separate scope if needed.
- Does not change the `getUnsafeUnusedPort` helper itself — that's library code; we pin the test pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)