### PR TITLE
ci: restore stable Dart 3.12 to CI + finalize the >=3.12.0 SDK floor

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [beta, main]
+        sdk: [stable, beta, main]
     steps:
     - uses: actions/checkout@v4
     - uses: dart-lang/setup-dart@v1
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [beta]
+        sdk: [stable, beta]
     env:
       TEST_DIR: packages/core
     services:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        sdk: [beta, main]
+        sdk: [stable, beta, main]
     steps:
     - uses: actions/checkout@v4
     - uses: dart-lang/setup-dart@v1
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [beta]
+        sdk: [stable, beta]
     env:
       TEST_DIR: packages/core
       POSTGRES_HOST: localhost

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,14 +245,13 @@ jobs:
     if: needs.prepare.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     strategy:
-      # PR #250 raised the workspace SDK floor to >=3.12.0-0. Until Dart
-      # 3.12 ships in `stable`, the `dart:stable` / `dart:latest` images
-      # carry Dart 3.11.x and `dart pub global activate -spath
-      # packages/cli` fails on the SDK constraint. Build only against
-      # `beta` for now; restore the `main` / `stable` matrix entries once
-      # Dart 3.12 is GA.
+      # Dart 3.12 is GA in `stable` and the workspace SDK floor is
+      # `>=3.12.0`, so the `dart:stable` image resolves the constraint.
+      # `main` (== `dart:latest`) is omitted: it tracks `stable` and
+      # would publish a byte-identical image under a redundant tag.
       matrix:
         dart_channel:
+          - stable
           - beta
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        sdk: [beta, main]
+        sdk: [stable, beta, main]
     steps:
     - uses: actions/checkout@v4
     - uses: dart-lang/setup-dart@v1
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [beta]
+        sdk: [stable, beta]
     env:
       TEST_DIR: packages/core
       POSTGRES_HOST: localhost

--- a/examples/graphql_cross_source/pubspec.yaml
+++ b/examples/graphql_cross_source/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: none
 version: 0.0.1
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/examples/persistence_umbrella/pubspec.yaml
+++ b/examples/persistence_umbrella/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 version: 0.0.1
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dependencies:
   conduit_core:

--- a/packages/build_runner/pubspec.yaml
+++ b/packages/build_runner/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/cli/pubspec.yaml
+++ b/packages/cli/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/codable/pubspec.yaml
+++ b/packages/codable/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/common/pubspec.yaml
+++ b/packages/common/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/config/pubspec.yaml
+++ b/packages/config/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/fs_test_agent/pubspec.yaml
+++ b/packages/fs_test_agent/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/graph/pubspec.yaml
+++ b/packages/graph/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/graph_neo4j/pubspec.yaml
+++ b/packages/graph_neo4j/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/isolate_exec/pubspec.yaml
+++ b/packages/isolate_exec/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/mysql/pubspec.yaml
+++ b/packages/mysql/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/open_api/pubspec.yaml
+++ b/packages/open_api/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/password_hash/pubspec.yaml
+++ b/packages/password_hash/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/postgresql/pubspec.yaml
+++ b/packages/postgresql/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/runtime/pubspec.yaml
+++ b/packages/runtime/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/sqlite/pubspec.yaml
+++ b/packages/sqlite/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/packages/test_harness/pubspec.yaml
+++ b/packages/test_harness/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 resolution: workspace
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/conduit-dart/conduit
 issue_tracker: https://github.com/conduit-dart/conduit/issues
 
 environment:
-  sdk: ">=3.12.0-0 <4.0.0"
+  sdk: ">=3.12.0 <4.0.0"
 
 dev_dependencies:
   # 7.4.0 introduced layered topological sort for `melos exec


### PR DESCRIPTION
## Why

Dart 3.12 is now GA on the `stable` channel. Two workarounds from the 3.12-prerelease window can be unwound — which also unblocks the **v7.0.0** release pipeline:

- PR #250 set the workspace SDK floor to `>=3.12.0-0`; the `-0` prerelease suffix was only needed so the constraint resolved against Dart 3.12 dev/beta builds.
- PR #254 pruned `stable` from the CI channel matrices because the `dart:stable` image carried Dart 3.11.x and could not satisfy the floor.

## What

- **`build`** — drop `-0` from the SDK floor across the workspace root and all 20 member/example pubspecs → `>=3.12.0 <4.0.0`. Matches what `packages/core/CHANGELOG.md` already documents.
- **`ci`** — add `stable` to the smoke + unit matrices on linux/macos/windows, and restore `stable` to the `publish.yml` docker image matrix. `main` stays omitted from the docker matrix: `dart:latest` tracks `stable` and would publish a byte-identical image under a redundant tag.

Out of scope: `docker-flutter` still builds only the `aot-builder` (`dart:beta`) stage — gated on the `cirruslabs/flutter` image's Dart version, a separate issue.

## Release

This is the CI/constraint prep for **v7.0.0** — already version-bumped with per-package `## 7.0.0` CHANGELOG sections on master, but never tagged (the publish pipeline was blocked by Dart 3.12 not being in `stable`). Once this merges and master is green, pushing the `v7.0.0` tag triggers the Release workflow.

## Test Plan

- [ ] Linux / macOS / Windows CI green on the new `stable` matrix entry
- [ ] `dart pub get` resolves the workspace on Dart 3.12 stable
- [ ] (post-merge) `v7.0.0` tag → Release workflow dry-run + publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)