### PR TITLE
chore(ci): run packages/core/bench/* on every PR (non-gating)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,3 +81,27 @@ jobs:
       - name: Run tests
         working-directory: ${{ env.TEST_DIR }}
         run: . ../../ci/.env && dart test -r failures-only
+  bench:
+    needs: smoke
+    runs-on: ubuntu-latest
+    # Non-gating: surfaces bench numbers in the run summary so reviewers
+    # can eyeball regressions without blocking the PR. Pair with the
+    # methodology + verdict captured in packages/core/bench/RESULTS.md.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: beta
+      - name: Bootstrap
+        run: |
+          export PUB_CACHE="$HOME/.pub-cache"
+          export PATH="$PATH:$PUB_CACHE/bin"
+          echo "PUB_CACHE=$PUB_CACHE" >> "$GITHUB_ENV"
+          echo "$PUB_CACHE/bin" >> "$GITHUB_PATH"
+          dart pub global activate melos
+          melos bootstrap
+      - name: Run benches
+        working-directory: packages/core
+        run: bash ../../ci/run-benches.sh
+        continue-on-error: true

--- a/ci/run-benches.sh
+++ b/ci/run-benches.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Runs each bench under packages/core/bench/, captures stdout to a file,
+# and appends a fenced markdown block per bench to GITHUB_STEP_SUMMARY so
+# the numbers show up inline on the run page. Non-gating: a single bench
+# crashing prints the failure but does not abort the others.
+#
+# Run from packages/core/ (the workflow sets working-directory).
+set -u
+
+summary="${GITHUB_STEP_SUMMARY:-/dev/stderr}"
+
+{
+  echo "# Bench results"
+  echo
+  echo "_Non-gating microbenchmarks. See \`packages/core/bench/RESULTS.md\` for"
+  echo "methodology, baseline, and the post-#267 verdict._"
+  echo
+} >> "$summary"
+
+for bench in bench/predicate_construction_bench.dart \
+             bench/ast_render_bench.dart \
+             bench/query_e2e_bench.dart; do
+  name="$(basename "$bench" .dart)"
+  out="$(mktemp)"
+  echo "::group::$name"
+  if dart run "$bench" 2>&1 | tee "$out"; then
+    status="ok"
+  else
+    status="FAILED"
+  fi
+  echo "::endgroup::"
+  {
+    echo "## $name ($status)"
+    echo
+    echo '```'
+    cat "$out"
+    echo '```'
+    echo
+  } >> "$summary"
+  rm -f "$out"
+done


### PR DESCRIPTION
## Summary

Adds a `bench` job to `.github/workflows/linux.yml` that runs the three benches from #270 on every PR and writes the numbers to the GitHub run summary as fenced markdown. Non-gating — `continue-on-error: true` at both the job and the bench-execution step level so a flaky or crashing bench prints to the summary but does not block the PR.

The intent matches RESULTS.md: spot drift visually on each PR; the canonical reference numbers + methodology still live in `packages/core/bench/RESULTS.md`. CI gates on noise floor are deliberately out of scope until that floor is characterized in CI conditions.

### Files

- `.github/workflows/linux.yml` — new `bench` job, `needs: smoke`, beta SDK, no matrix.
- `ci/run-benches.sh` — runs `predicate_construction_bench`, `ast_render_bench`, `query_e2e_bench` and appends each invocation's stdout to `\$GITHUB_STEP_SUMMARY` under a fenced block per bench.

### Local verification

Bootstrap + `bash ci/run-benches.sh` from `packages/core/` on the same Ryzen 9 9950X used for #270's RESULTS.md. All three benches ran clean; summary file populated as expected. Numbers within the RESULTS.md envelope:

\`\`\`
predicate: 5-term AND     ~15.5 µs   (RESULTS.md: 15.48)
predicate: 10-term AND    ~29.7 µs   (RESULTS.md: 29.18)
ast render: 5-term named   ~8.8 µs   (RESULTS.md: 8.65)
query e2e: 10-term named   ~50.3 µs  (RESULTS.md: 49.89)
\`\`\`

## Test plan

- [ ] PR-CI Linux workflow runs the new `bench` job to completion
- [ ] Bench numbers appear in the run summary under fenced markdown blocks
- [ ] Existing `smoke` and `unit` jobs are unaffected