### PR TITLE
feat(postgresql): opt-in connection pooling via maxConnectionCount

### DIFF
--- a/docs/CONNECTION_POOLING.md
+++ b/docs/CONNECTION_POOLING.md
@@ -1,0 +1,105 @@
+# Connection pooling design — per-isolate pools for the Postgres store
+
+Status: implemented (opt-in, default off) — 2026-07.
+Companion to [PLANNING.md](PLANNING.md) §2 item 1.
+
+## The question
+
+Conduit's concurrency model is isolate-based: `Application.start` spawns N
+isolates, each re-instantiating the full `ApplicationChannel`, and each
+channel's `prepare()` creates one `PersistentStore` holding **one** database
+connection. Queries within an isolate serialize on that connection. Should
+that remain the only mode?
+
+## Findings (code archaeology, 2026-07)
+
+### The single-connection contract is real and load-bearing
+
+1. **Transactions.** `PostgreSQLPersistentStore.transaction()` runs `runTx`
+   on the store's connection and swaps the context's store for a
+   `_TransactionProxy` pinned to the `TxSession`
+   (`postgresql_persistent_store.dart`). `ManagedContext.transaction`'s docs
+   warn that using the outer context inside the block "will deadlock your
+   application" — a direct artifact of the single connection.
+2. **Implicit serialization is tested behavior.** The test
+   "Queries outside of transaction block while transaction block is running
+   are queued until transaction is complete"
+   (`packages/postgresql/test/transaction_test.dart`) starts a transaction
+   *without awaiting it*, immediately fetches on the outer context, and
+   expects the fetch to observe the committed result. That only holds
+   because both serialize on one connection.
+3. **The test harness needs session affinity.**
+   `TestHarnessORMMixin.addSchema` creates `CREATE TEMPORARY TABLE`s
+   (session-scoped) on the store's connection; a pooled store would create
+   them on one connection and run later queries on another.
+4. **Not all backends can pool.** `conduit_mysql` issues a session-level
+   `SET time_zone` at connect; `conduit_sqlite` wraps a synchronous FFI
+   `Database` handle where a pool is meaningless — for SQLite, isolates
+   *are* the concurrency mechanism. The `PersistentStore` contract must
+   therefore stay single-session-compatible.
+5. **The docs promise it.** `docs/application/threading.md`: "each isolate
+   has its own database connection … a serial queue"; total connections =
+   machines × isolates. Downstream deployments may size Postgres
+   `max_connections` on that arithmetic.
+
+### But single-connection-only is a real bottleneck
+
+1. **The default is one connection for the whole app.**
+   `ApplicationOptions.isolates` defaults to **0**, which runs the channel
+   on the current isolate — so a stock app serializes *every* query through
+   one connection. (`docs/application/threading.md` claiming a default of 3
+   isolates was stale; the code default is 0.)
+2. **Isolates are an expensive unit of DB concurrency.** Each isolate
+   duplicates the channel, ORM registry, and dev-mode mirror state. Isolates
+   should scale with CPU; connection count should scale with I/O
+   concurrency. The single-connection design couples them.
+3. **The deadlock footgun.** With a pool, `runTx` checks out a dedicated
+   connection; outer-context queries during a transaction proceed on
+   another connection instead of deadlocking.
+4. **The seam already existed.** `executionContext` is typed
+   `Future<Session>`, and `postgres` v3's `Pool` implements `Session` and
+   `SessionExecutor` (`execute`, `runTx`, `withConnection`). A dead
+   `getConnectionPool()` helper (hardcoded `maxConnectionCount: 10`, never
+   called) was already half-way there.
+
+## Decision
+
+**Keep single-connection-per-isolate as the default and guaranteed mode;
+add opt-in per-isolate pooling to the Postgres store.**
+
+- `PostgreSQLPersistentStore` gains `maxConnectionCount` (default **1**).
+  At 1, the store keeps the exact legacy code path: one lazily opened
+  `Connection`, reconnect-on-next-query, `Finalizer` cleanup, implicit
+  query serialization.
+- At >1, the store lazily creates a `Pool` sized to `maxConnectionCount`;
+  `executionContext` returns the pool, and `transaction()` / `upgrade()`
+  run through `pool.runTx` (each transaction gets a dedicated pooled
+  connection; the `_TransactionProxy` mechanism is unchanged).
+- `DatabaseConfiguration` gains an optional `maxConnectionCount` field
+  (default 1) so the standard config-file → store plumbing can carry it;
+  the `db` template threads it through.
+- `getDatabaseConnection()` throws `StateError` on a pooled store — session
+  state on a checked-out connection would not be visible to queries, so
+  handing out a raw connection would be a trap. Use `executionContext`.
+
+### Semantics that change in pooled mode (documented, intentional)
+
+- Queries no longer serialize per store. Code that relied on issuing
+  un-awaited queries in program order (the transaction_test pattern above)
+  must await its futures.
+- Session-scoped state (temporary tables, `SET`, advisory locks, LISTEN)
+  is not meaningful through a pooled store. The test harness must keep
+  pool size 1 (the default — nothing to do).
+- Total Postgres connections become isolates × maxConnectionCount; size
+  against `max_connections` (default 100).
+
+### Out of scope, sequenced deliberately
+
+- **mysql/sqlite pooling**: mysql needs per-connection `SET time_zone`
+  init before it can pool; sqlite never pools. Both keep the default path.
+- **Statement caching** (PLANNING §2 item 2): prepared statements are
+  per-connection; if added later it must live inside
+  `withConnection`/session scope, not per-store. Pooling lands first on
+  purpose.
+- **Changing the pooled default**: revisit making `maxConnectionCount`
+  default to >1 (or CPU-derived) in the next major, after soak time.

--- a/docs/PLANNING.md
+++ b/docs/PLANNING.md
@@ -37,13 +37,13 @@ Full audit result (July 2026): drivers are current (`postgres` v3 API,
 third-party HTTP layer — core rides `dart:io`. The wins are wiring, not
 dependency swaps:
 
-1. **Wire up the dead Postgres connection pool.** (highest impact)
-   `PostgreSQLPersistentStore.getConnectionPool()` builds a
-   `Pool.withEndpoints(..., maxConnectionCount: 10)` but is never called;
-   every isolate serializes all queries over one `Connection`
-   (`postgresql_persistent_store.dart:148`, `:481-501`). postgres v3 `Pool`
-   implements `Session`, so the execution context can switch over with no new
-   dependency. Needs load-test evidence before/after.
+1. **Wire up the dead Postgres connection pool.** *(landed — opt-in)*
+   `PostgreSQLPersistentStore` now takes `maxConnectionCount` (default 1 =
+   legacy single-connection behavior); above 1 the store fronts a postgres
+   v3 `Pool` and transactions check out dedicated connections. See
+   [CONNECTION_POOLING.md](CONNECTION_POOLING.md) for the design and the
+   semantics that change in pooled mode. Still owed: load-test evidence
+   and a decision on flipping the default in the next major.
 2. **Cache prepared statements.** Every ORM call re-parses via
    `Sql.named(...)` + `QueryMode.extended` and discards the statement
    (`postgresql_persistent_store.dart:383-388`; same pattern in

--- a/docs/application/threading.md
+++ b/docs/application/threading.md
@@ -26,7 +26,7 @@ However, when implementing `ApplicationChannel.initializeApplication`, code runs
 
 ## How Many Isolates Should I Use
 
-To give you a starting point, the default number of isolates for an application is 3 when started with `conduit serve`. While less than 3 isolates will most certainly degrade performance, more than 3 doesn't necessarily improve performance. \(And many more will certainly degrade performance.\)
+By default, an application runs on a single isolate: `conduit serve` and the project templates default `--isolates` to 0, which runs the channel on the main isolate. For production workloads you will almost always want more — a good starting point is 2-3 isolates, tuned from there.
 
 There are a number of variables that factor into the isolate count decision. First, recall a computer essentially does two things: it executes instructions and transmits data. Both of these tasks take time, especially when that data is transmitted to another computer thousands of miles away. \(It is a modern marvel that these tasks occur as fast as they do - one that we often take for granted.\)
 
@@ -54,5 +54,5 @@ There are diminishing returns as more database connections are added. That's bec
 
 As a general rule, start with N-1 isolates, where N is the number of processors on the machine. Use `wrk` and Observatory to profile your application and tune accordingly. In a multi-instance environment, remember that the total number of database connections is MxN, where M is the number of machines and N is the number of isolates.
 
-If you find yourself in a jam where IO would be better served by less isolates, but CPU would be better served by more isolates, you may consider using a database connection pool isolate.
+If you find yourself in a jam where IO would be better served by more database connections, but CPU would be better served by fewer isolates, the PostgreSQL persistent store supports per-isolate connection pooling: construct it with `maxConnectionCount` greater than 1 (or set `maxConnectionCount` in your database configuration) and each isolate maintains a pool of that size instead of a single connection. The total number of database connections is then machines × isolates × pool size — size this against your database server's connection limit. See [Database Connection Behavior](../db/connecting.md) for the semantics of a pooled store.
 

--- a/docs/db/connecting.md
+++ b/docs/db/connecting.md
@@ -111,5 +111,9 @@ database:
 
 ### Connection Behavior
 
-A persistent store manages one database connection. This connection is automatically maintained - the first time a query is executed, the connection is opened. If the connection is lost, the next query will reopen the connection. If a connection fails to open, an exception is thrown when trying to execute a query. This connection will return a 503 response if left uncaught.
+By default, a persistent store manages one database connection. This connection is automatically maintained - the first time a query is executed, the connection is opened. If the connection is lost, the next query will reopen the connection. If a connection fails to open, an exception is thrown when trying to execute a query. This connection will return a 503 response if left uncaught.
+
+Because a single connection handles one query at a time, queries within an isolate execute serially. The PostgreSQL store can instead front a connection pool: construct `PostgreSQLPersistentStore` with `maxConnectionCount` greater than 1, or add `maxConnectionCount` to the `database:` block of your configuration file and pass it through when creating the store. With a pool, concurrent requests execute queries in parallel and each transaction runs on its own pooled connection.
+
+A pooled store changes two behaviors to be aware of. First, queries no longer serialize per store — code that issues queries without awaiting them can no longer rely on them executing in order. Second, session-scoped database state (temporary tables, `SET` commands, advisory locks) is not meaningful through a pooled store, because each statement may execute on a different connection; for this reason the test harness should keep the default of 1. See `docs/CONNECTION_POOLING.md` in the repository for the full design.
 

--- a/packages/cli/templates/db/lib/channel.dart
+++ b/packages/cli/templates/db/lib/channel.dart
@@ -58,6 +58,7 @@ class WildfireChannel extends ApplicationChannel {
       connectionInfo.host,
       connectionInfo.port,
       connectionInfo.databaseName,
+      maxConnectionCount: connectionInfo.maxConnectionCount,
     );
 
     return ManagedContext(dataModel, psc);

--- a/packages/cli/templates/db_and_auth/lib/channel.dart
+++ b/packages/cli/templates/db_and_auth/lib/channel.dart
@@ -88,6 +88,7 @@ class WildfireChannel extends ApplicationChannel
       connectionInfo.host,
       connectionInfo.port,
       connectionInfo.databaseName,
+      maxConnectionCount: connectionInfo.maxConnectionCount,
     );
 
     return ManagedContext(dataModel, psc);

--- a/packages/config/lib/src/default_configurations.dart
+++ b/packages/config/lib/src/default_configurations.dart
@@ -19,6 +19,7 @@ class DatabaseConfiguration extends Configuration {
     this.port,
     this.databaseName, {
     this.isTemporary = false,
+    this.maxConnectionCount = 1,
   });
 
   /// The host of the database to connect to.
@@ -52,6 +53,15 @@ class DatabaseConfiguration extends Configuration {
   /// dropping it after the tests are complete.
   /// This property is optional.
   bool isTemporary = false;
+
+  /// The maximum number of concurrent connections a persistent store may
+  /// open against this database (its connection pool size).
+  ///
+  /// This property is optional. Defaults to 1, which preserves the
+  /// single-connection-per-store behavior: queries serialize on one
+  /// connection. Values greater than 1 enable pooling in stores that
+  /// support it (currently PostgreSQL only).
+  int maxConnectionCount = 1;
 
   @override
   void decode(dynamic value) {

--- a/packages/config/test/config_test.dart
+++ b/packages/config/test/config_test.dart
@@ -849,6 +849,27 @@ void main() {
     expect(dbConfig.databaseName, "dbname");
   });
 
+  test("DatabaseConfiguration.maxConnectionCount defaults to 1", () {
+    const yamlString = "port: 80\n"
+        "database:\n"
+        "  host: stablekernel.com\n"
+        "  port: 5432\n"
+        "  databaseName: dbname\n";
+    final dbConfig = TopLevelConfiguration.fromString(yamlString).database;
+    expect(dbConfig.maxConnectionCount, 1);
+  });
+
+  test("DatabaseConfiguration.maxConnectionCount is read when present", () {
+    const yamlString = "port: 80\n"
+        "database:\n"
+        "  host: stablekernel.com\n"
+        "  port: 5432\n"
+        "  databaseName: dbname\n"
+        "  maxConnectionCount: 8\n";
+    final dbConfig = TopLevelConfiguration.fromString(yamlString).database;
+    expect(dbConfig.maxConnectionCount, 8);
+  });
+
   test(
       "Assigning value of incorrect type to parsed integer emits error and field name",
       () {

--- a/packages/postgresql/lib/src/postgresql_persistent_store.dart
+++ b/packages/postgresql/lib/src/postgresql_persistent_store.dart
@@ -43,6 +43,7 @@ class PostgreSQLPersistentStore extends PersistentStore
     this.databaseName, {
     this.timeZone = "UTC",
     this.sslMode,
+    this.maxConnectionCount = 1,
     SqlDialect dialect = const PostgresSqlDialect(),
     // The lint wants `this._dialect`, but private-named optional params
     // aren't allowed in Dart; the assignment form is the idiomatic
@@ -62,6 +63,7 @@ class PostgreSQLPersistentStore extends PersistentStore
     this.databaseName, {
     this.timeZone = "UTC",
     this.sslMode,
+    this.maxConnectionCount = 1,
     SqlDialect dialect = const PostgresSqlDialect(),
     // The lint wants `this._dialect`, but private-named optional params
     // aren't allowed in Dart; the assignment form is the idiomatic
@@ -80,7 +82,8 @@ class PostgreSQLPersistentStore extends PersistentStore
       port = from.port,
       databaseName = from.databaseName,
       timeZone = from.timeZone,
-      sslMode = from.sslMode;
+      sslMode = from.sslMode,
+      maxConnectionCount = from.maxConnectionCount;
 
   factory PostgreSQLPersistentStore._transactionProxy(
     PostgreSQLPersistentStore parent,
@@ -116,6 +119,21 @@ class PostgreSQLPersistentStore extends PersistentStore
   /// The SSL mode of the connection to the database.
   final String? sslMode;
 
+  /// The maximum number of concurrent connections this store may open.
+  ///
+  /// Defaults to 1: the store maintains a single connection and queries
+  /// serialize on it (the historical Conduit behavior — see
+  /// `docs/CONNECTION_POOLING.md`). When greater than 1, the store fronts
+  /// a connection pool of this size: queries from concurrent requests
+  /// execute in parallel, and [transaction] checks out a dedicated
+  /// connection per transaction.
+  ///
+  /// Pooled stores do not provide session affinity outside a transaction:
+  /// session-scoped state (temporary tables, `SET`, advisory locks) is not
+  /// meaningful, and un-awaited queries are no longer implicitly ordered.
+  /// Total connections per application = isolates × [maxConnectionCount].
+  final int maxConnectionCount;
+
   final SqlDialect _dialect;
 
   /// The SQL dialect this store was constructed with — controls type
@@ -129,12 +147,19 @@ class PostgreSQLPersistentStore extends PersistentStore
   /// Connections are automatically opened when a query is executed, so this property should not be used
   /// under normal operation. See [getDatabaseConnection].
   bool get isConnected {
+    if (isPooled) {
+      return _pool != null;
+    }
+
     if (_databaseConnection == null) {
       return false;
     }
 
     return _databaseConnection!.isOpen;
   }
+
+  /// Whether this store fronts a connection pool ([maxConnectionCount] > 1).
+  bool get isPooled => maxConnectionCount > 1;
 
   /// Amount of time to wait before connection fails to open.
   ///
@@ -145,22 +170,66 @@ class PostgreSQLPersistentStore extends PersistentStore
     (connection) => connection.close(),
   );
 
+  static final Finalizer<Pool> _poolFinalizer = Finalizer((pool) => pool.close());
+
   Connection? _databaseConnection;
   Completer<Connection>? _pendingConnectionCompleter;
+  Pool? _pool;
 
   /// Retrieves the query execution context of this store.
   ///
   /// Use this property to execute raw queries on the underlying database connection.
   /// If running a transaction, this context is the transaction context.
-  Future<Session> get executionContext => getDatabaseConnection();
+  /// On a pooled store ([isPooled]), this is the pool itself and each
+  /// statement may execute on a different pooled connection.
+  Future<Session> get executionContext async {
+    if (isPooled) {
+      return _getPool();
+    }
+    return getDatabaseConnection();
+  }
+
+  /// The [SessionExecutor] transactions run against: the single connection
+  /// by default, the pool when [isPooled] (each transaction then checks out
+  /// its own connection).
+  Future<SessionExecutor> _transactionExecutor() async {
+    if (isPooled) {
+      return _getPool();
+    }
+    return getDatabaseConnection();
+  }
+
+  Pool _getPool() {
+    final existing = _pool;
+    if (existing != null) {
+      return existing;
+    }
+    final pool = getConnectionPool();
+    _pool = pool;
+    _poolFinalizer.attach(this, pool, detach: this);
+    return pool;
+  }
 
   /// Retrieves a connection to the database this instance connects to.
   ///
-  /// If no connection exists, one will be created. A store will have no more than one connection at a time.
+  /// If no connection exists, one will be created. A non-pooled store will
+  /// have no more than one connection at a time.
   ///
   /// When executing queries, prefer to use [executionContext] instead. Failure to do so might result
   /// in issues when executing queries during a transaction.
+  ///
+  /// Throws [StateError] on a pooled store ([isPooled]): a raw connection's
+  /// session state would not be visible to queries, which execute on
+  /// arbitrary pooled connections.
   Future<Connection> getDatabaseConnection() async {
+    if (isPooled) {
+      throw StateError(
+        "getDatabaseConnection() is unavailable on a pooled "
+        "PostgreSQLPersistentStore (maxConnectionCount: $maxConnectionCount). "
+        "Use executionContext, or construct the store with "
+        "maxConnectionCount: 1.",
+      );
+    }
     if (_databaseConnection == null || !_databaseConnection!.isOpen) {
       if (_pendingConnectionCompleter == null) {
         _pendingConnectionCompleter = Completer<Connection>();
@@ -241,6 +310,13 @@ class PostgreSQLPersistentStore extends PersistentStore
     await _databaseConnection?.close();
     _finalizer.detach(this);
     _databaseConnection = null;
+
+    final pool = _pool;
+    if (pool != null) {
+      _pool = null;
+      _poolFinalizer.detach(this);
+      await pool.close();
+    }
   }
 
   @override
@@ -248,10 +324,10 @@ class PostgreSQLPersistentStore extends PersistentStore
     ManagedContext transactionContext,
     Future<T> Function(ManagedContext transaction) transactionBlock,
   ) async {
-    final Connection dbConnection = await getDatabaseConnection();
+    final SessionExecutor executor = await _transactionExecutor();
 
     try {
-      return await dbConnection.runTx((dbTransactionContext) async {
+      return await executor.runTx((dbTransactionContext) async {
         transactionContext.persistentStore =
             PostgreSQLPersistentStore._transactionProxy(
               this,
@@ -306,11 +382,11 @@ class PostgreSQLPersistentStore extends PersistentStore
     List<Migration> withMigrations, {
     bool temporary = false,
   }) async {
-    final Connection connection = await getDatabaseConnection();
+    final SessionExecutor executor = await _transactionExecutor();
 
     var schema = fromSchema;
 
-    await connection.runTx((ctx) async {
+    await executor.runTx((ctx) async {
       final transactionStore = PostgreSQLPersistentStore._transactionProxy(
         this,
         ctx,
@@ -478,9 +554,12 @@ class PostgreSQLPersistentStore extends PersistentStore
     );
   }
 
+  /// Builds a [Pool] against this store's endpoint, sized to
+  /// [maxConnectionCount]. Pooled stores ([isPooled]) create and reuse one
+  /// of these lazily; calling this directly always constructs a new pool.
   Pool getConnectionPool() {
     final settings = PoolSettings(
-      maxConnectionCount: 10,
+      maxConnectionCount: maxConnectionCount,
       queryTimeout: const Duration(minutes: 10),
       connectTimeout: const Duration(seconds: 30),
       timeZone: timeZone,
@@ -522,4 +601,16 @@ class _TransactionProxy extends PostgreSQLPersistentStore {
 
   @override
   Future<Session> get executionContext async => context;
+
+  // A (mis)use of the transaction context to start another transaction
+  // must not mint a second pool on this proxy instance — share the owning
+  // store's pool. Non-pooled stores keep the legacy behavior (a
+  // proxy-local connection running an independent transaction).
+  @override
+  Future<SessionExecutor> _transactionExecutor() {
+    if (isPooled) {
+      return parent._transactionExecutor();
+    }
+    return super._transactionExecutor();
+  }
 }

--- a/packages/postgresql/test/pooled_store_test.dart
+++ b/packages/postgresql/test/pooled_store_test.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+
+import 'package:conduit_core/conduit_core.dart';
+import 'package:conduit_postgresql/conduit_postgresql.dart';
+import 'package:test/test.dart';
+
+import 'not_tests/postgres_test_config.dart';
+
+void main() {
+  final config = PostgresTestConfig();
+
+  PostgreSQLPersistentStore pooledStore({int maxConnectionCount = 3}) =>
+      PostgreSQLPersistentStore(
+        config.username,
+        config.password,
+        config.host,
+        config.port,
+        config.dbName,
+        maxConnectionCount: maxConnectionCount,
+      );
+
+  group("Default store (maxConnectionCount: 1)", () {
+    late PostgreSQLPersistentStore store;
+
+    setUp(() {
+      store = config.persistentStore();
+    });
+
+    tearDown(() async {
+      await store.close();
+    });
+
+    test("is not pooled", () {
+      expect(store.isPooled, false);
+      expect(store.maxConnectionCount, 1);
+    });
+
+    test("serializes concurrent queries on a single backend", () async {
+      final rows = await Future.wait(
+        List.generate(
+          3,
+          (_) => store.execute("SELECT pg_backend_pid() FROM pg_sleep(0.2)"),
+        ),
+      );
+      final pids = rows.map((r) => (r as List).first.first).toSet();
+      expect(pids, hasLength(1));
+    });
+  });
+
+  group("Pooled store", () {
+    late PostgreSQLPersistentStore store;
+
+    setUp(() {
+      store = pooledStore();
+    });
+
+    tearDown(() async {
+      await store.close();
+    });
+
+    test("reports pooled state", () async {
+      expect(store.isPooled, true);
+      expect(store.isConnected, false);
+      await store.execute("SELECT 1");
+      expect(store.isConnected, true);
+    });
+
+    test("executes concurrent queries on multiple backends", () async {
+      final rows = await Future.wait(
+        List.generate(
+          3,
+          (_) => store.execute("SELECT pg_backend_pid() FROM pg_sleep(0.2)"),
+        ),
+      );
+      final pids = rows.map((r) => (r as List).first.first).toSet();
+      expect(pids.length, greaterThan(1));
+    });
+
+    test("getDatabaseConnection throws StateError", () async {
+      await expectLater(
+        store.getDatabaseConnection(),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test("can execute again after close (pool is recreated)", () async {
+      await store.execute("SELECT 1");
+      await store.close();
+      expect(store.isConnected, false);
+
+      final rows = await store.execute("SELECT 1") as List;
+      expect(rows.first.first, 1);
+    });
+  });
+
+  group("Transactions on a pooled store", () {
+    late PostgreSQLPersistentStore store;
+    late ManagedContext context;
+    late Schema schema;
+
+    setUp(() async {
+      store = pooledStore();
+      final dataModel = ManagedDataModel([PoolModel]);
+      schema = Schema.fromDataModel(dataModel);
+      for (final cmd in config.commandsFromDataModel(dataModel)) {
+        await store.execute(cmd);
+      }
+      context = ManagedContext(dataModel, store);
+    });
+
+    tearDown(() async {
+      await config.dropSchemaTables(schema, store);
+      await context.close();
+    });
+
+    test("transaction commits and returns closure value", () async {
+      final String? name = await context.transaction((t) async {
+        final o = await Query.insertObject(t, PoolModel()..name = "Bob");
+        return o.name;
+      });
+      expect(name, "Bob");
+
+      final rows = await Query<PoolModel>(context).fetch();
+      expect(rows, hasLength(1));
+      expect(rows.first.name, "Bob");
+    });
+
+    test("transaction rolls back when the block throws", () async {
+      try {
+        await context.transaction((t) async {
+          await Query.insertObject(t, PoolModel()..name = "doomed");
+          throw StateError("abort");
+        });
+        fail("unreachable");
+      } on StateError {
+        // expected
+      }
+
+      expect(await Query<PoolModel>(context).fetch(), isEmpty);
+    });
+
+    test(
+        "outer-context query proceeds on another connection while a transaction is open",
+        () async {
+      // On a single-connection store this pattern deadlocks (and issuing the
+      // outer query from inside the block throws a runTx error). On a pooled
+      // store the transaction holds one pooled connection while the outer
+      // query checks out another.
+      final release = Completer<void>();
+      final tx = context.transaction((t) async {
+        await Query.insertObject(t, PoolModel()..name = "in-tx");
+        await release.future;
+      });
+
+      final visibleDuringTx = await Query<PoolModel>(context).fetch();
+      expect(visibleDuringTx, isEmpty);
+
+      release.complete();
+      await tx;
+
+      final visibleAfterTx = await Query<PoolModel>(context).fetch();
+      expect(visibleAfterTx, hasLength(1));
+      expect(visibleAfterTx.first.name, "in-tx");
+    });
+  });
+}
+
+class _PoolModel {
+  @primaryKey
+  int? id;
+
+  String? name;
+}
+
+class PoolModel extends ManagedObject<_PoolModel> implements _PoolModel {}


### PR DESCRIPTION
## What

Adds opt-in per-isolate connection pooling to `PostgreSQLPersistentStore`, plus a design doc recording the findings behind the decision.

- `PostgreSQLPersistentStore` takes `maxConnectionCount` (default **1** — the legacy single-connection path is byte-for-byte unchanged). Above 1, the store lazily fronts a postgres v3 `Pool` sized from the field (the previously dead `getConnectionPool()` is now the factory): `executionContext` returns the pool, and `transaction()` / `upgrade()` run through `pool.runTx` so every transaction holds a dedicated connection.
- `getDatabaseConnection()` throws `StateError` on a pooled store — a raw connection's session state would be invisible to queries running on other pooled connections. Only pooled stores (new) can hit this.
- A nested `transaction()` started from a transaction context routes to the owning store's pool instead of minting a second pool on the proxy; non-pooled stores keep legacy nested-transaction behavior.
- `DatabaseConfiguration` gains an optional `maxConnectionCount` field (default 1, same shape as `isTemporary`, so it works in both mirror and AOT config modes), and the `db` / `db_and_auth` templates thread it from config into the store.
- `docs/CONNECTION_POOLING.md` documents what depends on single-connection session affinity (transaction proxy, test-harness temp tables, mysql/sqlite constraints), why single-connection-only is a bottleneck, and the semantics that intentionally change in pooled mode. `docs/application/threading.md`'s stale "default 3 isolates" claim is corrected (the code default is 0), and `docs/db/connecting.md` documents the pooled behavior.

## Why

An isolate can hold many in-flight requests but only one outstanding query — and the default of `isolates: 0` means a stock app serializes every query through one connection. Isolates should scale CPU; connections should scale I/O concurrency. Pooling decouples them without touching the default behavior, and it removes the documented outer-context-during-transaction deadlock in pooled mode. Kept opt-in because session affinity is load-bearing: temp-table test fixtures, un-awaited query ordering, and the mysql/sqlite backends all require the single-connection mode to remain.

## Tests

- `packages/postgresql/test/pooled_store_test.dart`:
  - pooled stores execute concurrent queries on **distinct backends** (`pg_backend_pid()`); default stores provably still serialize on one backend
  - transactions on pooled stores commit, roll back on throw, and return closure values
  - an outer-context query proceeds on a second connection while a transaction is held open (deadlocks on a single connection) and does not observe the uncommitted insert
  - pool is torn down on `close()` and recreated on next use; `getDatabaseConnection()` throws `StateError` when pooled
- `packages/config/test/config_test.dart`: `maxConnectionCount` defaults to 1 and parses from YAML.

## Related

The load-test harness, CI smoke lane, scale-testing docs, and provisioning tooling that produce the evidence for this feature are split into a stacked follow-up PR (`feature/claude-load-testing`, based on this branch) — it will be rebased onto master after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fgDZMiU9t6Nx6aDKsv5m4