### PR TITLE
feat(test): multipart and form-urlencoded body support in test Agent

### DIFF
--- a/packages/test_harness/lib/src/agent.dart
+++ b/packages/test_harness/lib/src/agent.dart
@@ -3,12 +3,15 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data' show BytesBuilder;
 
 import 'package:conduit_core/conduit_core.dart';
 
 import 'harness.dart';
 import 'matchers.dart';
 
+part 'multipart.dart';
 part 'request.dart';
 part 'response.dart';
 

--- a/packages/test_harness/lib/src/multipart.dart
+++ b/packages/test_harness/lib/src/multipart.dart
@@ -1,0 +1,152 @@
+part of 'agent.dart';
+
+/// Represents a file value in a `multipart/form-data` request body.
+///
+/// Pass instances of this class as values in the [Map] body of a
+/// [TestRequest] when sending a request whose [TestRequest.contentType]
+/// has the MIME type `multipart/form-data`. Non-file fields can be passed
+/// alongside files as plain values (e.g. [String], [num], [bool], [List]).
+///
+/// Example:
+///
+///         await agent.post("/upload", body: {
+///           "name": "alice",
+///           "avatar": MultipartFormFile.fromBytes(
+///             bytes,
+///             filename: "a.png",
+///             contentType: ContentType("image", "png"),
+///           ),
+///         }, contentType: ContentType.parse("multipart/form-data"));
+class MultipartFormFile {
+  /// Creates a multipart file part from raw [bytes].
+  ///
+  /// [filename] is the value of the `filename` parameter in the
+  /// `Content-Disposition` header of the part. If omitted, no filename is
+  /// emitted, which matches the behavior of an `<input type="file">` element
+  /// when no file has been chosen.
+  ///
+  /// [contentType] is the value of the part's `Content-Type` header. When
+  /// omitted, no `Content-Type` header is emitted for the part, and the
+  /// server is free to interpret the bytes per RFC 7578.
+  MultipartFormFile.fromBytes(
+    List<int> bytes, {
+    this.filename,
+    this.contentType,
+  }) : bytes = List<int>.unmodifiable(bytes);
+
+  /// Creates a multipart file part from a [String].
+  ///
+  /// The string is encoded as UTF-8 unless [contentType] specifies a
+  /// different charset. See [MultipartFormFile.fromBytes] for details on
+  /// [filename] and [contentType].
+  MultipartFormFile.fromString(
+    String value, {
+    this.filename,
+    ContentType? contentType,
+  })  : bytes = List<int>.unmodifiable(
+            (contentType?.charset != null
+                    ? Encoding.getByName(contentType!.charset) ?? utf8
+                    : utf8)
+                .encode(value)),
+        contentType = contentType ??
+            ContentType("text", "plain", charset: "utf-8");
+
+  /// The raw bytes of this part's body.
+  final List<int> bytes;
+
+  /// The filename to send in the part's `Content-Disposition` header, or null.
+  final String? filename;
+
+  /// The `Content-Type` of this part, or null to omit the header.
+  final ContentType? contentType;
+}
+
+/// Encodes a map of fields and files as a `multipart/form-data` body.
+///
+/// The returned bytes use [boundary] as the part separator. Per RFC 7578 the
+/// boundary must not appear anywhere in the encoded part bodies; callers are
+/// responsible for choosing one (see [_generateMultipartBoundary]).
+///
+/// Each entry in [fields] becomes one part:
+///   - [MultipartFormFile] values are emitted with their `filename` /
+///     `Content-Type` headers if set.
+///   - [Iterable] values are flattened: one part is emitted per element,
+///     all with the same field name (matching how HTML forms encode
+///     repeated inputs).
+///   - All other values are converted via `toString()` and sent as
+///     `text/plain` parts with no filename.
+List<int> _encodeMultipartFormData(
+  Map<String, dynamic> fields,
+  String boundary,
+) {
+  final builder = BytesBuilder(copy: false);
+  final dashBoundary = utf8.encode("--$boundary\r\n");
+  const crlf = [0x0d, 0x0a];
+
+  void writePart(String name, dynamic value) {
+    builder.add(dashBoundary);
+    if (value is MultipartFormFile) {
+      final disposition = StringBuffer(
+        'content-disposition: form-data; name="${_escapeQuoted(name)}"',
+      );
+      if (value.filename != null) {
+        disposition.write('; filename="${_escapeQuoted(value.filename!)}"');
+      }
+      disposition.write("\r\n");
+      builder.add(utf8.encode(disposition.toString()));
+      if (value.contentType != null) {
+        builder
+            .add(utf8.encode("content-type: ${value.contentType}\r\n"));
+      }
+      builder.add(crlf);
+      builder.add(value.bytes);
+      builder.add(crlf);
+    } else {
+      builder.add(
+        utf8.encode(
+          'content-disposition: form-data; name="${_escapeQuoted(name)}"\r\n\r\n',
+        ),
+      );
+      builder.add(utf8.encode("$value"));
+      builder.add(crlf);
+    }
+  }
+
+  fields.forEach((name, value) {
+    if (value is Iterable && value is! List<int>) {
+      for (final inner in value) {
+        writePart(name, inner);
+      }
+    } else {
+      writePart(name, value);
+    }
+  });
+
+  builder.add(utf8.encode("--$boundary--\r\n"));
+  return builder.takeBytes();
+}
+
+/// Escapes the characters that are not allowed in a `Content-Disposition`
+/// `name` or `filename` parameter (RFC 7578 § 4.2 references RFC 2388 which
+/// allows percent-encoding of CR, LF and double quote).
+String _escapeQuoted(String value) {
+  return value
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
+      .replaceAll('\r', '%0D')
+      .replaceAll('\n', '%0A');
+}
+
+/// Generates a random ASCII multipart boundary.
+///
+/// The shape `dart-conduit-<48 random hex chars>` keeps the boundary inside
+/// the RFC 2046 `bcharsnospace` set and is unlikely to collide with any
+/// real payload bytes.
+String _generateMultipartBoundary([math.Random? random]) {
+  final rng = random ?? math.Random.secure();
+  final buffer = StringBuffer("dart-conduit-");
+  for (var i = 0; i < 24; i++) {
+    buffer.write(rng.nextInt(256).toRadixString(16).padLeft(2, "0"));
+  }
+  return buffer.toString();
+}

--- a/packages/test_harness/lib/src/request.dart
+++ b/packages/test_harness/lib/src/request.dart
@@ -181,7 +181,7 @@ class TestRequest {
 
     if (body != null) {
       final bytes = _bodyBytes!;
-      request.headers.contentType = contentType;
+      request.headers.contentType = _outgoingContentType;
       request.headers.contentLength = bytes.length;
       request.add(bytes);
     }
@@ -195,6 +195,28 @@ class TestRequest {
     return response;
   }
 
+  /// Cached when [body] is encoded as `multipart/form-data` so that the
+  /// boundary parameter on the outgoing `Content-Type` header matches the
+  /// boundary embedded in the encoded body.
+  String? _multipartBoundary;
+
+  /// The content-type that will actually be sent on the wire, including any
+  /// `boundary` parameter required by `multipart/form-data` requests.
+  ContentType get _outgoingContentType {
+    if (_multipartBoundary == null) {
+      return contentType;
+    }
+
+    final params = Map<String, String?>.from(contentType.parameters)
+      ..["boundary"] = _multipartBoundary;
+    return ContentType(
+      contentType.primaryType,
+      contentType.subType,
+      charset: contentType.charset,
+      parameters: params,
+    );
+  }
+
   List<int>? get _bodyBytes {
     if (body == null) {
       return null;
@@ -202,6 +224,19 @@ class TestRequest {
 
     if (!encodeBody) {
       return body as List<int>?;
+    }
+
+    if (_isMultipartFormData(contentType)) {
+      if (body is! Map<String, dynamic>) {
+        throw StateError(
+          "multipart/form-data body must be a Map<String, dynamic>; "
+          "got ${body.runtimeType}.",
+        );
+      }
+      final boundary =
+          contentType.parameters["boundary"] ?? _generateMultipartBoundary();
+      _multipartBoundary = boundary;
+      return _encodeMultipartFormData(body as Map<String, dynamic>, boundary);
     }
 
     final codec =
@@ -219,4 +254,8 @@ class TestRequest {
 
     return codec.encode(body);
   }
+}
+
+bool _isMultipartFormData(ContentType type) {
+  return type.primaryType == "multipart" && type.subType == "form-data";
 }

--- a/packages/test_harness/test/agent_form_data_test.dart
+++ b/packages/test_harness/test/agent_form_data_test.dart
@@ -1,0 +1,329 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:conduit_test/conduit_test.dart';
+import 'package:test/test.dart';
+import 'package:test_core/src/util/io.dart';
+
+void main() {
+  group("Form-encoded body (application/x-www-form-urlencoded)", () {
+    late MockHTTPServer server;
+
+    setUp(() async {
+      server = await getUnusedPort(MockHTTPServer.new);
+      await server.open();
+    });
+
+    tearDown(() async {
+      await server.close();
+    });
+
+    test("Map body is sent as url-encoded and decodes back to the same map",
+        () async {
+      final agent = Agent.onPort(server.port)
+        ..contentType = ContentType("application", "x-www-form-urlencoded",
+            charset: "utf-8");
+
+      await agent.post("/login", body: {
+        "username": "alice",
+        "password": "p@ss w/special&chars",
+      });
+
+      final req = await server.next();
+      expect(req.method, "POST");
+      expect(req.raw.headers.contentType?.primaryType, "application");
+      expect(req.raw.headers.contentType?.subType, "x-www-form-urlencoded");
+
+      // Server-side decoding via the existing _FormDecoder produces a
+      // Map<String, List<String>>.
+      final decoded = req.body.as<Map<String, dynamic>>();
+      expect(decoded["username"], ["alice"]);
+      expect(decoded["password"], ["p@ss w/special&chars"]);
+    });
+
+    test("List values produce repeated key=value pairs", () async {
+      final agent = Agent.onPort(server.port)
+        ..contentType = ContentType("application", "x-www-form-urlencoded",
+            charset: "utf-8");
+
+      await agent.post("/q", body: {
+        "tag": ["a", "b", "c"],
+      });
+
+      final req = await server.next();
+      final decoded = req.body.as<Map<String, dynamic>>();
+      expect(decoded["tag"], ["a", "b", "c"]);
+    });
+  });
+
+  group("Multipart body (multipart/form-data)", () {
+    late HttpServer server;
+    late int port;
+
+    setUp(() async {
+      port = await getUnusedPort((p) => p);
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+    });
+
+    tearDown(() async {
+      await server.close(force: true);
+    });
+
+    test(
+        "Text fields and a binary file produce a body the server can parse, "
+        "Content-Type carries the boundary parameter", () async {
+      final received = Completer<_RawCapture>();
+      server.listen((req) async {
+        final bytes = <int>[];
+        await for (final chunk in req) {
+          bytes.addAll(chunk);
+        }
+        received.complete(_RawCapture(req.headers, bytes));
+        req.response.statusCode = 200;
+        await req.response.close();
+      });
+
+      final agent = Agent.onPort(port)
+        ..contentType = ContentType.parse("multipart/form-data");
+
+      final pngBytes = <int>[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+      ];
+
+      await agent.post("/upload", body: {
+        "name": "alice",
+        "note": "hello, world",
+        "avatar": MultipartFormFile.fromBytes(
+          pngBytes,
+          filename: "a.png",
+          contentType: ContentType("image", "png"),
+        ),
+      });
+
+      final captured = await received.future
+          .timeout(const Duration(seconds: 5));
+
+      // Boundary is on the Content-Type header.
+      final ct = captured.headers.contentType!;
+      expect(ct.primaryType, "multipart");
+      expect(ct.subType, "form-data");
+      final boundary = ct.parameters["boundary"];
+      expect(boundary, isNotNull);
+      expect(boundary, isNotEmpty);
+
+      // Body parses cleanly via the boundary.
+      final parts = _parseMultipart(captured.body, boundary!);
+      expect(parts.keys, containsAll(["name", "note", "avatar"]));
+
+      final namePart = parts["name"]!;
+      expect(utf8.decode(namePart.body), "alice");
+      expect(namePart.filename, isNull);
+
+      final notePart = parts["note"]!;
+      expect(utf8.decode(notePart.body), "hello, world");
+
+      final avatarPart = parts["avatar"]!;
+      expect(avatarPart.filename, "a.png");
+      expect(avatarPart.contentType, "image/png");
+      expect(avatarPart.body, pngBytes);
+    });
+
+    test("Boundary value is unique per request", () async {
+      final boundaries = <String?>[];
+      server.listen((req) async {
+        boundaries.add(req.headers.contentType?.parameters["boundary"]);
+        await req.drain<void>();
+        req.response.statusCode = 200;
+        await req.response.close();
+      });
+
+      final agent = Agent.onPort(port)
+        ..contentType = ContentType.parse("multipart/form-data");
+
+      await agent.post("/x", body: {"k": "v1"});
+      await agent.post("/x", body: {"k": "v2"});
+
+      // Allow time for the server's listener to record both requests.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(boundaries, hasLength(2));
+      expect(boundaries[0], isNotNull);
+      expect(boundaries[1], isNotNull);
+      expect(boundaries[0], isNot(equals(boundaries[1])));
+    });
+
+    test("Iterable values produce one part per element", () async {
+      final received = Completer<_RawCapture>();
+      server.listen((req) async {
+        final bytes = <int>[];
+        await for (final chunk in req) {
+          bytes.addAll(chunk);
+        }
+        received.complete(_RawCapture(req.headers, bytes));
+        req.response.statusCode = 200;
+        await req.response.close();
+      });
+
+      final agent = Agent.onPort(port)
+        ..contentType = ContentType.parse("multipart/form-data");
+
+      await agent.post("/q", body: {
+        "tag": ["a", "b"],
+      });
+
+      final captured = await received.future
+          .timeout(const Duration(seconds: 5));
+      final boundary = captured.headers.contentType!.parameters["boundary"]!;
+      final repeated = _parseMultipartRepeated(captured.body, boundary);
+      expect(repeated["tag"]?.map((p) => utf8.decode(p.body)).toList(),
+          ["a", "b"]);
+    });
+
+    test("Body that is not a Map throws StateError", () async {
+      final agent = Agent.onPort(port)
+        ..contentType = ContentType.parse("multipart/form-data");
+
+      await expectLater(
+        agent.post("/x", body: "not a map"),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group("JSON body backwards compatibility", () {
+    late MockHTTPServer server;
+
+    setUp(() async {
+      server = await getUnusedPort(MockHTTPServer.new);
+      await server.open();
+    });
+
+    tearDown(() async {
+      await server.close();
+    });
+
+    test("Default JSON body still works after multipart additions", () async {
+      final agent = Agent.onPort(server.port);
+      await agent.post("/foo", body: {"a": 1, "b": "two"});
+
+      final req = await server.next();
+      expect(req.raw.headers.contentType?.primaryType, "application");
+      expect(req.raw.headers.contentType?.subType, "json");
+      expect(req.body.as<Map<String, dynamic>>(), {"a": 1, "b": "two"});
+    });
+  });
+}
+
+class _RawCapture {
+  _RawCapture(this.headers, this.body);
+  final HttpHeaders headers;
+  final List<int> body;
+}
+
+/// Minimal multipart parser used only by these tests.
+class _ParsedPart {
+  _ParsedPart(this.body, this.filename, this.contentType);
+  final List<int> body;
+  final String? filename;
+  final String? contentType;
+}
+
+Map<String, _ParsedPart> _parseMultipart(List<int> body, String boundary) {
+  final result = <String, _ParsedPart>{};
+  for (final entry in _parseMultipartEntries(body, boundary)) {
+    result[entry.key] = entry.value;
+  }
+  return result;
+}
+
+Map<String, List<_ParsedPart>> _parseMultipartRepeated(
+    List<int> body, String boundary) {
+  final result = <String, List<_ParsedPart>>{};
+  for (final entry in _parseMultipartEntries(body, boundary)) {
+    result.putIfAbsent(entry.key, () => []).add(entry.value);
+  }
+  return result;
+}
+
+Iterable<MapEntry<String, _ParsedPart>> _parseMultipartEntries(
+    List<int> body, String boundary) sync* {
+  final delim = utf8.encode("--$boundary");
+  final closing = utf8.encode("--$boundary--");
+  // Find each delimiter.
+  final indexes = <int>[];
+  for (var i = 0; i <= body.length - delim.length; i++) {
+    var match = true;
+    for (var j = 0; j < delim.length; j++) {
+      if (body[i + j] != delim[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      indexes.add(i);
+    }
+  }
+  if (indexes.isEmpty) return;
+  for (var k = 0; k < indexes.length - 1; k++) {
+    final start = indexes[k] + delim.length;
+    var end = indexes[k + 1];
+    // Skip CRLF after delimiter.
+    var s = start;
+    if (s + 2 <= body.length && body[s] == 0x0d && body[s + 1] == 0x0a) {
+      s += 2;
+    }
+    // Strip trailing CRLF before next delimiter.
+    if (end >= 2 && body[end - 1] == 0x0a && body[end - 2] == 0x0d) {
+      end -= 2;
+    }
+    final partBytes = body.sublist(s, end);
+    // Split headers and body on first \r\n\r\n.
+    var hdrEnd = -1;
+    for (var i = 0; i <= partBytes.length - 4; i++) {
+      if (partBytes[i] == 0x0d &&
+          partBytes[i + 1] == 0x0a &&
+          partBytes[i + 2] == 0x0d &&
+          partBytes[i + 3] == 0x0a) {
+        hdrEnd = i;
+        break;
+      }
+    }
+    if (hdrEnd < 0) continue;
+    final headerStr = utf8.decode(partBytes.sublist(0, hdrEnd));
+    final partBody = partBytes.sublist(hdrEnd + 4);
+    String? name;
+    String? filename;
+    String? contentType;
+    for (final raw in headerStr.split("\r\n")) {
+      final line = raw.toLowerCase();
+      if (line.startsWith("content-disposition:")) {
+        final m = RegExp(r'name="([^"]*)"').firstMatch(raw);
+        if (m != null) name = m.group(1);
+        final fm = RegExp(r'filename="([^"]*)"').firstMatch(raw);
+        if (fm != null) filename = fm.group(1);
+      } else if (line.startsWith("content-type:")) {
+        contentType = raw.substring(raw.indexOf(":") + 1).trim();
+      }
+    }
+    if (name == null) continue;
+    yield MapEntry(name, _ParsedPart(partBody, filename, contentType));
+  }
+  // Validate there's a closing boundary so callers can trust the parse.
+  if (indexes.isNotEmpty) {
+    final last = indexes.last;
+    if (last + closing.length <= body.length) {
+      var match = true;
+      for (var j = 0; j < closing.length; j++) {
+        if (body[last + j] != closing[j]) {
+          match = false;
+          break;
+        }
+      }
+      if (!match) {
+        // Not fatal for tests; still yielded all real parts above.
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `multipart/form-data` support to the test `Agent` / `TestRequest`: when the caller sets that content-type, body finalization detects it, generates a random boundary, and encodes `Map<String, dynamic>` bodies into a multipart payload per RFC 7578 (including the new `MultipartFormFile` class with `fromBytes` / `fromString` constructors that emit per-part `Content-Disposition` and optional `Content-Type` headers; the boundary is mirrored into the outgoing `Content-Type`). `application/x-www-form-urlencoded` already worked via the existing `_FormCodec`; tests now lock that path in and exercise multipart end-to-end (text fields + binary file part round-tripped through a hand-rolled parser, unique boundaries per request, iterable values flattened, plus a backwards-compat JSON test). No new dependencies; public surface gains one class exported via `package:conduit_test/conduit_test.dart`. Closes #166.

Test plan:
- [ ] CI: new multipart tests green (round-trip + boundary uniqueness + iterable flattening)
- [ ] CI: existing JSON/form-urlencoded paths unchanged (backwards-compat test)
- [ ] CI: full `test_harness` package suite green across stable/beta/main matrix
- [ ] Downstream: verify `Agent.post(..., contentType: 'multipart/form-data', body: {...})` works in a sample app

Note: local pre-flight `melos run analyze` blocked by host Dart SDK 3.11 vs workspace floor 3.12 — relying on origin CI as the analyze gate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>