### PR TITLE
build(nix): pinned devShell + Woodpecker nix smoke step

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -45,6 +45,15 @@ steps:
       - dart pub global activate melos
       - melos bootstrap
 
+  nix-shell:
+    # Reproducible Nix devShell smoke: proves flake.nix materializes the
+    # pinned Dart toolchain. Independent of the dart:beta bootstrap chain.
+    image: nixos/nix:2.24.9
+    environment:
+      NIX_CONFIG: "experimental-features = nix-command flakes"
+    commands:
+      - nix develop -c dart --version
+
   lint:
     image: *dart_image
     depends_on: [bootstrap]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,23 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-24.11.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-24.11.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "conduit — Dart HTTP server framework (Melos monorepo)";
+
+  # Pinned to a tarball URL (not `github:`) so the flake resolves
+  # without hitting api.github.com — a small but real concern from
+  # behind corporate proxies or when CI runners share an IP.
+  inputs.nixpkgs.url = "https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-24.11.tar.gz";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            buildInputs = [
+              # Pure Dart toolchain (NOT Flutter — conduit is server-side Dart).
+              pkgs.dart
+              # Melos drives the cross-package scripts (bootstrap/analyze/test).
+              # Present in nixpkgs 24.11; if it ever drops out, fall back to
+              # `dart pub global activate melos` inside the shell.
+              pkgs.melos
+              # conduit_postgresql + core integration tests need a postgres
+              # server (CI spins up postgres:18). `postgresql` provides the
+              # server + client binaries (initdb, pg_ctl, psql) for local runs.
+              pkgs.postgresql
+            ];
+
+            shellHook = ''
+              echo "conduit dev shell — $(dart --version 2>&1)"
+              echo "  melos: $(command -v melos >/dev/null 2>&1 && echo "on PATH ($(command -v melos))" || echo 'run: dart pub global activate melos')"
+              echo "  postgres: $(postgres --version 2>&1 | head -1)"
+            '';
+          };
+        });
+
+      # Best-effort smoke check usable from CI / `nix flake check`.
+      # Scope is honest: a *pure* package build of a Melos monorepo is not
+      # practical (melos bootstrap + per-package `dart pub get` need network
+      # and a writable PUB_CACHE, which a pure derivation forbids). We only
+      # assert the toolchain materializes and Dart runs.
+      checks = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in {
+          dart-version = pkgs.runCommand "conduit-dart-version" { } ''
+            ${pkgs.dart}/bin/dart --version 2>&1 | tee "$out"
+          '';
+        });
+    };
+}


### PR DESCRIPTION
Adds a pinned Nix `flake.nix`/`flake.lock` devShell and a Woodpecker nix smoke step, so the toolchain (Dart SDK + deps) is reproducible across machines and CI.

Rebased clean onto current master (single commit). No changes to package code or published artifacts — build/CI tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)