### PR TITLE
feat(graphql): conduit_graphql skeleton + GraphQLController (G1)

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -1,0 +1,171 @@
+# conduit_graphql
+
+GraphQL HTTP transport for [Conduit](https://www.theconduit.dev). Mounts a
+`GraphQLController` over a hand-written `GraphQLSchema`, implementing the
+[GraphQL-over-HTTP spec](https://graphql.github.io/graphql-over-http/draft/)
+for `POST` (queries + mutations) and `GET` (queries only).
+
+## Status — G1 of the GraphQL evaluation plan
+
+This is the **first phase** of a five-phase delivery. G1 ships the HTTP
+transport only; everything that talks to a Conduit data model is deferred
+to a later phase.
+
+| Phase  | Scope | Ships in this package? |
+|--------|-------|------------------------|
+| **G1** | Controller, parse + validate + execute, JSON envelope, GET-of-mutation rejection, introspection | **Yes** |
+| G2     | Derive a `GraphQLSchema` from `ManagedDataModel` | Stub only (`SchemaBuilder` throws `UnimplementedError`) |
+| G3     | SQL resolvers + dataloader against `Query<T>`     | No |
+| G4     | Graph resolvers against `GraphQuery<N>` (Neo4j)   | No |
+| G5     | Cross-source dispatch + `@FieldAuthorize`         | No |
+
+GraphQL **subscriptions are out of scope for the entire plan**; Conduit
+has no WebSocket transport in core.
+
+## Install
+
+Add to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  conduit_core: ^6.0.0
+  conduit_graphql: ^6.0.0
+```
+
+`conduit_graphql` re-exports the surfaces of `graphql_schema2`,
+`graphql_parser2`, and `graphql_server2` — you do not need to add those
+packages to your own `pubspec.yaml` to assemble a hand-written schema.
+
+## Wire-up example
+
+```dart
+import 'package:conduit_core/conduit_core.dart';
+import 'package:conduit_graphql/conduit_graphql.dart';
+
+final helloSchema = graphQLSchema(
+  queryType: objectType('Query', fields: [
+    field('hello', graphQLString, resolve: (_, _) => 'world'),
+    field(
+      'greet',
+      graphQLString.nonNullable(),
+      inputs: [GraphQLFieldInput('name', graphQLString.nonNullable())],
+      resolve: (_, args) => 'Hello, ${args['name']}!',
+    ),
+  ]),
+);
+
+class MyChannel extends ApplicationChannel {
+  @override
+  Controller get entryPoint {
+    final router = Router();
+    router.route('/graphql').link(() => GraphQLController(helloSchema));
+    return router;
+  }
+}
+```
+
+Then:
+
+```bash
+$ curl -sX POST http://localhost:8888/graphql \
+    -H 'content-type: application/json' \
+    -d '{"query":"{ hello, greet(name: \"alice\") }"}'
+{"data":{"hello":"world","greet":"Hello, alice!"}}
+```
+
+## Wire format
+
+### Request — `POST /graphql` with `application/json`
+
+```json
+{
+  "query":         "<GraphQL document>",
+  "operationName": "<optional>",
+  "variables":     { "<name>": <value>, ... },
+  "extensions":    { ... }
+}
+```
+
+`extensions` is accepted but ignored in G1.
+
+### Request — `POST /graphql` with `application/graphql`
+
+The body is the raw query document. No JSON envelope.
+
+### Request — `GET /graphql`
+
+```
+GET /graphql?query=<doc>&operationName=<name>&variables=<JSON-encoded>
+```
+
+Per the spec, `GET` is restricted to `query` operations. Sending a
+`mutation` over `GET` returns `405 Method Not Allowed`.
+
+### Response
+
+Always JSON. Two media types are supported:
+
+* `application/json` — the legacy default; what you get unless you opt in.
+* `application/graphql-response+json` — the modern spec-aligned media
+  type. Send `Accept: application/graphql-response+json` to receive it.
+  This package registers the codec with Conduit's `CodecRegistry` on
+  first `GraphQLController` construction; you do not need to register
+  it yourself.
+
+```json
+{
+  "data":   ...,
+  "errors": [
+    {
+      "message":    "...",
+      "locations":  [{ "line": 1, "column": 9 }],
+      "path":       [...],
+      "extensions": { ... }
+    }
+  ]
+}
+```
+
+### HTTP status codes
+
+* `200` — request was processed. Field-resolver runtime errors land
+  here, with `data: null` and a populated `errors[]` (per spec §7.1.2).
+* `400` — malformed body, parse error, validation error, missing
+  `query`, malformed `?variables=`, or variable-coercion failure.
+* `405` — `GET` of a `mutation` or `subscription`.
+
+Field-existence validation is performed locally before execution to
+work around an upstream gap in `graphql_server2` v6.5.0 — see "Known
+limitations" below.
+
+## What this package does NOT do (yet)
+
+* **No schema derivation** — `SchemaBuilder` is a `UnimplementedError`
+  stub. Caller hand-assembles the `GraphQLSchema`. (G2.)
+* **No resolver framework** — there is no `Query<T>`/`GraphQuery<N>`
+  integration. Resolvers are caller-provided closures. (G3 / G4.)
+* **No dataloader** — N+1 mitigation is on the caller until G3.
+* **No field-level authorization** — `@FieldAuthorize` is a G5 surface.
+  Per-resolver auth checks against `request.authorization` are the
+  current pattern; the conduit `Request` is exposed to resolvers via
+  `globalVariables['conduitRequest']`.
+* **No subscriptions** — out of scope for the entire plan; Conduit core
+  has no WebSocket transport.
+
+## Known limitations (G1)
+
+* `graphql_server2` v6.5.0 silently drops field selections that don't
+  exist on the parent type. We work around this with a minimal
+  pre-execution validator that rejects unknown root-and-nested fields
+  with HTTP 400 / `errors[]`. Fragment spreads and inline fragments are
+  not yet checked by the local validator and fall through to the
+  upstream executor.
+* Field-resolver runtime errors are surfaced as a single error with the
+  thrown object's `toString()` as `message`. Path information is not
+  yet populated; `graphql_server2` does not attribute paths to its
+  thrown `GraphQLException`s, and the path machinery lands in G3
+  alongside the dataloader.
+
+## License
+
+BSD-3-Clause, matching the rest of the Conduit framework.

--- a/packages/graphql/analysis_options.yaml
+++ b/packages/graphql/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/packages/graphql/lib/conduit_graphql.dart
+++ b/packages/graphql/lib/conduit_graphql.dart
@@ -1,0 +1,26 @@
+/// GraphQL HTTP transport for Conduit.
+///
+/// `conduit_graphql` ships a [GraphQLController] — a [ResourceController]
+/// subclass that implements the
+/// [GraphQL-over-HTTP spec](https://graphql.github.io/graphql-over-http/draft/)
+/// for `POST` and `GET` against a hand-written
+/// [GraphQLSchema](package:graphql_schema2/graphql_schema2.dart).
+///
+/// This is **phase G1** of the Conduit GraphQL plan. The follow-up
+/// phases — schema derivation from `ManagedDataModel` (G2), SQL
+/// resolvers (G3), graph resolvers (G4), and cross-source dispatch
+/// + field-level auth (G5) — are not in this package yet.
+///
+/// See `README.md` for usage and the deferred-work list.
+library;
+
+// Re-export the schema + parser surfaces callers need to assemble a
+// hand-written schema. Re-exporting keeps callers from having to add
+// graphql_schema2 / graphql_parser2 / graphql_server2 to their own
+// pubspecs just to construct the argument to `GraphQLController`.
+export 'package:graphql_parser2/graphql_parser2.dart';
+export 'package:graphql_schema2/graphql_schema2.dart';
+export 'package:graphql_server2/graphql_server2.dart';
+
+export 'src/controller/graphql_controller.dart';
+export 'src/schema/builder.dart';

--- a/packages/graphql/lib/src/controller/graphql_controller.dart
+++ b/packages/graphql/lib/src/controller/graphql_controller.dart
@@ -1,0 +1,595 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:conduit_core/conduit_core.dart';
+import 'package:graphql_parser2/graphql_parser2.dart';
+import 'package:graphql_schema2/graphql_schema2.dart';
+import 'package:graphql_server2/graphql_server2.dart';
+
+/// GraphQL request / response key constants per the
+/// [GraphQL-over-HTTP spec](https://graphql.github.io/graphql-over-http/draft/).
+const _kQuery = 'query';
+const _kOperationName = 'operationName';
+const _kVariables = 'variables';
+// `extensions` is accepted on input but otherwise ignored in G1.
+const _kExtensions = 'extensions';
+
+/// The `application/graphql` content type — historical Apollo / Express
+/// convention where the request body is a raw GraphQL document with no
+/// JSON envelope. The current spec keeps it as an optional input form,
+/// and we accept it for compatibility.
+final _applicationGraphQL = ContentType('application', 'graphql');
+
+/// The standard, mandatory output content type.
+final _applicationJson = ContentType.json;
+
+/// The newer GraphQL-over-HTTP response media type. We answer `Accept:
+/// application/graphql-response+json` with this exact content type so
+/// negotiating clients see the spec-aligned envelope.
+final _applicationGraphQLResponseJson =
+    ContentType('application', 'graphql-response+json');
+
+/// Registers the `application/graphql-response+json` codec with
+/// Conduit's [CodecRegistry] exactly once. The spec defines this media
+/// type as JSON; we route it through the existing JSON codec so
+/// negotiating clients receive the spec-aligned envelope without
+/// callers having to register anything in their `ApplicationChannel`.
+bool _codecRegistered = false;
+void _ensureCodecRegistered() {
+  if (_codecRegistered) return;
+  CodecRegistry.defaultInstance.add(
+    ContentType('application', 'graphql-response+json', charset: 'utf-8'),
+    const JsonCodec(),
+  );
+  _codecRegistered = true;
+}
+
+/// HTTP transport for GraphQL.
+///
+/// Mount one of these on a route to expose a GraphQL endpoint backed by
+/// a hand-written [GraphQLSchema]. Implements the
+/// [GraphQL-over-HTTP spec](https://graphql.github.io/graphql-over-http/draft/)
+/// for the `POST` (queries + mutations) and `GET` (queries only) methods.
+///
+/// **G1 scope.** The schema is hand-assembled by the caller. Schema
+/// derivation from `ManagedDataModel` is deferred to G2; a resolver
+/// framework that integrates with `Query<T>` / `GraphQuery` is deferred
+/// to G3 / G4; field-level auth and cross-source dispatch is deferred
+/// to G5; subscriptions are out of scope for the entire plan.
+///
+/// ### Wire format
+///
+/// **Request body (POST, `application/json`).**
+///
+/// ```json
+/// {
+///   "query":         "<GraphQL document>",
+///   "operationName": "<optional>",
+///   "variables":     { "<name>": <value>, ... },
+///   "extensions":    { ... }   // accepted but ignored in G1
+/// }
+/// ```
+///
+/// **Request body (POST, `application/graphql`).** The full body is the
+/// query document; no JSON envelope.
+///
+/// **GET querystring.** `?query=...&operationName=...&variables=<JSON>`.
+/// Per the spec, GET is restricted to `query` operations — mutations
+/// receive HTTP 405.
+///
+/// **Response.** Always JSON, shape:
+///
+/// ```json
+/// { "data": ..., "errors": [ { "message": ..., "locations": [...], "path": [...], "extensions": {...} } ] }
+/// ```
+///
+/// Per the spec:
+///   * Parse / validate / variable-coercion failures are HTTP 400 with
+///     no `data` key.
+///   * Field-resolver / runtime errors are HTTP 200 with `errors[]` and
+///     `data: null` (the request was *processed*; the *result* was
+///     errored).
+///   * GET-of-mutation is HTTP 405.
+///   * Malformed JSON body or malformed `?variables=` is HTTP 400.
+class GraphQLController extends ResourceController {
+  /// Builds a controller that serves [schema] over GraphQL-over-HTTP.
+  GraphQLController(this.schema)
+      : _graphql = GraphQL(schema) {
+    _ensureCodecRegistered();
+    acceptedContentTypes = [_applicationJson, _applicationGraphQL];
+  }
+
+  /// The schema served at this endpoint.
+  ///
+  /// In G1 this is hand-written by the caller. G2 will introduce a
+  /// derivation path that walks `ManagedDataModel` and emits a schema
+  /// directly.
+  final GraphQLSchema schema;
+
+  /// The execution engine. Constructed once per controller-runtime so
+  /// schema introspection caches survive across requests.
+  final GraphQL _graphql;
+
+  // -- POST --------------------------------------------------------------
+
+  @Operation.post()
+  Future<Response> graphqlPost() async {
+    final request = this.request!;
+    final contentType = request.raw.headers.contentType;
+
+    String? query;
+    String? operationName;
+    Map<String, dynamic> variables = const {};
+
+    if (contentType != null &&
+        contentType.primaryType == _applicationGraphQL.primaryType &&
+        contentType.subType == _applicationGraphQL.subType) {
+      // `application/graphql` — body is the raw query document.
+      // ResourceController has already decoded the body for us; with
+      // this content type we expect the decoder to have produced a
+      // string (or bytes we can stringify).
+      final decoded = request.body.as<dynamic>();
+      if (decoded is String) {
+        query = decoded;
+      } else if (decoded is List<int>) {
+        query = utf8.decode(decoded);
+      } else {
+        return _httpErrorResponse(
+          HttpStatus.badRequest,
+          [_GqlError('Invalid application/graphql body: expected a string.')],
+          request,
+        );
+      }
+    } else {
+      // application/json envelope.
+      final dynamic body = request.body.as<dynamic>();
+      if (body is! Map<String, dynamic>) {
+        return _httpErrorResponse(
+          HttpStatus.badRequest,
+          [
+            _GqlError(
+              'Invalid GraphQL request: body must be a JSON object with a '
+              '"query" field.',
+            )
+          ],
+          request,
+        );
+      }
+      final dynamic q = body[_kQuery];
+      if (q is! String) {
+        return _httpErrorResponse(
+          HttpStatus.badRequest,
+          [_GqlError('Invalid GraphQL request: missing "query" field.')],
+          request,
+        );
+      }
+      query = q;
+      final dynamic name = body[_kOperationName];
+      if (name != null && name is! String) {
+        return _httpErrorResponse(
+          HttpStatus.badRequest,
+          [_GqlError('Invalid GraphQL request: "operationName" must be a string.')],
+          request,
+        );
+      }
+      operationName = name as String?;
+      final dynamic vars = body[_kVariables];
+      if (vars != null) {
+        if (vars is! Map) {
+          return _httpErrorResponse(
+            HttpStatus.badRequest,
+            [_GqlError('Invalid GraphQL request: "variables" must be an object.')],
+            request,
+          );
+        }
+        variables = Map<String, dynamic>.from(vars);
+      }
+      // `extensions` is accepted but ignored in G1.
+      final _ = body[_kExtensions];
+    }
+
+    return _executeAndRespond(
+      query: query,
+      operationName: operationName,
+      variables: variables,
+      allowMutations: true,
+      request: request,
+    );
+  }
+
+  // -- GET ---------------------------------------------------------------
+
+  @Operation.get()
+  Future<Response> graphqlGet(
+    @Bind.query(_kQuery) String query, {
+    @Bind.query(_kOperationName) String? operationName,
+    @Bind.query(_kVariables) String? variablesJson,
+  }) async {
+    final request = this.request!;
+
+    Map<String, dynamic> variables = const {};
+    if (variablesJson != null) {
+      try {
+        final dynamic parsed = json.decode(variablesJson);
+        if (parsed is! Map) {
+          return _httpErrorResponse(
+            HttpStatus.badRequest,
+            [
+              _GqlError(
+                'Invalid "variables" query parameter: expected a JSON object.',
+              )
+            ],
+            request,
+          );
+        }
+        variables = Map<String, dynamic>.from(parsed);
+      } on FormatException catch (e) {
+        return _httpErrorResponse(
+          HttpStatus.badRequest,
+          [_GqlError('Invalid "variables" query parameter: ${e.message}')],
+          request,
+        );
+      }
+    }
+
+    return _executeAndRespond(
+      query: query,
+      operationName: operationName,
+      variables: variables,
+      allowMutations: false,
+      request: request,
+    );
+  }
+
+  // -- Core --------------------------------------------------------------
+
+  /// Parses, validates, and executes [query], formatting the response
+  /// per the GraphQL-over-HTTP spec.
+  ///
+  /// [allowMutations] is false for GET. We pre-parse the document so we
+  /// can detect the operation type before handing it to `parseAndExecute`,
+  /// because the spec requires GET-of-mutation to fail with 405 (not
+  /// 200/`errors`).
+  Future<Response> _executeAndRespond({
+    required String query,
+    required String? operationName,
+    required Map<String, dynamic> variables,
+    required bool allowMutations,
+    required Request request,
+  }) async {
+    // Step 1: parse. We do this ourselves so we can sniff the
+    // operation type and surface parse errors as HTTP 400.
+    DocumentContext document;
+    try {
+      final tokens = scan(query);
+      final parser = Parser(tokens);
+      document = parser.parseDocument();
+      if (parser.errors.isNotEmpty) {
+        return _httpErrorResponse(
+          HttpStatus.badRequest,
+          parser.errors
+              .map(
+                (e) => _GqlError(
+                  'Syntax error: ${e.message}',
+                  locations: e.span == null
+                      ? const []
+                      : [
+                          _GqlLocation(
+                            e.span!.start.line + 1,
+                            e.span!.start.column + 1,
+                          )
+                        ],
+                ),
+              )
+              .toList(),
+          request,
+        );
+      }
+    } on Object catch (e) {
+      return _httpErrorResponse(
+        HttpStatus.badRequest,
+        [_GqlError('Syntax error: $e')],
+        request,
+      );
+    }
+
+    // Step 2: enforce GET = query-only.
+    if (!allowMutations) {
+      final ops = document.definitions.whereType<OperationDefinitionContext>();
+      OperationDefinitionContext? selected;
+      if (operationName != null) {
+        selected = ops.where((op) => op.name == operationName).firstOrNull;
+      } else if (ops.length == 1) {
+        selected = ops.first;
+      }
+      if (selected != null && (selected.isMutation || selected.isSubscription)) {
+        return Response(
+          HttpStatus.methodNotAllowed,
+          {HttpHeaders.allowHeader: 'POST'},
+          {
+            'errors': [
+              {
+                'message':
+                    'GraphQL ${selected.isMutation ? "mutations" : "subscriptions"} '
+                    'must use HTTP POST.',
+              }
+            ]
+          },
+        )..contentType = _negotiatedJsonContentType(request);
+      }
+    }
+
+    // Step 2b: validate that selected fields exist on their parent
+    // type. graphql_server2 6.5.0 silently skips unknown fields rather
+    // than rejecting them; we add a minimal pre-validation pass so
+    // typos and stale clients surface as HTTP 400 / `errors[]` per the
+    // GraphQL-over-HTTP spec.
+    final validationErrors = _validateFieldExistence(document, schema);
+    if (validationErrors.isNotEmpty) {
+      return _httpErrorResponse(
+        HttpStatus.badRequest,
+        validationErrors,
+        request,
+      );
+    }
+
+    // Step 3: execute.
+    try {
+      final dynamic data = await _graphql.parseAndExecute(
+        query,
+        operationName: operationName,
+        variableValues: variables,
+        // Make the conduit Request available to resolvers (G3+ will
+        // need this for auth + dependency injection).
+        globalVariables: <String, dynamic>{
+          'conduitRequest': request,
+        },
+      );
+
+      if (data is Stream) {
+        // Subscriptions are out of scope; if someone hand-rolls a
+        // subscription type, the spec says reject with an explicit
+        // error rather than streaming.
+        return _httpErrorResponse(
+          HttpStatus.badRequest,
+          [_GqlError('Subscriptions are not supported over HTTP.')],
+          request,
+        );
+      }
+
+      return _jsonResponse(
+        HttpStatus.ok,
+        {'data': data},
+        request,
+      );
+    } on GraphQLException catch (e) {
+      // graphql_server2 throws GraphQLException for all server-side
+      // failures it can attribute (variable coercion, missing required
+      // operation, etc.). Per the GraphQL-over-HTTP spec these are
+      // *request errors* and warrant HTTP 400 — the request was not
+      // executable.
+      return _httpErrorResponse(
+        HttpStatus.badRequest,
+        e.errors.map(_GqlError.fromUpstream).toList(),
+        request,
+      );
+    } on Object catch (e, st) {
+      // Anything else is a *field error* — a resolver threw. Per
+      // §7.1.2 of the GraphQL spec and the GraphQL-over-HTTP spec,
+      // these are returned with HTTP 200, `data: null`, and the
+      // failure represented in `errors[]`. (graphql_server2 v6.5.0
+      // does not trap these into the result map itself; see the
+      // README "G1 status & known limitations" section for context.)
+      logger.fine(
+        'GraphQL field resolver threw — surfacing as 200/errors',
+        e,
+        st,
+      );
+      return _jsonResponse(
+        HttpStatus.ok,
+        {
+          'data': null,
+          'errors': [
+            _GqlError(e.toString()).toJson(),
+          ],
+        },
+        request,
+      );
+    }
+  }
+
+  // -- Response helpers --------------------------------------------------
+
+  Response _httpErrorResponse(
+    int status,
+    List<_GqlError> errors,
+    Request request,
+  ) {
+    return Response(
+      status,
+      null,
+      {'errors': errors.map((e) => e.toJson()).toList()},
+    )..contentType = _negotiatedJsonContentType(request);
+  }
+
+  /// JSON-envelope response builder that honors the negotiated GraphQL
+  /// content type (`application/json` by default, switching to
+  /// `application/graphql-response+json` when the client asks for it).
+  Response _jsonResponse(
+    int status,
+    Map<String, dynamic> body,
+    Request request,
+  ) {
+    return Response(status, null, body)
+      ..contentType = _negotiatedJsonContentType(request);
+  }
+
+  /// Picks the JSON-family content type for the response based on the
+  /// client's Accept header, defaulting to `application/json`.
+  ContentType _negotiatedJsonContentType(Request request) {
+    for (final accept in request.acceptableContentTypes) {
+      if (accept.primaryType == _applicationGraphQLResponseJson.primaryType &&
+          accept.subType == _applicationGraphQLResponseJson.subType) {
+        return _applicationGraphQLResponseJson;
+      }
+    }
+    return _applicationJson;
+  }
+}
+
+// -- Internal error model ---------------------------------------------------
+
+/// Internal helper bundling the four spec-defined error fields
+/// (`message`, `locations`, `path`, `extensions`) with a `toJson` that
+/// omits empty fields per the spec.
+class _GqlError {
+  _GqlError(
+    this.message, {
+    this.locations = const [],
+    // `path` and `extensions` are part of the GraphQL spec error shape
+    // but no code path inside G1 produces them yet — resolver-side
+    // errors land inside graphql_server2's own envelope, and field-
+    // level extensions arrive in G5. Keeping the constructor surface
+    // ready avoids churn when those phases land.
+    // ignore: unused_element_parameter
+    this.path = const [],
+    // ignore: unused_element_parameter
+    this.extensions = const {},
+  });
+
+  factory _GqlError.fromUpstream(GraphQLExceptionError e) {
+    return _GqlError(
+      e.message,
+      locations: e.locations
+          .map((l) => _GqlLocation(l.line, l.column))
+          .toList(),
+    );
+  }
+
+  final String message;
+  final List<_GqlLocation> locations;
+  final List<Object> path;
+  final Map<String, Object?> extensions;
+
+  Map<String, dynamic> toJson() {
+    final out = <String, dynamic>{'message': message};
+    if (locations.isNotEmpty) {
+      out['locations'] = locations.map((l) => l.toJson()).toList();
+    }
+    if (path.isNotEmpty) out['path'] = path;
+    if (extensions.isNotEmpty) out['extensions'] = extensions;
+    return out;
+  }
+}
+
+class _GqlLocation {
+  _GqlLocation(this.line, this.column);
+  final int line;
+  final int column;
+  Map<String, int> toJson() => {'line': line, 'column': column};
+}
+
+extension _IterableFirstOrNull<E> on Iterable<E> {
+  E? get firstOrNull {
+    final it = iterator;
+    if (!it.moveNext()) return null;
+    return it.current;
+  }
+}
+
+// -- Field-existence validator ---------------------------------------------
+
+/// Walks each operation in [document] and reports any field that is
+/// not defined on its parent type in [schema].
+///
+/// This is a deliberately narrow subset of the GraphQL spec's
+/// validation rules — `graphql_server2` v6.5.0 silently drops unknown
+/// fields rather than rejecting the request, which violates the
+/// GraphQL-over-HTTP spec's expectation that validation errors come
+/// back as HTTP 400 with `errors[]`. Until the upstream validator
+/// lands (or we adopt a separate validator package), this catches the
+/// common "typo in query" and "stale client" cases that production
+/// users hit first. Fragment spreads, inline fragments, and
+/// argument-shape validation are deferred to the upstream executor.
+List<_GqlError> _validateFieldExistence(
+  DocumentContext document,
+  GraphQLSchema schema,
+) {
+  final errors = <_GqlError>[];
+  for (final op in document.definitions.whereType<OperationDefinitionContext>()) {
+    GraphQLObjectType? root;
+    if (op.isMutation) {
+      root = schema.mutationType;
+    } else if (op.isSubscription) {
+      root = schema.subscriptionType;
+    } else {
+      root = schema.queryType;
+    }
+    if (root == null) continue;
+    _checkSelectionSet(op.selectionSet, root, errors);
+  }
+  return errors;
+}
+
+void _checkSelectionSet(
+  SelectionSetContext set,
+  GraphQLObjectType type,
+  List<_GqlError> errors,
+) {
+  for (final sel in set.selections) {
+    final field = sel.field;
+    if (field == null) continue; // fragments handled by upstream executor
+    final name = field.fieldName.alias?.name ?? field.fieldName.name;
+    if (name == null) continue;
+    // Introspection fields and `__typename` are universally available.
+    if (name.startsWith('__')) continue;
+    final defined = type.fields.firstWhereOrNull((f) => f.name == name);
+    if (defined == null) {
+      final span = field.fieldName.span;
+      errors.add(
+        _GqlError(
+          'Cannot query field "$name" on type "${type.name}".',
+          locations: span == null
+              ? const []
+              : [_GqlLocation(span.start.line + 1, span.start.column + 1)],
+        ),
+      );
+      continue;
+    }
+    // Recurse into nested selection sets when the declared field is
+    // itself an object type. Lists / non-null wrappers unwrap.
+    final nested = field.selectionSet;
+    if (nested != null) {
+      final inner = _unwrapObjectType(defined.type);
+      if (inner != null) {
+        _checkSelectionSet(nested, inner, errors);
+      }
+    }
+  }
+}
+
+GraphQLObjectType? _unwrapObjectType(GraphQLType type) {
+  GraphQLType current = type;
+  while (true) {
+    if (current is GraphQLObjectType) return current;
+    if (current is GraphQLNonNullableType) {
+      current = current.ofType;
+      continue;
+    }
+    if (current is GraphQLListType) {
+      current = current.ofType;
+      continue;
+    }
+    return null;
+  }
+}
+
+extension _FieldsFirstOrNull<E> on List<E> {
+  E? firstWhereOrNull(bool Function(E) test) {
+    for (final e in this) {
+      if (test(e)) return e;
+    }
+    return null;
+  }
+}

--- a/packages/graphql/lib/src/schema/builder.dart
+++ b/packages/graphql/lib/src/schema/builder.dart
@@ -1,0 +1,62 @@
+import 'package:conduit_core/conduit_core.dart';
+import 'package:graphql_schema2/graphql_schema2.dart';
+
+/// Forward-declared entry point for schema derivation from a Conduit
+/// data model.
+///
+/// **Status: G2 placeholder.** G1 ships only the HTTP transport — the
+/// `GraphQLController` accepts a hand-written [GraphQLSchema]. This
+/// class exists so callers can already see (and import) the API surface
+/// that G2 will fill in; every method is currently
+/// `UnimplementedError`.
+///
+/// ### Design intent for G2
+///
+/// G2 will walk a [ManagedDataModel] and emit a [GraphQLSchema]
+/// directly, mirroring the deferred-ref pattern used by Conduit's
+/// existing OpenAPI emitter (`packages/common/lib/src/openapi/`):
+///
+/// 1. Iterate every [ManagedEntity] in the model.
+/// 2. For each entity, emit a `GraphQLObjectType` whose fields are
+///    derived from `ManagedAttributeDescription` (scalars, dates,
+///    booleans, transient props) and `ManagedRelationshipDescription`
+///    (object / list relationships).
+/// 3. Resolve circular references lazily — relationships register a
+///    deferred reference into the type registry, exactly like
+///    `APIComponentCollection<T>` does for OpenAPI schemas.
+/// 4. Emit input types for `where:` / `orderBy:` / `limit:` / `offset:`
+///    arguments on root-`Query` fields. The argument shape lowers to
+///    `Query<T>` predicates in G3.
+///
+/// ### Why this is here in G1
+///
+/// Pinning the public name and import path now means G2 lands as a
+/// pure addition rather than a rename — downstream callers writing
+/// hand-written schemas in G1 can structure their wire-up around this
+/// class and replace their hand-built [GraphQLSchema] with
+/// `SchemaBuilder.fromManagedDataModel(...)` in G2 without touching
+/// the controller mount.
+class SchemaBuilder {
+  SchemaBuilder._();
+
+  /// Derives a [GraphQLSchema] from [model].
+  ///
+  /// G2 work item. See class-level docs for the planned algorithm.
+  static GraphQLSchema fromManagedDataModel(ManagedDataModel model) {
+    throw UnimplementedError(
+      'SchemaBuilder.fromManagedDataModel: schema derivation lands in G2 of '
+      'the conduit_graphql plan. For G1, hand-assemble a GraphQLSchema and '
+      'pass it directly to GraphQLController.',
+    );
+  }
+
+  /// Derives a `GraphQLObjectType` for a single [entity], without
+  /// closing over the rest of the model. G2 will use this to register
+  /// types into a shared registry as it walks the model.
+  static GraphQLObjectType objectTypeFor(ManagedEntity entity) {
+    throw UnimplementedError(
+      'SchemaBuilder.objectTypeFor: schema derivation lands in G2 of the '
+      'conduit_graphql plan.',
+    );
+  }
+}

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -1,0 +1,27 @@
+name: conduit_graphql
+description: GraphQL HTTP transport for conduit. Mounts a GraphQLController over a hand-written GraphQLSchema; schema derivation, resolver framework, and cross-source dispatch are deferred to later phases.
+version: 6.0.0
+home: https://www.theconduit.dev
+repository: https://github.com/conduit-dart/conduit
+issue_tracker: https://github.com/conduit-dart/conduit/issues
+
+environment:
+  sdk: ">=3.12.0-0 <4.0.0"
+resolution: workspace
+
+dependencies:
+  conduit_core: ^6.0.0
+  graphql_parser2: ^6.5.0
+  graphql_schema2: ^6.5.0
+  graphql_server2: ^6.5.0
+
+dev_dependencies:
+  http: ^1.2.0
+  lints: ^6.0.0
+  test: ^1.25.2
+  # `test_core` exposes `getUnsafeUnusedPort`, used by the e2e helper
+  # copied from `packages/core/test/_helpers/free_port.dart`. It comes
+  # in transitively via `test`, but the analyzer's
+  # `depend_on_referenced_packages` lint requires we depend on it
+  # directly when we import its `src/util/io.dart`.
+  test_core: any

--- a/packages/graphql/test/_helpers/free_port.dart
+++ b/packages/graphql/test/_helpers/free_port.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:conduit_core/conduit_core.dart';
+import 'package:test_core/src/util/io.dart' show getUnsafeUnusedPort;
+
+/// Builds an [Application], assigns it an OS-picked free port, and starts
+/// it — retrying on EADDRINUSE.
+///
+/// Copied from `packages/core/test/_helpers/free_port.dart` (see #272).
+/// This is intentionally test-private code that the per-package test
+/// suites depend on; pre-G5 there's no shared `conduit_test_kit`
+/// package, so copy-paste keeps each package's tests self-contained.
+///
+/// `getUnusedPort` from `package:test_core` has a built-in race window: it
+/// binds a probe socket on port 0 to discover an unused port, closes the
+/// socket, and returns the port number. Between the close and the actual
+/// downstream `HttpServer.bind`, another process can grab the port. The
+/// usual mitigation is to perform the real bind *inside* the `tryPort`
+/// callback so a null return triggers a fresh port — but
+/// `Application.start` rolls in isolate spawning + supervisor wiring,
+/// which the simple null-retry contract doesn't model cleanly.
+///
+/// This helper handles the retry explicitly: each attempt builds a fresh
+/// [Application] via [build], assigns a probed port, and calls `start`. If
+/// `start` throws a [SocketException] with EADDRINUSE (errno 48 on macOS
+/// or 98 on Linux), the failed app is stopped and the loop retries with a
+/// new port. Other failures propagate.
+Future<({Application<T> app, int port})>
+    startWithFreePort<T extends ApplicationChannel>(
+  Application<T> Function() build, {
+  int numberOfInstances = 1,
+  int maxAttempts = 10,
+}) async {
+  Object? lastError;
+  StackTrace? lastStack;
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    final candidate = await getUnsafeUnusedPort();
+    final app = build();
+    app.options.port = candidate;
+    try {
+      await app.start(numberOfInstances: numberOfInstances);
+      return (app: app, port: candidate);
+    } on SocketException catch (e, st) {
+      if (_isAddrInUse(e)) {
+        await _safeStop(app);
+        lastError = e;
+        lastStack = st;
+        continue;
+      }
+      await _safeStop(app);
+      rethrow;
+    } on ApplicationStartupException catch (e, st) {
+      // Application.start wraps the underlying SocketException as
+      // ApplicationStartupException for the multi-isolate path; sniff
+      // the message to decide whether this is the same race.
+      if (e.toString().contains('Failed to create server socket') &&
+          e.toString().contains('Address already in use')) {
+        await _safeStop(app);
+        lastError = e;
+        lastStack = st;
+        continue;
+      }
+      await _safeStop(app);
+      rethrow;
+    }
+  }
+  throw StateError(
+    'startWithFreePort: could not bind a free port after $maxAttempts '
+    'attempts. Last error: $lastError\n$lastStack',
+  );
+}
+
+bool _isAddrInUse(SocketException e) {
+  final code = e.osError?.errorCode;
+  return code == 48 || code == 98; // macOS / Linux
+}
+
+Future<void> _safeStop(Application<dynamic> app) async {
+  try {
+    await app.stop();
+  } catch (_) {
+    // Stop can fail if start did not get far enough to register
+    // supervisors; ignore — the retry will build a fresh app.
+  }
+}

--- a/packages/graphql/test/fixtures/hello_schema.dart
+++ b/packages/graphql/test/fixtures/hello_schema.dart
@@ -1,0 +1,57 @@
+import 'package:conduit_graphql/conduit_graphql.dart';
+
+/// A tiny hand-written schema used by the unit + e2e tests.
+///
+/// G1 ships only the HTTP transport — schemas are caller-supplied. This
+/// fixture exists purely to exercise the controller's plumbing (parse,
+/// validate, execute, error envelopes, introspection). G2 will replace
+/// the hand-written path with derivation from `ManagedDataModel`, but
+/// hand-written schemas remain the supported authoring path.
+///
+/// `graphql_server2`'s executor casts resolvers down to
+/// `(dynamic, Map<String, dynamic>) => dynamic` regardless of the
+/// generic types declared on `field<Value, Serialized>`. To stay
+/// compatible we leave the resolver closures untyped — Dart's
+/// generic-function inference would otherwise specialize them and
+/// trigger a runtime cast failure inside the executor.
+final GraphQLSchema helloSchema = graphQLSchema(
+  queryType: objectType(
+    'Query',
+    fields: [
+      field(
+        'hello',
+        graphQLString,
+        resolve: (_, _) => 'world',
+      ),
+      field(
+        'echo',
+        graphQLString,
+        inputs: [
+          GraphQLFieldInput('message', graphQLString.nonNullable()),
+        ],
+        resolve: (_, args) => args['message'] as String,
+      ),
+      // Used by the "resolver throws" test. Spec says runtime resolver
+      // errors come back inside the JSON envelope, not as HTTP 4xx.
+      field(
+        'boom',
+        graphQLString,
+        resolve: (_, _) => throw StateError('boom'),
+      ),
+    ],
+  ),
+  mutationType: objectType(
+    'Mutation',
+    fields: [
+      field(
+        'shout',
+        graphQLString,
+        inputs: [
+          GraphQLFieldInput('message', graphQLString.nonNullable()),
+        ],
+        resolve: (_, args) =>
+            (args['message'] as String).toUpperCase(),
+      ),
+    ],
+  ),
+);

--- a/packages/graphql/test/graphql_controller_test.dart
+++ b/packages/graphql/test/graphql_controller_test.dart
@@ -1,0 +1,245 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:conduit_core/conduit_core.dart';
+import 'package:conduit_graphql/conduit_graphql.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'fixtures/hello_schema.dart';
+
+/// Spins up an HttpServer with a single GraphQLController mounted at
+/// `/graphql`. This is the in-process variant — no isolate, no
+/// `Application` overhead — for fast unit tests of the controller's
+/// HTTP envelope behavior. The end-to-end isolate path lives in
+/// `graphql_e2e_test.dart`.
+Future<HttpServer> _startServer(GraphQLSchema schema) async {
+  final router = Router();
+  router.route('/graphql').link(() => GraphQLController(schema));
+  router.didAddToChannel();
+
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.map(Request.new).listen(router.receive);
+  return server;
+}
+
+Uri _u(HttpServer s, [Map<String, String>? q]) => Uri(
+      scheme: 'http',
+      host: 'localhost',
+      port: s.port,
+      path: '/graphql',
+      queryParameters: q,
+    );
+
+Future<http.Response> _post(
+  HttpServer s,
+  Object body, {
+  String contentType = 'application/json',
+}) {
+  return http.post(
+    _u(s),
+    headers: {'content-type': contentType},
+    body: body is String ? body : json.encode(body),
+  );
+}
+
+void main() {
+  late HttpServer server;
+
+  setUpAll(() {
+    hierarchicalLoggingEnabled = true;
+    Logger('conduit')
+      ..level = Level.ALL
+      ..onRecord.listen((r) {
+        // ignore: avoid_print
+        print('[conduit] ${r.level.name}: ${r.message} ${r.error ?? ''}\n${r.stackTrace ?? ''}');
+      });
+  });
+
+  setUp(() async {
+    server = await _startServer(helloSchema);
+  });
+
+  tearDown(() async {
+    await server.close(force: true);
+  });
+
+  test('POST { hello } returns data.hello == "world"', () async {
+    final res = await _post(server, {'query': '{ hello }'});
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body);
+    expect(body, {
+      'data': {'hello': 'world'}
+    });
+  });
+
+  test('POST query with variables resolves correctly', () async {
+    final res = await _post(server, {
+      'query': r'query Echo($m: String!) { echo(message: $m) }',
+      'variables': {'m': 'hi'},
+    });
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body);
+    expect(body, {
+      'data': {'echo': 'hi'}
+    });
+  });
+
+  test('POST malformed JSON body returns 400', () async {
+    final res = await _post(server, '{not json,');
+    expect(res.statusCode, 400);
+  });
+
+  test('POST query with parse error returns 400 with Syntax message',
+      () async {
+    final res = await _post(server, {'query': '{ hello'});
+    expect(res.statusCode, 400);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    final errors = body['errors'] as List;
+    expect(errors, isNotEmpty);
+    expect(errors.first['message'] as String, contains('Syntax'));
+  });
+
+  test(
+      'POST query referencing undefined field returns 400 with field name in error',
+      () async {
+    final res = await _post(server, {'query': '{ nonexistentField }'});
+    expect(res.statusCode, 400);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    final errors = body['errors'] as List;
+    expect(errors, isNotEmpty);
+    expect(errors.first['message'] as String, contains('nonexistentField'));
+  });
+
+  test(
+      'POST mutation that throws returns 200 with errors array (per spec)',
+      () async {
+    final res = await _post(server, {'query': '{ boom }'});
+    // Per the GraphQL-over-HTTP spec, a resolver that throws is still
+    // a *processed* request — the result map carries `errors` and the
+    // failed field is null. HTTP status stays 200.
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    final errors = body['errors'] as List;
+    expect(errors, isNotEmpty);
+    expect((errors.first as Map)['message'], isNotEmpty);
+    expect((body['data'] as Map?)?['boom'], isNull);
+  });
+
+  test('GET ?query={hello} returns 200 with data.hello', () async {
+    final res = await http.get(_u(server, {'query': '{ hello }'}));
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body);
+    expect(body, {
+      'data': {'hello': 'world'}
+    });
+  });
+
+  test('GET attempting a mutation returns 405', () async {
+    final res =
+        await http.get(_u(server, {'query': 'mutation { shout(message: "hi") }'}));
+    expect(res.statusCode, 405);
+    expect(res.headers['allow'], contains('POST'));
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    expect(body['errors'], isNotEmpty);
+  });
+
+  test('GET ?variables=invalid-json returns 400', () async {
+    final res = await http.get(_u(server, {
+      'query': '{ hello }',
+      'variables': 'not-json',
+    }));
+    expect(res.statusCode, 400);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    expect(body['errors'], isNotEmpty);
+  });
+
+  test('Content-Type application/graphql raw body parses correctly',
+      () async {
+    final res = await _post(
+      server,
+      '{ hello }',
+      contentType: 'application/graphql',
+    );
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body);
+    expect(body, {
+      'data': {'hello': 'world'}
+    });
+  });
+
+  test('Introspection: { __schema { queryType { name } } } returns "Query"',
+      () async {
+    final res = await _post(server, {
+      'query': '{ __schema { queryType { name } } }',
+    });
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    final data = body['data'] as Map<String, dynamic>;
+    final schemaField = data['__schema'] as Map<String, dynamic>;
+    final queryType = schemaField['queryType'] as Map<String, dynamic>;
+    expect(queryType['name'], 'Query');
+  });
+
+  test('POST mutation succeeds (POST allows mutations)', () async {
+    final res = await _post(server, {
+      'query': r'mutation S($m: String!) { shout(message: $m) }',
+      'variables': {'m': 'hello'},
+    });
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body);
+    expect(body, {
+      'data': {'shout': 'HELLO'}
+    });
+  });
+
+  test('POST without query field returns 400', () async {
+    final res = await _post(server, {'operationName': 'Foo'});
+    expect(res.statusCode, 400);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    expect(body['errors'], isNotEmpty);
+  });
+
+  test('POST with non-object variables returns 400', () async {
+    final res = await _post(server, {
+      'query': '{ hello }',
+      'variables': 'not-an-object',
+    });
+    expect(res.statusCode, 400);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    expect(body['errors'], isNotEmpty);
+  });
+
+  test(
+      'Accept: application/graphql-response+json returns matching content type',
+      () async {
+    final res = await http.post(
+      _u(server),
+      headers: {
+        'content-type': 'application/json',
+        'accept': 'application/graphql-response+json',
+      },
+      body: json.encode({'query': '{ hello }'}),
+    );
+    expect(res.statusCode, 200);
+    expect(res.headers['content-type'],
+        contains('application/graphql-response+json'));
+  });
+
+  test(
+      'Operation selection: operationName picks the right operation',
+      () async {
+    final res = await _post(server, {
+      'query': '''
+query A { hello }
+query B { echo(message: "from-B") }
+''',
+      'operationName': 'B',
+    });
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body);
+    expect(body, {
+      'data': {'echo': 'from-B'}
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ workspace:
   - packages/core
   - packages/graph
   - packages/graph_neo4j
+  - packages/graphql
   - packages/isolate_exec
   - packages/open_api
   - packages/password_hash
@@ -85,6 +86,7 @@ melos:
                             -V conduit_core:$v \
                             -V conduit_graph:$v \
                             -V conduit_graph_neo4j:$v \
+                            -V conduit_graphql:$v \
                             -V conduit_isolate_exec:$v \
                             -V conduit_mysql:$v \
                             -V conduit_open_api:$v \


### PR DESCRIPTION
## Summary

First phase of the [Conduit GraphQL evaluation plan](https://github.com/conduit-dart/conduit/blob/master/CHANGELOG.md) (private plan: section _CONDUIT — GraphQL evaluation: mapping abstraction across data sources_, 2026-05-06). Adds a new workspace package `packages/graphql/` (`conduit_graphql`) that ships the HTTP transport for a hand-written `GraphQLSchema`. This is the minimum useful slice — schema derivation, resolvers, dataloader, and field-level auth all land in subsequent phases.

## In scope (G1)

- `GraphQLController extends ResourceController` mounting at any route, implementing the [GraphQL-over-HTTP spec](https://graphql.github.io/graphql-over-http/draft/) for `POST` (queries + mutations) and `GET` (queries only).
- JSON envelope on the wire. Registers `application/graphql-response+json` with Conduit's `CodecRegistry` on first `GraphQLController` construction, so negotiating clients (`Accept: application/graphql-response+json`) get the spec-aligned media type without any per-app wiring.
- Spec-aligned HTTP status mapping:
  - `200` for processed requests (resolver-runtime errors stay inside the JSON envelope per spec § 7.1.2).
  - `400` for parse, validation, missing-`query`, malformed `?variables=`, or variable-coercion errors.
  - `405` for `GET` of a `mutation` / `subscription`, with `Allow: POST`.
- Pre-execution field-existence validator that works around an upstream gap in `graphql_server2` v6.5.0 (which silently drops unknown field selections rather than rejecting them).
- `SchemaBuilder` forward-declared as a stub for G2 — every method throws `UnimplementedError('schema derivation lands in G2')`. Pinning the public name now lets G2 ship as a pure addition.
- 16 integration tests covering hello-world query / mutation / variables, parse and validation errors, content-type negotiation, GET-of-mutation rejection, introspection, and operation-name selection. All green.
- Re-exports `graphql_parser2` / `graphql_schema2` / `graphql_server2` so callers do not need to add those to their own `pubspec.yaml`.
- README with the wire-up example, full wire-format reference, and known-limitations log.

## Out of scope (deferred to later phases)

| Phase  | Scope |
|--------|-------|
| **G2** | Derive `GraphQLSchema` from `ManagedDataModel` (mirrors the OpenAPI emitter's deferred-ref walker). |
| G3     | SQL `Resolver` factory lowering `where:` / `orderBy:` / `limit:` / `offset:` args to `Query<T>` calls; dataloader (~150 LOC) for N+1 mitigation. |
| G4     | Graph `Resolver` factory against `GraphQuery<N>` / `GraphFilterExpression`; edge-property fields as connection types. |
| G5     | Cross-source dispatch via `Persistence<G>`; `@FieldAuthorize(scopes: [...])` annotation honored at execution. |

GraphQL **subscriptions are out of scope for the entire plan** — Conduit core has no WebSocket transport, and the cost/benefit doesn't pencil out until measured demand surfaces.

## Library activeness

Per the project's "active libraries only" rule (~12-month freshness window): `graphql_server2`, `graphql_schema2`, and `graphql_parser2` from `dukefirehawk` are ~5 months old (BSD-3, all current versions on pub.dev as of 2026-05-06). The `leto` family was rejected (~2 years stale).

## Test plan

- [x] `melos bootstrap` from the repo root — succeeds, 18 packages bootstrapped.
- [x] `cd packages/graphql && dart analyze .` — zero issues.
- [x] `cd packages/graphql && dart test` — 16/16 passing.
- [x] `cd packages/core && dart test -r failures-only` — 1123 passing, 7 skipped (unchanged from master baseline at `a21907bb`).
- [ ] CI matrix on the PR (Postgres / SQLite / MySQL).

## Known limitations carried into G2

- `graphql_server2` v6.5.0 silently drops unknown field selections; we work around this with a minimal pre-execution validator. Fragment spreads / inline fragments are not yet checked locally and fall through to the upstream executor.
- Field-resolver runtime errors do not yet populate `path` — the upstream `GraphQLException` does not attribute paths, and the path machinery lands with the dataloader in G3.
- The hand-written-schema path is the canonical entry point; G2 will introduce `SchemaBuilder.fromManagedDataModel(...)` as an additional way to construct the `GraphQLSchema` argument to `GraphQLController`. The controller's contract does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)