### PR TITLE
docs(migration): add 7.0 migration guide

### DIFF
--- a/docs/migration/7.0.md
+++ b/docs/migration/7.0.md
@@ -1,0 +1,292 @@
+# Migrating to Conduit 7.0
+
+Conduit `7.0.0` retires the custom `conduit build` AOT pipeline, replaces
+it with standard `build_runner` codegen, adds first-class SQLite, MySQL,
+and graph backends, and raises the Dart SDK floor to `>=3.12.0`. The
+upgrade is biggest for anyone who used `conduit build` in their deploy
+pipeline; everything else is mostly mechanical.
+
+This guide covers the upgrade path from `6.0.x`. If you're coming from
+`4.x` or `5.x`, start with [6.0.md](6.0.md) and then return here.
+
+## Quick checklist
+
+```yaml
+# pubspec.yaml
+environment:
+  sdk: ">=3.12.0 <4.0.0"
+
+dependencies:
+  conduit: ^7.0.0
+  conduit_postgresql: ^7.0.0   # or conduit_sqlite / conduit_mysql
+
+dev_dependencies:
+  conduit_test: ^7.0.0
+  build_runner: ^2.14.1
+  conduit_build_runner: ^7.0.0
+```
+
+```sh
+dart pub upgrade
+dart run build_runner build --delete-conflicting-outputs
+```
+
+The application code that compiled against 6.0.0 typically compiles
+against 7.0.0 unmodified. The deploy command does change — see §2.
+
+## 1. Dart SDK floor — `>=3.12.0`
+
+Bump the `environment.sdk` constraint in every package's `pubspec.yaml`.
+7.0.0 is published against Dart 3.12 (released stable May 2026); older
+SDKs will fail to resolve. The bump is a hard requirement, not just a
+warning — the framework now uses Dart 3 patterns (switch expressions
+with or-patterns, language-level records) internally.
+
+If you maintain a CI matrix, drop `stable`/`beta` 3.11.x and below.
+`dart-lang/setup-dart@v1` with `sdk: stable` picks up 3.12.0+ as of
+May 2026.
+
+## 2. `conduit build` is gone — use `build_runner` + `dart compile exe`
+
+The single biggest change. `conduit build` ran a custom AOT pipeline
+([packages/runtime/lib/src/build.dart][1]) that used `dart:mirrors` to
+discover Compiler subclasses, emit Dart source for runtime objects, copy
+framework packages into a build directory, and rewrite their pubspecs to
+strip `dart:mirrors`. That whole thing is replaced by a `package:build`
+builder that runs under standard `build_runner`.
+
+### Old (6.0.x)
+
+```sh
+conduit build
+./build/conduit_app
+```
+
+### New (7.0.0)
+
+```sh
+dart run build_runner build --delete-conflicting-outputs
+dart compile exe bin/main.dart -o build/server
+./build/server
+```
+
+### What changes in your project
+
+1. **Add `conduit_build_runner` as a dev_dependency** (shown in §0).
+2. **Add a `build.yaml`** at the project root that enables the builders
+   (the new `conduit create` template does this for you; for an existing
+   project, copy it from
+   [`packages/cli/templates/default/build.yaml`][2]):
+
+   ```yaml
+   targets:
+     $default:
+       builders:
+         conduit_build_runner|stamp_builder:
+           enabled: false
+         conduit_build_runner|serializable_builder:
+           enabled: true
+         conduit_build_runner|channel_builder:
+           enabled: true
+         conduit_build_runner|controller_builder:
+           enabled: true
+         conduit_build_runner|registry_builder:
+           enabled: true
+   ```
+
+3. **Update `bin/main.dart`** to import and call the generated
+   bootstrap:
+
+   ```dart
+   // Before — 6.0.x
+   import 'package:my_app/my_app.dart';
+   Future main(List<String> args) async {
+     final app = Application<MyChannel>();
+     // ...
+   }
+
+   // After — 7.0.0
+   import 'package:my_app/my_app.g.dart' as conduit_runtime;
+   import 'package:my_app/my_app.dart';
+
+   Future main(List<String> args) async {
+     // Installs the build_runner-generated runtime registry.
+     // Required for AOT (`dart compile exe`); under JIT the call is
+     // safe but redundant — the mirror-based fallback would resolve
+     // the same types.
+     conduit_runtime.bootstrap();
+
+     final app = Application<MyChannel>();
+     app.options = ApplicationOptions.fromArgs(args);
+     if (app.options.isolates == 0) {
+       await app.startOnCurrentIsolate();
+     } else {
+       await app.start(numberOfInstances: app.options.isolates);
+     }
+   }
+   ```
+
+4. **Add `lib/<app>.g.dart` to `.gitignore`** — it is regenerated each
+   build:
+
+   ```gitignore
+   .dart_tool/
+   build/
+   lib/*.g.dart
+   ```
+
+5. **Delete `build/` from source control** if you committed it for the
+   old pipeline.
+
+### Dev-mode (`dart run` / `conduit serve`) is unchanged
+
+JIT execution still resolves types via `dart:mirrors`; the
+build_runner-generated registry is only required for AOT. You can
+continue to do `dart run bin/main.dart` or `conduit serve` during
+development without invoking `build_runner` first.
+
+### Container builds
+
+Most Dockerfiles for Conduit apps look like:
+
+```dockerfile
+# Before — 6.0.x
+FROM dart:stable AS build
+WORKDIR /app
+COPY . .
+RUN dart pub get && conduit build
+FROM scratch
+COPY --from=build /app/build/conduit_app /app
+ENTRYPOINT ["/app"]
+
+# After — 7.0.0
+FROM dart:stable AS build
+WORKDIR /app
+COPY . .
+RUN dart pub get \
+ && dart run build_runner build --delete-conflicting-outputs \
+ && dart compile exe bin/main.dart -o /app/server
+FROM scratch
+COPY --from=build /app/server /app
+ENTRYPOINT ["/app"]
+```
+
+## 3. Five new backend packages
+
+7.0.0 is the first publish to pub.dev for these. They were versioned at
+6.0.0 since October 2025 but the old commit-prefix-driven publish
+workflow silently never pushed them — fixed in the new tag-driven
+`publish.yml`. Add explicitly as needed:
+
+| Package | Use for |
+| --- | --- |
+| `conduit_sqlite` | SQLite backend (schema + raw execute; full ORM `newQuery` arrived in #275) |
+| `conduit_mysql` | MySQL backend (full ORM via the dialect-agnostic core query builders) |
+| `conduit_graph` | `GraphNode` / `GraphEdge` type system + `GraphPersistentStore` abstraction |
+| `conduit_graph_neo4j` | Neo4j backend implementing `GraphPersistentStore` |
+| `conduit_graphql` | `GraphQLController`, SQL resolvers, DataLoader |
+
+`conduit_postgresql` keeps its 6.x semantics — internally it is byte-
+identical at the SQL boundary; #275 just moved the builder family into
+`conduit_core` so sibling backends can reuse it.
+
+## 4. Unified Persistence umbrella ([#271][3])
+
+`conduit_core` now exposes a single `PersistenceContext` abstraction
+covering both relational stores (`PersistentStore`, the postgres /
+sqlite / mysql family) and graph stores (`GraphPersistentStore`, the
+neo4j family). The umbrella is additive — your existing
+`ManagedContext` / `PersistentStore` code keeps working — but the new
+shape is preferred for any new code that needs to dispatch on backend
+kind:
+
+```dart
+final ctx = PersistenceContext.relational(store: postgresStore);
+// or:
+final ctx = PersistenceContext.graph(store: neo4jStore);
+```
+
+If you imported `package:conduit_core/conduit_core.dart`, no change is
+needed — the umbrella types are re-exported through the same library.
+
+## 5. `newQuery<T>` is dialect-agnostic ([#275][4])
+
+In 6.x, `newQuery<T>` lived in `conduit_postgresql` and was Postgres-
+specific. 7.0 lifts the builder family to `conduit_core` so SQLite
+and MySQL get full ORM support. Code calling `newQuery<T>` does not
+change shape — but if you reached into postgres-specific builder
+internals (rare), those imports moved:
+
+| 6.x import | 7.0 import |
+| --- | --- |
+| `package:conduit_postgresql/src/builders/...` | `package:conduit_core/src/db/builders/...` |
+| `package:conduit_postgresql/src/predicate_builder.dart` | `package:conduit_core/src/db/predicate_builder.dart` |
+
+The CLI's `--connection` flag now dispatches the right store family
+based on the URI scheme (`postgres://`, `sqlite://`, `mysql://`,
+`bolt://` for neo4j) — see [`connection_string.dart`][5].
+
+## 6. `QueryPredicate` AST migration ([#267][6], [#270][7])
+
+`QueryPredicate.format` is still the user-facing API, but internally
+predicates are now an AST that each backend renders. If you wrote
+custom matchers, they continue to work via the legacy adapter; if you
+implemented `PersistentStore.compilePredicate` directly, the contract
+changed — see the `RenderedPredicate` types in `conduit_core`.
+
+Microbenchmarks for predicate rendering are checked into
+`packages/core/bench/RESULTS.md`. The 6.x→7.0 cut is within noise
+(±2%); the regression analysis from #270 is the reference if you see
+hot-path slowdowns.
+
+## 7. Multi-backend test harness ([#268][8])
+
+`conduit_test` now exposes a connection-string-driven test harness so
+the same test file can run against postgres, sqlite, or mysql by
+flipping an env var. If you use the harness, the constructor signature
+changed:
+
+```dart
+// Before — 6.0.x
+final harness = TestHarness<MyChannel>()
+  ..options = TestHarnessOptions(database: postgresConfig);
+
+// After — 7.0.0
+final harness = TestHarness<MyChannel>()
+  ..options = TestHarnessOptions.fromConnectionString(
+    Platform.environment['TEST_CONNECTION'] ?? 'postgres://...',
+  );
+```
+
+`PostgresTestConfig` and the environment-variable fallback chain from
+6.0 (see [6.0.md §5](6.0.md#5-test-fixture-connection-details)) still
+work for postgres-only flows.
+
+## 8. Smaller things you may notice
+
+- `conduit serve` still works in 7.0; only `conduit build` is gone.
+- `package:conduit/conduit.dart` re-exports unchanged.
+- The `default` template includes an `@Operation('get', '/example')`
+  handler instead of the historic `@Operation.get('/example')` form —
+  both work; the new form matches the post-#267 surface and is what
+  `conduit create -t default` produces.
+- `analyzer ^12.1.0` is the new minimum (was `^10.0.0`).
+
+## 9. If you're tracking `master` already
+
+The 6.0 migration guide ended with a "what's coming on master" section
+describing exactly the AOT-via-`build_runner` migration that is now
+shipping in 7.0. If you adopted that work-in-progress build path
+already, your project is forward-compatible: the published
+`conduit_build_runner ^7.0.0` will pick up cleanly. Just bump the SDK
+floor and the `^7.0.0` constraints, then run
+`dart pub upgrade` + `dart run build_runner build`.
+
+[1]: ../../packages/runtime/lib/src/build.dart
+[2]: ../../packages/cli/templates/default/build.yaml
+[3]: https://github.com/conduit-dart/conduit/pull/271
+[4]: https://github.com/conduit-dart/conduit/pull/275
+[5]: ../../packages/cli/lib/src/connection_string.dart
+[6]: https://github.com/conduit-dart/conduit/pull/267
+[7]: https://github.com/conduit-dart/conduit/pull/270
+[8]: https://github.com/conduit-dart/conduit/pull/268

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -5,3 +5,7 @@
 * [6.0.md] — `ServiceRegistry` removed, snake_case naming (opt-in),
   `PostgresTestConfig` defaults, Dart `>=3.11.0`, `conduit_common_test`
   retired.
+* [7.0.md] — `conduit build` retired, `build_runner` + `dart compile exe`
+  is the new AOT path; first publish of `conduit_sqlite`, `_mysql`,
+  `_graph`, `_graph_neo4j`, `_graphql`; unified `PersistenceContext`;
+  dialect-agnostic `newQuery<T>`; Dart `>=3.12.0`.


### PR DESCRIPTION
## Summary

Adds `docs/migration/7.0.md` and links it from `docs/migration/README.md`. This is the migration-guide deliverable called out in `hardening-checklist.md` as top-priority pre-`v7.0.0` work — every other ship-blocker is plumbing the workflow handles; this one is the only thing a human has to author so a downstream user can upgrade without spelunking 7+ PRs of CHANGELOGs.

## Why now

Pre-7.0, the migration ladder was `4.1.8 → 4.3.6 → 6.0` and stopped. `6.0.md` even pointed readers at the "build_runner-driven AOT pipeline that retires `conduit build`" as future work. That future is what 7.0 ships, plus:
- 5 new packages first-publishing to pub.dev (`conduit_sqlite`, `_mysql`, `_graph`, `_graph_neo4j`, `_graphql`)
- SDK floor bump to `>=3.12.0`
- Unified `PersistenceContext` (#271)
- Dialect-agnostic `newQuery<T>` (#275)

Without a single narrative document, a 6.0 user upgrading hits all of these simultaneously with no through-line.

## What the guide covers

1. Quick checklist (pubspec diff + commands).
2. SDK floor → `>=3.12.0`.
3. **`conduit build` retired; new AOT path** — before/after `bin/main.dart`, the `build.yaml` shape, Dockerfile diff, why dev-mode is unaffected. This is the longest section because it's the breaking change with the most surface.
4. Five new backend packages — when to add which.
5. Unified `PersistenceContext` umbrella.
6. Dialect-agnostic `newQuery<T>` — including the postgres → core import path moves for anyone who reached into builder internals.
7. `QueryPredicate` AST migration.
8. Multi-backend test harness.
9. Smaller things (`analyzer ^12`, `@Operation('get', '/x')` form).
10. "If you're tracking master already" — bridges the 6.0 guide's "what's coming" promise to the 7.0 reality.

Style follows `6.0.md` (quick checklist, numbered sections, before/after code blocks). All PR cross-references are to the actually-merged PRs that landed each piece.

## Test plan

- [x] `docs/migration/README.md` index updated to list 7.0.md.
- [x] All file links resolve relative to `docs/migration/`.
- [x] All PR links resolve (verified against `git log --oneline`).
- [x] Quick checklist `dart pub upgrade` flow matches the
      `packages/cli/templates/default/pubspec.yaml` deps shape.
- [x] Before/after `bin/main.dart` matches the live template.
- [x] Branch starts with `feat/` so the unit CI job actually runs;
      doc-only diff means the smoke matrices will skip (intentional).

## Cross-reference

Sibling artifacts produced in the same audit pass and tracked for the v7.0.0 ship:
- `hardening-checklist.md` (worktree, not in this PR) — top-3 ship-blockers.
- `license-audit.md` (worktree, not in this PR) — 🟢 ship-safe verdict; the per-package picture is mixed legacy-BSD + new-MIT.