### PR TITLE
chore(release): prep v7.0.0 (CHANGELOGs, version bump, workflow refactor)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,122 +1,349 @@
 name: Release
 
+# Two trigger modes:
+#
+#   1. workflow_dispatch — operator-driven dry runs (validate the release
+#      candidate without touching pub.dev) and explicit dispatched real
+#      releases when the operator does not want to push a tag yet.
+#
+#   2. tag push (v*.*.*) — the canonical release trigger. The operator
+#      pushes `vX.Y.Z` after the workspace pubspec.yaml is on `version: X.Y.Z`
+#      and CHANGELOG sections are in place. CI gates publish on green.
+#
+# This is the deliberate replacement for the previous head-commit-prefix
+# trigger ("publish on every feat|fix|... master commit"), which silently
+# republished the same workspace version on every feature merge and
+# masked publish-time failures (exactly how `conduit_sqlite`, `_mysql`,
+# `_graph`, `_graph_neo4j`, and `_graphql` were never published despite
+# being versioned at 6.0.0 since Oct 2025).
+
 on:
   push:
-    branches:
-    - master
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (x.y.z, no leading v)'
+        required: true
+      dry_run:
+        description: 'Run dry-run only (no actual publish, no tag, no GH release)'
+        type: boolean
+        default: true
 
 concurrency:
-  group: "publish"
-    
+  group: publish
+  cancel-in-progress: false
+
 jobs:
-  pub:
-    if: |
-      startsWith(github.event.head_commit.message, 'feat')
-      || startsWith(github.event.head_commit.message, 'fix')
-      || startsWith(github.event.head_commit.message, 'bug')
-      || startsWith(github.event.head_commit.message, 'perf')
-      || startsWith(github.event.head_commit.message, 'refactor')
-      || startsWith(github.event.head_commit.message, 'revert')
+  # ---------------------------------------------------------------------------
+  # prepare: derive the release version from the trigger and assert that
+  # pubspec.yaml's `version:` matches. Fails fast if the operator pushed
+  # `v7.0.1` but forgot to bump pubspec.yaml.
+  # ---------------------------------------------------------------------------
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.derive.outputs.version }}
+      dry_run: ${{ steps.derive.outputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: derive
+        name: Derive release version
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            v="${GITHUB_REF_NAME#v}"
+            dry=false
+          else
+            v="${{ inputs.version }}"
+            dry="${{ inputs.dry_run }}"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$dry" >> "$GITHUB_OUTPUT"
+          echo "Release version: $v (dry_run=$dry)"
+      - name: Assert pubspec.yaml version matches
+        run: |
+          ws_v=$(sed -nE 's/^version:[[:space:]]*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' pubspec.yaml | head -1)
+          if [ "$ws_v" != "${{ steps.derive.outputs.version }}" ]; then
+            echo "::error::Workspace pubspec.yaml is at $ws_v but trigger wants ${{ steps.derive.outputs.version }}."
+            echo "::error::Bump pubspec.yaml first, run `melos sync-version`, commit, then retry."
+            exit 1
+          fi
+
+  # ---------------------------------------------------------------------------
+  # dry-run: `dart pub publish --dry-run` across all 18 packages. Fails the
+  # whole pipeline on any single-package error. This is the gate that would
+  # have caught the missing-CHANGELOG.md silent failures in the 6.0.0
+  # release window.
+  #
+  # Note: there is no separate `require-green-ci` job in this workflow.
+  # `linux.yml` and `macos.yml` only trigger on `pull_request`, not on tag
+  # push, so a tag-SHA CI run does not exist to wait for. Operators must
+  # rely on branch protection to ensure master is green before tagging,
+  # and the dry-run step here is the last-mile validation.
+  # ---------------------------------------------------------------------------
+  dry-run:
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: dart-lang/setup-dart@v1
-      with:
-        sdk: main
-    - name: Prepare pub credentials
-      run: |
-        mkdir "$XDG_CONFIG_HOME/dart"
-        echo '${{ secrets.PUB_CREDENTIALS }}' > "$XDG_CONFIG_HOME/dart/pub-credentials.json"
-    - name: Git config
-      run: |
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-    - name: Install melos
-      run: |
-        cat pubspec.yaml
-        dart pub global activate melos
-    - name: Uptick versions
-      run: melos sync-version
-    - name: Changelog
-      run: git diff --unified=0 $GITHUB_SHA packages/cli/CHANGELOG.md | tail +6 | sed -e 's/^\+//' > CHANGES.txt
-    - name: Cache Source
-      run: melos cache-source
-    - name: Publish package
-      run: melos publish --no-dry-run --git-tag-version --yes
-    - name: Push tags
-      uses: CasperWA/push-protected@v2
-      with:
-        token: ${{ secrets.CONDUIT_PAT }}
-        tags: true
-        branch: master
-    - name: Compute the release tag
-      run: |
-        echo "release_tag=v`cat pubspec.yaml | sed -nre 's/^version: [^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p'`" >> $GITHUB_ENV
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: ${{ env.release_tag }}
-        body_path: CHANGES.txt
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: beta
+      - name: Activate melos
+        run: dart pub global activate melos
+      - name: Bootstrap workspace
+        run: melos bootstrap
+      - name: Seed pub cache with workspace packages
+        run: melos cache-source
+      - name: Dry-run publish for every workspace package
+        # Fail-fast: any single dry-run failure aborts the release.
+        run: melos exec --no-private -- "dart pub publish --dry-run"
+
+  # ---------------------------------------------------------------------------
+  # publish: walk the topological tier list and publish each package via
+  # OIDC trusted publishing. This requires a one-time per-package
+  # configuration in pub.dev's admin UI (Trusted Publishers section)
+  # pointing at this repo + workflow. Without that, `dart pub publish`
+  # falls back to credential-based auth and fails because no
+  # `pub-credentials.json` is written.
+  #
+  # Order matters: `conduit_graphql` depends on `conduit_graph`, which
+  # must be visible on pub.dev's resolver before graphql tries to
+  # publish. We poll the pub.dev API after each package and only proceed
+  # to the next tier once the version is indexed.
+  # ---------------------------------------------------------------------------
+  publish:
+    needs: [prepare, dry-run]
+    if: needs.prepare.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write    # required for OIDC trusted publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: beta
+      - name: Activate melos
+        run: dart pub global activate melos
+      - name: Bootstrap workspace
+        run: melos bootstrap
+      - name: Publish in topological tier order
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # tier:path:name — `name` is the published package name (often
+          # differs from the directory). Tiers separated by blank lines
+          # are published in parallel-safe groups; we poll between tiers.
+          declare -a TIERS=(
+            # Tier 0 — leaves with no intra-monorepo runtime deps
+            "0:packages/codable:conduit_codable"
+            "0:packages/fs_test_agent:fs_test_agent"
+            "0:packages/runtime:conduit_runtime"
+            "0:packages/password_hash:conduit_password_hash"
+            "0:packages/isolate_exec:conduit_isolate_exec"
+            "0:packages/graph:conduit_graph"
+
+            # Tier 1
+            "1:packages/open_api:conduit_open_api"
+            "1:packages/config:conduit_config"
+            "1:packages/graph_neo4j:conduit_graph_neo4j"
+
+            # Tier 2
+            "2:packages/common:conduit_common"
+
+            # Tier 3 — the hub
+            "3:packages/core:conduit_core"
+
+            # Tier 4 — depend on core (graphql also on graph)
+            "4:packages/postgresql:conduit_postgresql"
+            "4:packages/sqlite:conduit_sqlite"
+            "4:packages/mysql:conduit_mysql"
+            "4:packages/test_harness:conduit_test"
+            "4:packages/build_runner:conduit_build_runner"
+            "4:packages/graphql:conduit_graphql"
+
+            # Tier 5 — CLI
+            "5:packages/cli:conduit"
+          )
+
+          publish_one() {
+            local path="$1" name="$2"
+            echo "::group::Publishing $name from $path"
+            (cd "$path" && dart pub publish --force)
+            echo "::endgroup::"
+          }
+
+          await_pub_dev() {
+            local name="$1"
+            for i in $(seq 1 30); do
+              local v
+              v=$(curl -sf "https://pub.dev/api/packages/$name" | jq -r '.latest.version' 2>/dev/null || echo "")
+              if [ "$v" = "$RELEASE_VERSION" ]; then
+                echo "$name@$RELEASE_VERSION visible on pub.dev"
+                return 0
+              fi
+              echo "Waiting for $name@$RELEASE_VERSION on pub.dev (currently: ${v:-unknown})…"
+              sleep 10
+            done
+            echo "::error::pub.dev never reported $name@$RELEASE_VERSION after 5 minutes."
+            return 1
+          }
+
+          last_tier=""
+          for entry in "${TIERS[@]}"; do
+            tier="${entry%%:*}"
+            rest="${entry#*:}"
+            path="${rest%%:*}"
+            name="${rest##*:}"
+            if [ -n "$last_tier" ] && [ "$tier" != "$last_tier" ]; then
+              # entered a new tier; stall briefly so pub.dev's index settles
+              echo "Tier $last_tier complete — settling 30s before tier $tier"
+              sleep 30
+            fi
+            publish_one "$path" "$name"
+            await_pub_dev "$name"
+            last_tier="$tier"
+          done
+
+  # ---------------------------------------------------------------------------
+  # tag-and-release: only if this was a workflow_dispatch (real, not dry).
+  # Tag-push triggers already have the tag; just create the GH release.
+  # ---------------------------------------------------------------------------
+  tag-and-release:
+    needs: [prepare, publish]
+    if: needs.prepare.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push tag (workflow_dispatch only — tag-push trigger already has it)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          V: ${{ needs.prepare.outputs.version }}
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name  "github-actions[bot]"
+          git tag -a "v$V" -m "Conduit $V"
+          git push origin "v$V"
+      - name: Aggregate per-package release notes
+        env:
+          V: ${{ needs.prepare.outputs.version }}
+        run: |
+          {
+            echo "## Conduit $V"
+            echo
+            echo "Per-package highlights (from each \`packages/*/CHANGELOG.md\`'s \`## $V\` section):"
+            echo
+            for f in packages/*/CHANGELOG.md; do
+              pkg_name=$(grep -m1 '^name:' "$(dirname "$f")/pubspec.yaml" | awk '{print $2}')
+              section=$(awk -v v="## $V" '
+                $0 == v {flag=1; next}
+                /^## / && flag {exit}
+                flag {print}
+              ' "$f")
+              if [ -n "$section" ]; then
+                echo "### $pkg_name"
+                echo
+                echo "$section"
+                echo
+              fi
+            done
+          } > CHANGES.md
+          echo "Generated CHANGES.md ($(wc -l < CHANGES.md) lines)."
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.prepare.outputs.version }}
+          name: Conduit ${{ needs.prepare.outputs.version }}
+          body_path: CHANGES.md
+          generate_release_notes: true   # auto-append PRs since previous tag
+
+  # ---------------------------------------------------------------------------
+  # docker / docker-flutter: build and push images on the same tag-push or
+  # dispatch event. Trigger is no longer the brittle `chore`-commit gate.
+  # ---------------------------------------------------------------------------
   docker:
-    if: |
-      startsWith(github.event.head_commit.message, 'chore')
+    needs: [prepare, publish]
+    if: needs.prepare.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     strategy:
-        # PR #250 raised the workspace SDK floor to >=3.12.0-0. Until
-        # Dart 3.12 ships in the `stable` channel, the `dart:stable` /
-        # `dart:latest` Docker images carry Dart 3.11.x and `dart pub
-        # global activate -spath packages/cli` fails on the SDK
-        # constraint. Build only against `beta` for now; restore the
-        # `main` / `stable` matrix entries once Dart 3.12 is GA.
-        matrix:
-          dart_channel:
-            - beta
+      # PR #250 raised the workspace SDK floor to >=3.12.0-0. Until Dart
+      # 3.12 ships in `stable`, the `dart:stable` / `dart:latest` images
+      # carry Dart 3.11.x and `dart pub global activate -spath
+      # packages/cli` fails on the SDK constraint. Build only against
+      # `beta` for now; restore the `main` / `stable` matrix entries once
+      # Dart 3.12 is GA.
+      matrix:
+        dart_channel:
+          - beta
     steps:
-    - uses: actions/checkout@v4
-    - name: Compute the release tag
-      run: |
-        echo "release_tag=v`cat pubspec.yaml | sed -nre 's/^version: [^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p'`" >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USER }}
-        password: ${{ secrets.DOCKER_PAT }}
-    - name: Build and Push
-      run: docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 --file docker/Dockerfile.${{ matrix.dart_channel }} --tag conduitdart/conduit:${{ env.release_tag }}-${{ matrix.dart_channel }} --push .
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+      - name: Build and push
+        env:
+          V: ${{ needs.prepare.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64/v8,linux/arm/v7 \
+            --file docker/Dockerfile.${{ matrix.dart_channel }} \
+            --tag conduitdart/conduit:v$V-${{ matrix.dart_channel }} \
+            --push .
+
   docker-flutter:
-    if: |
-      startsWith(github.event.head_commit.message, 'chore')
+    needs: [prepare, publish]
+    if: needs.prepare.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Compute the release tag
-      run: |
-        echo "release_tag=v`cat pubspec.yaml | sed -nre 's/^version: [^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p'`" >> $GITHUB_ENV
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-      with:
-        platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
-    - name: Login to GHCR
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.DOCKER_USER }}
-        password: ${{ secrets.CONDUIT_PAT }}
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USER }}
-        password: ${{ secrets.DOCKER_PAT }}
-    # The cirruslabs/flutter:latest image bundles Dart 3.11.x; the
-    # workspace SDK floor is >=3.12.0-0 (PR #250). Build only the
-    # `aot-builder` stage of Dockerfile.flutter-aot, which uses
-    # `dart:beta` and does the workspace bootstrap. The Flutter
-    # downstream stage stays defined for local-dev use but is
-    # excluded from the published image until the Flutter image
-    # ships Dart 3.12.
-    - name: Build
-      run: docker buildx build --platform linux/amd64,linux/arm64/v8 --target aot-builder --file docker/Dockerfile.flutter-aot --tag conduitdart/conduit:${{ env.release_tag }}-flutter --push .
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.CONDUIT_PAT }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+      # cirruslabs/flutter:latest still bundles Dart 3.11.x; the
+      # workspace SDK floor is >=3.12.0-0 (PR #250). Build only the
+      # `aot-builder` stage of Dockerfile.flutter-aot, which uses
+      # `dart:beta`. The Flutter downstream stage stays defined for
+      # local-dev use but is excluded from the published image until
+      # the Flutter image ships Dart 3.12.
+      - name: Build and push aot-builder
+        env:
+          V: ${{ needs.prepare.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64/v8 \
+            --target aot-builder \
+            --file docker/Dockerfile.flutter-aot \
+            --tag conduitdart/conduit:v$V-flutter \
+            --push .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,17 +105,36 @@ jobs:
         run: melos exec --no-private -- "dart pub publish --dry-run"
 
   # ---------------------------------------------------------------------------
-  # publish: walk the topological tier list and publish each package via
-  # OIDC trusted publishing. This requires a one-time per-package
-  # configuration in pub.dev's admin UI (Trusted Publishers section)
-  # pointing at this repo + workflow. Without that, `dart pub publish`
-  # falls back to credential-based auth and fails because no
-  # `pub-credentials.json` is written.
+  # publish: walk the workspace in topological order via `melos exec
+  # --order-dependents` (layered topological sort, available since melos
+  # 7.4.0; uses `dart pub publish` per package directly so OIDC trusted
+  # publishing kicks in).
   #
-  # Order matters: `conduit_graphql` depends on `conduit_graph`, which
-  # must be visible on pub.dev's resolver before graphql tries to
-  # publish. We poll the pub.dev API after each package and only proceed
-  # to the next tier once the version is indexed.
+  # OIDC trusted publishing requires a one-time per-package configuration
+  # in pub.dev's admin UI (Trusted Publishers section) pointing at this
+  # repo + workflow. Without that, `dart pub publish` errors because no
+  # `pub-credentials.json` is written. The 5 packages that were never on
+  # pub.dev (`conduit_sqlite`, `_mysql`, `_graph`, `_graph_neo4j`,
+  # `_graphql`) need an initial credential-based publish before trusted
+  # publishing can be configured for them — see Phase A of the plan in
+  # ~/.claude/plans/analyze-release-pipeline-and-dreamy-puppy.md.
+  #
+  # The implicit dependency order produced by `--order-dependents`
+  # matches the documented Phase A4 tier list:
+  #   Tier 0: codable, fs_test_agent, runtime, password_hash,
+  #           isolate_exec, graph
+  #   Tier 1: open_api, config, graph_neo4j
+  #   Tier 2: common
+  #   Tier 3: core
+  #   Tier 4: postgresql, sqlite, mysql, test_harness, build_runner,
+  #           graphql
+  #   Tier 5: cli
+  #
+  # `--concurrency 1` forces sequential execution so the inter-package
+  # poll has a stable point to reach. The poll handles pub.dev's index
+  # propagation lag — `dart pub publish` returns when the upload is
+  # accepted, but dependent resolvers may not see the new version for a
+  # few seconds afterward.
   # ---------------------------------------------------------------------------
   publish:
     needs: [prepare, dry-run]
@@ -135,85 +154,31 @@ jobs:
         run: dart pub global activate melos
       - name: Bootstrap workspace
         run: melos bootstrap
-      - name: Publish in topological tier order
+      - name: Publish in topological order
         env:
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
-
-          # tier:path:name — `name` is the published package name (often
-          # differs from the directory). Tiers separated by blank lines
-          # are published in parallel-safe groups; we poll between tiers.
-          declare -a TIERS=(
-            # Tier 0 — leaves with no intra-monorepo runtime deps
-            "0:packages/codable:conduit_codable"
-            "0:packages/fs_test_agent:fs_test_agent"
-            "0:packages/runtime:conduit_runtime"
-            "0:packages/password_hash:conduit_password_hash"
-            "0:packages/isolate_exec:conduit_isolate_exec"
-            "0:packages/graph:conduit_graph"
-
-            # Tier 1
-            "1:packages/open_api:conduit_open_api"
-            "1:packages/config:conduit_config"
-            "1:packages/graph_neo4j:conduit_graph_neo4j"
-
-            # Tier 2
-            "2:packages/common:conduit_common"
-
-            # Tier 3 — the hub
-            "3:packages/core:conduit_core"
-
-            # Tier 4 — depend on core (graphql also on graph)
-            "4:packages/postgresql:conduit_postgresql"
-            "4:packages/sqlite:conduit_sqlite"
-            "4:packages/mysql:conduit_mysql"
-            "4:packages/test_harness:conduit_test"
-            "4:packages/build_runner:conduit_build_runner"
-            "4:packages/graphql:conduit_graphql"
-
-            # Tier 5 — CLI
-            "5:packages/cli:conduit"
-          )
-
-          publish_one() {
-            local path="$1" name="$2"
-            echo "::group::Publishing $name from $path"
-            (cd "$path" && dart pub publish --force)
+          melos exec --order-dependents --concurrency 1 --no-private -- '
+            set -e
+            echo "::group::Publishing $MELOS_PACKAGE_NAME@$MELOS_PACKAGE_VERSION"
+            dart pub publish --force
             echo "::endgroup::"
-          }
-
-          await_pub_dev() {
-            local name="$1"
             for i in $(seq 1 30); do
-              local v
-              v=$(curl -sf "https://pub.dev/api/packages/$name" | jq -r '.latest.version' 2>/dev/null || echo "")
-              if [ "$v" = "$RELEASE_VERSION" ]; then
-                echo "$name@$RELEASE_VERSION visible on pub.dev"
-                return 0
+              v=$(curl -sf "https://pub.dev/api/packages/$MELOS_PACKAGE_NAME" \
+                  | jq -r ".latest.version" 2>/dev/null || echo "")
+              if [ "$v" = "$MELOS_PACKAGE_VERSION" ]; then
+                echo "$MELOS_PACKAGE_NAME@$MELOS_PACKAGE_VERSION visible on pub.dev"
+                break
               fi
-              echo "Waiting for $name@$RELEASE_VERSION on pub.dev (currently: ${v:-unknown})…"
+              [ "$i" -eq 30 ] && {
+                echo "::error::pub.dev never reported $MELOS_PACKAGE_NAME@$MELOS_PACKAGE_VERSION after 5 minutes."
+                exit 1
+              }
+              echo "Waiting for $MELOS_PACKAGE_NAME@$MELOS_PACKAGE_VERSION on pub.dev (currently: ${v:-unknown})…"
               sleep 10
             done
-            echo "::error::pub.dev never reported $name@$RELEASE_VERSION after 5 minutes."
-            return 1
-          }
-
-          last_tier=""
-          for entry in "${TIERS[@]}"; do
-            tier="${entry%%:*}"
-            rest="${entry#*:}"
-            path="${rest%%:*}"
-            name="${rest##*:}"
-            if [ -n "$last_tier" ] && [ "$tier" != "$last_tier" ]; then
-              # entered a new tier; stall briefly so pub.dev's index settles
-              echo "Tier $last_tier complete — settling 30s before tier $tier"
-              sleep 30
-            fi
-            publish_one "$path" "$name"
-            await_pub_dev "$name"
-            last_tier="$tier"
-          done
+          '
 
   # ---------------------------------------------------------------------------
   # tag-and-release: only if this was a workflow_dispatch (real, not dry).

--- a/ci/template-aot-smoke.sh
+++ b/ci/template-aot-smoke.sh
@@ -36,10 +36,19 @@ cd tmpl/
 # Repoint conduit_* deps at the workspace so we exercise the source
 # under test, not whatever conduit_build_runner / conduit_core happens
 # to be on pub.dev.
+#
+# This list MUST mirror the full set of conduit_* packages under
+# packages/* — a missing entry resolves against pub.dev instead, which
+# breaks during release prep when every package is bumped together but
+# the new version is not published yet (the omitted conduit_postgresql
+# entry is what broke #280's smoke). Overrides for packages outside the
+# template's dependency graph are inert, so listing them all is safe.
 cat > pubspec_overrides.yaml <<EOF
 dependency_overrides:
   conduit:
     path: $WORKSPACE/packages/cli
+  conduit_build_runner:
+    path: $WORKSPACE/packages/build_runner
   conduit_codable:
     path: $WORKSPACE/packages/codable
   conduit_common:
@@ -48,18 +57,28 @@ dependency_overrides:
     path: $WORKSPACE/packages/config
   conduit_core:
     path: $WORKSPACE/packages/core
+  conduit_graph:
+    path: $WORKSPACE/packages/graph
+  conduit_graph_neo4j:
+    path: $WORKSPACE/packages/graph_neo4j
+  conduit_graphql:
+    path: $WORKSPACE/packages/graphql
   conduit_isolate_exec:
     path: $WORKSPACE/packages/isolate_exec
+  conduit_mysql:
+    path: $WORKSPACE/packages/mysql
   conduit_open_api:
     path: $WORKSPACE/packages/open_api
   conduit_password_hash:
     path: $WORKSPACE/packages/password_hash
+  conduit_postgresql:
+    path: $WORKSPACE/packages/postgresql
   conduit_runtime:
     path: $WORKSPACE/packages/runtime
+  conduit_sqlite:
+    path: $WORKSPACE/packages/sqlite
   conduit_test:
     path: $WORKSPACE/packages/test_harness
-  conduit_build_runner:
-    path: $WORKSPACE/packages/build_runner
 EOF
 
 # pub workspaces (in the conduit monorepo) ignore overrides files in

--- a/examples/graphql_cross_source/pubspec.yaml
+++ b/examples/graphql_cross_source/pubspec.yaml
@@ -13,9 +13,9 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_core: ^6.0.0
-  conduit_graph: ^6.0.0
-  conduit_graphql: ^6.0.0
+  conduit_core: ^7.0.0
+  conduit_graph: ^7.0.0
+  conduit_graphql: ^7.0.0
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/build_runner/CHANGELOG.md
+++ b/packages/build_runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/build_runner/pubspec.yaml
+++ b/packages/build_runner/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_build_runner
 description: build_runner builders that generate the runtime code Conduit needs at AOT compile time, replacing dart:mirrors-based discovery.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+ - **CHORE**(ci): predicate / AST-rendering benchmarks + post-#267 regression analysis ([#270](https://github.com/conduit-dart/conduit/pull/270)).
+ - **CHORE**(ci): run packages/core/bench/* on every PR (non-gating) ([#274](https://github.com/conduit-dart/conduit/pull/274)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/cli/pubspec.yaml
+++ b/packages/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit
 description: A modern HTTP server application framework, ORM and OAuth2 provider with OpenAPI 3.0 integration. Foundation for REST, RPC or GraphQL services.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -13,14 +13,14 @@ dependencies:
   analyzer: ^12.0.0
   args: ^2.4.2
   collection: ^1.18.0
-  conduit_common: ^6.0.0
-  conduit_config: ^6.0.0
-  conduit_core: ^6.0.0
-  conduit_isolate_exec: ^6.0.0
-  conduit_open_api: ^6.0.0
-  conduit_password_hash: ^6.0.0
-  conduit_postgresql: ^6.0.0
-  conduit_runtime: ^6.0.0
+  conduit_common: ^7.0.0
+  conduit_config: ^7.0.0
+  conduit_core: ^7.0.0
+  conduit_isolate_exec: ^7.0.0
+  conduit_open_api: ^7.0.0
+  conduit_password_hash: ^7.0.0
+  conduit_postgresql: ^7.0.0
+  conduit_runtime: ^7.0.0
   crypto: ^3.0.3
   io: ^1.0.4
   logging: ^1.2.0

--- a/packages/cli/templates/db/pubspec.yaml
+++ b/packages/cli/templates/db/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
-  conduit: ^6.0.0
-  conduit_core: ^6.0.0
-  conduit_postgresql: ^6.0.0
+  conduit: ^7.0.0
+  conduit_core: ^7.0.0
+  conduit_postgresql: ^7.0.0
 
 dev_dependencies:
   test: ^1.25.2
-  conduit_test: ^6.0.0
+  conduit_test: ^7.0.0

--- a/packages/cli/templates/db_and_auth/pubspec.yaml
+++ b/packages/cli/templates/db_and_auth/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
-  conduit: ^6.0.0
-  conduit_core: ^6.0.0
-  conduit_postgresql: ^6.0.0
+  conduit: ^7.0.0
+  conduit_core: ^7.0.0
+  conduit_postgresql: ^7.0.0
 
 dev_dependencies:
   test: ^1.25.2
-  conduit_test: ^6.0.0
+  conduit_test: ^7.0.0

--- a/packages/cli/templates/default/pubspec.yaml
+++ b/packages/cli/templates/default/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: ">=3.12.0-0 <4.0.0"
 
 dependencies:
-  conduit: ^6.0.0
-  conduit_core: ^6.0.0
+  conduit: ^7.0.0
+  conduit_core: ^7.0.0
 
 dev_dependencies:
   test: ^1.25.2
-  conduit_test: ^6.0.0
+  conduit_test: ^7.0.0
   build_runner: ^2.14.1
-  conduit_build_runner: ^6.0.0
+  conduit_build_runner: ^7.0.0

--- a/packages/codable/CHANGELOG.md
+++ b/packages/codable/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/codable/pubspec.yaml
+++ b/packages/codable/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_codable
 description: A serialization library for converting dynamic, structured data (JSON, YAML) into Dart types.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/common/pubspec.yaml
+++ b/packages/common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_common
 description: Common classes shared by conduit projects.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_open_api: ^6.0.0
+  conduit_open_api: ^7.0.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/config/pubspec.yaml
+++ b/packages/config/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_config
 description: A safe and convenient way to read YAML configuration files.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_runtime: ^6.0.0
+  conduit_runtime: ^7.0.0
   meta: ^1.3.0
   yaml: ^3.1.2
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+ - **FEAT**(core): unified Persistence umbrella for relational + graph contexts ([#271](https://github.com/conduit-dart/conduit/pull/271)).
+ - **REFACTOR**(core): lift query builders to dialect-agnostic core; wire SQLite + MySQL newQuery ([#275](https://github.com/conduit-dart/conduit/pull/275)).
+ - **CHORE**(bench): predicate / AST-rendering benchmarks + post-#267 regression analysis ([#270](https://github.com/conduit-dart/conduit/pull/270)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_core
-version: 6.0.0
+version: 7.0.0
 description: This is the core of the framework.
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
@@ -13,12 +13,12 @@ dependencies:
   analyzer: ^12.0.0
   args: ^2.4.2
   collection: ^1.18.0
-  conduit_common: ^6.0.0
-  conduit_config: ^6.0.0
-  conduit_isolate_exec: ^6.0.0
-  conduit_open_api: ^6.0.0
-  conduit_password_hash: ^6.0.0
-  conduit_runtime: ^6.0.0
+  conduit_common: ^7.0.0
+  conduit_config: ^7.0.0
+  conduit_isolate_exec: ^7.0.0
+  conduit_open_api: ^7.0.0
+  conduit_password_hash: ^7.0.0
+  conduit_runtime: ^7.0.0
   crypto: ^3.0.3
   io: ^1.0.4
   logging: ^1.2.0

--- a/packages/fs_test_agent/CHANGELOG.md
+++ b/packages/fs_test_agent/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/fs_test_agent/pubspec.yaml
+++ b/packages/fs_test_agent/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fs_test_agent
-version: 6.0.0
+version: 7.0.0
 description: Utilities for writing tests to validate file system and Dart project directory operations.
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit

--- a/packages/graph/CHANGELOG.md
+++ b/packages/graph/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 7.0.0
+
+> Note: First publish to pub.dev. Requires Dart SDK >=3.12.0.
+
+ - **FEAT**: add conduit_graph package — GraphNode/GraphEdge type system + GraphPersistentStore abstraction ([#266](https://github.com/conduit-dart/conduit/pull/266)).

--- a/packages/graph/pubspec.yaml
+++ b/packages/graph/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_graph
 description: Type-system foundation for an Object-Graph Mapper (OGM) on top of conduit. Parallel to the SQL ORM — nodes, typed edges with edge-properties, and pattern queries — backend-agnostic.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues

--- a/packages/graph_neo4j/CHANGELOG.md
+++ b/packages/graph_neo4j/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 7.0.0
+
+> Note: First publish to pub.dev. Requires Dart SDK >=3.12.0 and conduit_graph 7.0.0.
+
+ - **FEAT**: Neo4j backend for conduit_graph ([#269](https://github.com/conduit-dart/conduit/pull/269)).

--- a/packages/graph_neo4j/pubspec.yaml
+++ b/packages/graph_neo4j/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_graph_neo4j
 description: Neo4j (Bolt protocol) backend for the conduit_graph type system. Implements Neo4jPersistentStore against a self-contained Bolt v4.x client.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_graph: ^6.0.0
+  conduit_graph: ^7.0.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 7.0.0
+
+> Note: First publish to pub.dev. Requires Dart SDK >=3.12.0.
+
+ - **FEAT**: conduit_graphql skeleton + GraphQLController (G1) ([#273](https://github.com/conduit-dart/conduit/pull/273)).
+ - **FEAT**: SchemaBuilder.fromManagedDataModel + custom scalars (G2) ([#276](https://github.com/conduit-dart/conduit/pull/276)).
+ - **FEAT**: SQL resolvers + dataloader (G3) ([#278](https://github.com/conduit-dart/conduit/pull/278)).

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_graphql
 description: GraphQL HTTP transport for conduit. Mounts a GraphQLController over a hand-written GraphQLSchema; schema derivation, resolver framework, and cross-source dispatch are deferred to later phases.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_core: ^6.0.0
+  conduit_core: ^7.0.0
   graphql_parser2: ^6.5.0
   graphql_schema2: ^6.5.0
   graphql_server2: ^6.5.0
@@ -20,8 +20,8 @@ dev_dependencies:
   # graphql package itself does not depend on postgres at runtime;
   # the resolver factory only assumes a `ManagedContext`, and apps
   # supply whatever PersistentStore they want.
-  conduit_postgresql: ^6.0.0
-  conduit_test: ^6.0.0
+  conduit_postgresql: ^7.0.0
+  conduit_test: ^7.0.0
   http: ^1.2.0
   lints: ^6.0.0
   test: ^1.25.2

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   # Neo4j backend is exercised only by the gated G4 integration test;
   # production callers do not pull this in transitively.
-  conduit_graph_neo4j: ^6.0.0
+  conduit_graph_neo4j: ^7.0.0
   # Used by G3 unit + integration tests for SqlResolverFactory. The
   # graphql package itself does not depend on postgres at runtime;
   # the resolver factory only assumes a `ManagedContext`, and apps

--- a/packages/isolate_exec/CHANGELOG.md
+++ b/packages/isolate_exec/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/isolate_exec/pubspec.yaml
+++ b/packages/isolate_exec/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_isolate_exec
-version: 6.0.0
+version: 7.0.0
 description: This library contains types that allow for executing code in a spawned isolate, perhaps with additional imports.
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 7.0.0
+
+> Note: First publish to pub.dev. Requires Dart SDK >=3.12.0.
+
+ - **FEAT**: add conduit_mysql backend + QueryPredicate AST migration ([#267](https://github.com/conduit-dart/conduit/pull/267)).
+ - **FEAT**: multi-backend test harness + connection-string dispatch ([#268](https://github.com/conduit-dart/conduit/pull/268)).
+ - **REFACTOR**: lift query builders to dialect-agnostic core; wire SQLite + MySQL newQuery ([#275](https://github.com/conduit-dart/conduit/pull/275)).

--- a/packages/mysql/pubspec.yaml
+++ b/packages/mysql/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_mysql
 description: MySQL / MariaDB ORM backend for conduit. Schema management, raw execute path, and dialect-agnostic ORM `newQuery<T>` (lifted from the postgresql package).
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_core: ^6.0.0
+  conduit_core: ^7.0.0
   # mysql_dart 1.2.1 (2025-11-20) is the actively maintained native-Dart
   # MySQL client. It supports MySQL 5.7/8 and MariaDB 10, offers TLS, and
   # binds parameters positionally with `?` — the placeholder

--- a/packages/open_api/CHANGELOG.md
+++ b/packages/open_api/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/open_api/pubspec.yaml
+++ b/packages/open_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_open_api
-version: 6.0.0
+version: 7.0.0
 description: Data structures for OpenAPI (Swagger) specification. Reads and writes JSON specifications.
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_codable: ^6.0.0
+  conduit_codable: ^7.0.0
   meta: ^1.12.0
 
 dev_dependencies:

--- a/packages/password_hash/CHANGELOG.md
+++ b/packages/password_hash/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/password_hash/pubspec.yaml
+++ b/packages/password_hash/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_password_hash
-version: 6.0.0
+version: 7.0.0
 description: PBKDF2 password hashing utility
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+ - **REFACTOR**: lift query builders to dialect-agnostic core; wire SQLite + MySQL newQuery ([#275](https://github.com/conduit-dart/conduit/pull/275)). Postgres is byte-identical at the SQL boundary; this is an internal refactor that lets sibling backends reuse the same builder family.
+
 ## 6.0.0
 
  - **REFACTOR**(db): extract SqlDialect abstraction from postgresql package ([#263](https://github.com/conduit-dart/conduit/issues/263)). ([37614c0c](https://github.com/conduit-dart/conduit/commit/37614c0cfa1e8151afca13a674c43f87c044c1f6))

--- a/packages/postgresql/pubspec.yaml
+++ b/packages/postgresql/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_postgresql
 description: The postgresql ORM for conduit.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -11,7 +11,7 @@ resolution: workspace
 
 dependencies:
   collection: ^1.17.1
-  conduit_core: ^6.0.0
+  conduit_core: ^7.0.0
   postgres: ^3.1.1
 
 dev_dependencies:

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+
 ## 6.0.0
 
 > Note: This release has breaking changes.

--- a/packages/runtime/pubspec.yaml
+++ b/packages/runtime/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_runtime
-version: 6.0.0
+version: 7.0.0
 description: Provides behaviors and base types for packages that can use mirrors and be AOT compiled.
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
@@ -12,7 +12,7 @@ resolution: workspace
 dependencies:
   analyzer: ^12.0.0
   args: ^2.0.0
-  conduit_isolate_exec: ^6.0.0
+  conduit_isolate_exec: ^7.0.0
   io: ^1.0.4
   package_config: ^2.1.0
   path: ^1.9.0

--- a/packages/sqlite/CHANGELOG.md
+++ b/packages/sqlite/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 7.0.0
+
+> Note: First publish to pub.dev. Requires Dart SDK >=3.12.0.
+
+ - **FEAT**: add conduit_sqlite backend (schema + raw execute; ORM path deferred) ([#264](https://github.com/conduit-dart/conduit/pull/264)).
+ - **FEAT**: multi-backend test harness + connection-string dispatch ([#268](https://github.com/conduit-dart/conduit/pull/268)).
+ - **REFACTOR**: lift query builders to dialect-agnostic core; wire SQLite + MySQL newQuery ([#275](https://github.com/conduit-dart/conduit/pull/275)).

--- a/packages/sqlite/pubspec.yaml
+++ b/packages/sqlite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: conduit_sqlite
 description: SQLite ORM backend for conduit. Embedded / in-process; closes the test-harness gap by enabling no-Docker test fixtures.
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  conduit_core: ^6.0.0
+  conduit_core: ^7.0.0
   sqlite3: ^2.4.0
 
 dev_dependencies:

--- a/packages/test_harness/CHANGELOG.md
+++ b/packages/test_harness/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.0.0
+
+> Note: Breaking constraint change — minimum Dart SDK is now `>=3.12.0`. Major version bump because raising the minimum SDK is breaking per pub semver convention.
+
+ - **REFACTOR**: bump minimum Dart SDK to `>=3.12.0` ([#250](https://github.com/conduit-dart/conduit/pull/250)).
+ - **FEAT**(cli, test): multi-backend test harness + connection-string dispatch ([#268](https://github.com/conduit-dart/conduit/pull/268)).
+
 ## 6.0.0
 
 > Note: This release has breaking changes.

--- a/packages/test_harness/pubspec.yaml
+++ b/packages/test_harness/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_test
-version: 6.0.0
+version: 7.0.0
 description: Utilities for writing automated tests for Conduit applications
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
@@ -12,7 +12,7 @@ resolution: workspace
 dependencies:
   test: ^1.25.2
   matcher: ^0.12.16+1
-  conduit_core: ^6.0.0
+  conduit_core: ^7.0.0
 
 dev_dependencies:
   conduit_postgresql:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: conduit_workspace
-version: 6.0.0
+version: 7.0.0
 home: https://www.theconduit.dev
 repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,10 @@ environment:
   sdk: ">=3.12.0-0 <4.0.0"
 
 dev_dependencies:
-  melos: ^7.4.0
+  # 7.4.0 introduced layered topological sort for `melos exec
+  # --order-dependents`, which is what the publish workflow relies on.
+  # 7.7.0 fixes pubspec_overrides handling under workspace resolution.
+  melos: ^7.7.0
 
 workspace:
   - packages/build_runner


### PR DESCRIPTION
Phase A pre-flight + Phase B workflow rewrite from
~/.claude/plans/analyze-release-pipeline-and-dreamy-puppy.md.

Why a major bump
================
PR #250 raised the workspace SDK floor to >=3.12.0-0 after the v6.0.0
publish (pub.dev versions still pin >=3.9.0). Raising the minimum SDK
is breaking per pub semver convention, so the next release is 7.0.0.

What's in this commit
=====================

Workspace + per-package version bump

* pubspec.yaml: 6.0.0 -> 7.0.0
* All 18 package pubspecs: 6.0.0 -> 7.0.0
* 26 intra-monorepo dep constraints: ^6.0.0 -> ^7.0.0 (lints: ^6.0.0
  is the Dart lints package, left untouched)

CHANGELOG.md for the 5 unpublished packages (pub.dev requires the file
or it 404s the publish, which is exactly why these never landed at 6.0):

* packages/graph/CHANGELOG.md (new) — references #266
* packages/graph_neo4j/CHANGELOG.md (new) — #269
* packages/graphql/CHANGELOG.md (new) — #273 G1, #276 G2, #278 G3
* packages/mysql/CHANGELOG.md (new) — #267, #268, #275
* packages/sqlite/CHANGELOG.md (new) — #264, #268, #275

7.0.0 sections prepended to the 13 existing CHANGELOGs (SDK-floor
bump as the headline; per-package PR refs where applicable).

Workflow rewrite — .github/workflows/publish.yml

Replaced the head-commit-prefix trigger ("publish on every feat/fix
master commit," which silently no-op'd against pub.dev for already-
published packages and masked the 5-package failures) with:

* Trigger: tag push v*.*.* OR workflow_dispatch (with version + dry_run
  inputs)
* prepare: assert pubspec.yaml's version matches the trigger
* dry-run: melos exec dart pub publish --dry-run across all 18 — the
  gate that would have caught the missing-CHANGELOG silent failures
* publish (id-token: write for OIDC trusted publishing): walks an
  explicit topological tier list, polls pub.dev between tiers so
  dependents resolve against the freshly-published version
* tag-and-release: aggregates per-package CHANGELOG sections into the
  GH release body
* docker / docker-flutter: same trigger as publish (no more chore-
  prefix gate); same beta-only matrix per the inline notes about Dart
  3.12 not being on stable yet

Operator follow-ups before the actual 7.0.0 release
===================================================

1. Configure trusted publishing on pub.dev for each of the 18 packages
   (one-time per package, repo + workflow path). The 5 newly-created
   packages need an initial credential-based publish first since
   trusted-publisher config requires the package to exist on pub.dev.
2. Run the manual coordinated publish per Phase A4 of the plan to
   clear the backlog (5 new packages first, then the 13 republish at
   7.0.0). Once landed, push v7.0.0 and the new workflow takes over
   for v7.0.1+.