### PR TITLE
fix(ci): reconcile Release workflow with workspace SDK floor 3.12

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,11 +62,15 @@ jobs:
       startsWith(github.event.head_commit.message, 'chore')
     runs-on: ubuntu-latest
     strategy:
+        # PR #250 raised the workspace SDK floor to >=3.12.0-0. Until
+        # Dart 3.12 ships in the `stable` channel, the `dart:stable` /
+        # `dart:latest` Docker images carry Dart 3.11.x and `dart pub
+        # global activate -spath packages/cli` fails on the SDK
+        # constraint. Build only against `beta` for now; restore the
+        # `main` / `stable` matrix entries once Dart 3.12 is GA.
         matrix:
           dart_channel:
-            - main
             - beta
-            - stable
     steps:
     - uses: actions/checkout@v4
     - name: Compute the release tag
@@ -102,12 +106,17 @@ jobs:
         registry: ghcr.io
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.CONDUIT_PAT }}
-    - name: Pull Prereequisites
-      run: docker pull ghcr.io/cirruslabs/flutter:latest
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PAT }}
+    # The cirruslabs/flutter:latest image bundles Dart 3.11.x; the
+    # workspace SDK floor is >=3.12.0-0 (PR #250). Build only the
+    # `aot-builder` stage of Dockerfile.flutter-aot, which uses
+    # `dart:beta` and does the workspace bootstrap. The Flutter
+    # downstream stage stays defined for local-dev use but is
+    # excluded from the published image until the Flutter image
+    # ships Dart 3.12.
     - name: Build
-      run: docker buildx build --platform linux/amd64,linux/arm64/v8 --file docker/Dockerfile.flutter --tag conduitdart/conduit:${{ env.release_tag }}-flutter --push .
+      run: docker buildx build --platform linux/amd64,linux/arm64/v8 --target aot-builder --file docker/Dockerfile.flutter-aot --tag conduitdart/conduit:${{ env.release_tag }}-flutter --push .


### PR DESCRIPTION
Reconciles the Release workflow's docker matrix with the workspace SDK floor of 3.12 (raised in PR #250). Until Dart 3.12 reaches the stable channel, the `dart:stable` and cirruslabs `flutter:latest` images still ship 3.11.x and trip version-solve at `dart pub global activate -spath packages/cli`. This prunes the `docker` matrix in `publish.yml` to `[beta]` only (keeping the matrix scaffolding + a comment for when stable catches up) and switches `docker-flutter` to build the `aot-builder` target from `Dockerfile.flutter-aot` (the dart:beta workspace stage), dropping the now-unused Flutter prereq pull step.

Test plan:
- [ ] CI: Release workflow runs clean on `dart:beta` (no SDK-constraint failure)
- [ ] CI: `docker-flutter` job builds `aot-builder` target successfully
- [ ] Follow-up tracked: restore `stable` matrix entry once Dart 3.12 hits the stable channel
- [ ] Local: `docker build -f docker/Dockerfile.beta .` clean (verified)
- [ ] Local: `docker build --target aot-builder -f docker/Dockerfile.flutter-aot .` clean (verified)

Note: local pre-flight `melos run analyze` blocked by host Dart SDK 3.11 vs workspace floor 3.12 — relying on origin CI as the analyze gate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>