### PR TITLE
chore: ignore .claude/worktrees and .pub-cache-docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ site/
 _build/
 
 *.reflectable.dart
+
+# Claude Code agent worktrees and pub-cache used by Docker-based CI runs.
+.claude/worktrees/
+.pub-cache-docker/


### PR DESCRIPTION
The Claude Code agent harness creates `.claude/worktrees/<slug>` directories inside the repo for parallel-agent isolation, and Docker-based CI runs use a host-mounted `.pub-cache-docker/` to avoid re-downloading dependencies on every container start. Both are tooling artifacts and should never land in a commit — appending matching ignore patterns to `.gitignore` (with a short explanatory comment) so they stay out of `git status` noise.

Test plan:
- [ ] CI: no behavior change — verifies the workflows are happy with the additional ignore lines
- [ ] Local: `git status` no longer flags `.claude/worktrees/` or `.pub-cache-docker/` when those dirs exist

Note: chore branch — no code change, no analyze impact. Branch is based on `origin/master` (not local master) to avoid carrying any unrelated diffs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>