### PR TITLE
test(core): make websocket_test 'chat' deterministic

### DIFF
--- a/packages/core/test/http/websocket_test.dart
+++ b/packages/core/test/http/websocket_test.dart
@@ -104,6 +104,26 @@ void main() {
       final rxUser1 = user1.stream.asBroadcastStream();
       final rxUser2 = user2.stream.asBroadcastStream();
 
+      // Wait for both client-side handshakes to complete. This also
+      // forces the server's `WebSocketTransformer.upgrade` futures to
+      // resolve, so `_socket["user1"]` and `_socket["user2"]` are
+      // populated before the first cross-user send below.
+      await user1.ready;
+      await user2.ready;
+
+      // Server-side, `newChat` sets `_socket[user]` and then attaches
+      // the listener in two synchronous statements. Run a self-ping
+      // through each client so the test only proceeds once both
+      // sockets are end-to-end wired (registration + listener +
+      // round-trip). Without this, sending user1→user2 immediately
+      // after `await user2.ready` could land at the server before
+      // user2's listener is attached, dropping the message and
+      // hanging the test until the 2-minute file-level timeout.
+      user1.sink.add('{"to": "user1", "msg": "ready1"}');
+      expect(await rxUser1.first, 'ready1');
+      user2.sink.add('{"to": "user2", "msg": "ready2"}');
+      expect(await rxUser2.first, 'ready2');
+
       const sentMsg1 = "hello user 2";
       const send1 = '{"to": "user2", "msg": "$sentMsg1"}';
 


### PR DESCRIPTION
Fixes a registration race in `test/http/websocket_test.dart: Upgrade to WebSocket chat` that caused PR #257's `unit (beta)` macOS run to hit the 2-minute file-level timeout. Adds `await user.ready` for both clients (forces server-side `WebSocketTransformer.upgrade` to resolve and `_socket[user]` to be populated) plus a self-ping handshake (proves the listener-attach microtask has completed before cross-user sends fire). Server-side `newChat` ordering is intentionally untouched — it's a test controller, and reordering would shift the race surface elsewhere.

Test plan:
- [ ] CI: `unit (beta)` macOS no longer hits the 2-minute timeout on `Upgrade to WebSocket chat`
- [ ] CI: all 4 tests in `websocket_test.dart` green across stable/beta/main matrix
- [ ] Local: 5 consecutive `dart test test/http/websocket_test.dart` runs in dart:beta — all green (verified)

Note: local pre-flight `melos run analyze` blocked by host Dart SDK 3.11 vs workspace floor 3.12 — relying on origin CI as the analyze gate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>